### PR TITLE
Use development version of coq-stdpp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 ARG coq_image="coqorg/coq:latest"
 FROM ${coq_image}
+RUN opam repo add iris-dev https://gitlab.mpi-sws.org/iris/opam.git
 RUN opam update && opam install coq-stdpp

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ opam install coq-matching-logic
 
 ### Dependencies:
 - Coq 8.12
-- stdpp
+- stdpp (development version)
 ```sh
+opam repo add iris-dev https://gitlab.mpi-sws.org/iris/opam.git
 opam install coq-stdpp
 ```
 


### PR DESCRIPTION
Reasons:
* Tamas uses a lemma that is present in the dev version but not yet in the released version
* Jan wants to send to stdpp a bunch of lemmas relating lists and sets, and it takes some time until it gets into the released version.
* The Iris folks use the dev version of stdpp in they main project (https://gitlab.mpi-sws.org/iris/iris), so I guess that the dev version is at least somewhat stable