### PR TITLE
generalize 'update_val_fresh12' to work with any signature

### DIFF
--- a/src/AML_soundness_lemmas.v
+++ b/src/AML_soundness_lemmas.v
@@ -130,128 +130,6 @@ Lemma evar_open_comm:
 Proof.
 Admitted.
 
-Lemma update_val_fresh12 {m : Model}:
-  forall sz  phi n,
-  le (size phi) sz ->
-  forall fresh1 fresh2,
-   fresh1 ∉ (free_evars phi) -> fresh2 ∉ (free_evars phi) ->
-  well_formed_closed (evar_open n fresh1 phi) -> well_formed_closed (evar_open n fresh2 phi)
-  ->
-  forall evar_val svar_val c,
-  pattern_interpretation (update_evar_val fresh1 c evar_val) svar_val (evar_open n fresh1 phi) =
-  @pattern_interpretation sig m (update_evar_val fresh2 c evar_val) svar_val (evar_open n fresh2 phi).
-Proof. 
-
-  (* Induction on size *)
-  induction sz; destruct phi; intros n0 Hsz fresh1 fresh2 HLs1 HLs2 Hwfb1 Hwfb2 eval sval c; auto; try inversion Hsz; subst.
-  - repeat rewrite evar_open_fresh. 
-    2, 3: unfold well_formed_closed; simpl; trivial.
-    repeat rewrite pattern_interpretation_free_evar_simpl.
-    unfold update_evar_val.
-    destruct (evar_eq fresh1 x) eqn:P; destruct (evar_eq fresh2 x) eqn:P1.
-    + rewrite e in HLs1. simpl in HLs1.
-      eapply not_elem_of_singleton_1 in HLs1. contradiction.
-    + rewrite e in HLs1. simpl in HLs1.
-      eapply not_elem_of_singleton_1 in HLs1. contradiction.
-    + rewrite e in HLs2. simpl in HLs2. 
-      eapply not_elem_of_singleton_1 in HLs2. contradiction.
-    + auto.
-  - unfold well_formed_closed in Hwfb1. simpl in Hwfb1.
-    assert (n = n0).
-    destruct (n =? n0) eqn:P.
-      + apply beq_nat_true in P. assumption.
-      + inversion Hwfb1.
-      + simpl. apply Nat.eqb_eq in H. rewrite H. repeat rewrite pattern_interpretation_free_evar_simpl. unfold update_evar_val.
-        destruct (evar_eq fresh1 fresh1) eqn:P. destruct (evar_eq fresh2 fresh2) eqn:P1.
-        auto. contradiction. contradiction.
-  - erewrite IHsz. reflexivity. assumption. assumption. assumption. assumption. assumption.
-  - erewrite IHsz. reflexivity. assumption. assumption. assumption. assumption. assumption.
-  - simpl. simpl in Hsz. repeat rewrite pattern_interpretation_app_simpl.
-    simpl in HLs1, HLs2.
-    rewrite elem_of_union in HLs1, HLs2. apply not_or_and in HLs1. apply not_or_and in HLs2.
-    destruct HLs1, HLs2. 
-    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb1. inversion Hwfb1.
-    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb2. inversion Hwfb2.
-    erewrite IHsz. erewrite (IHsz phi2). reflexivity. lia. assumption. assumption. 
-    + apply (wfc_ind_wfc). assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + lia.
-    + assumption.
-    + assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + erewrite <- evar_open_size. erewrite <- evar_open_size. lia. exact sig. exact sig.
-    + rewrite <- (evar_open_size sig n0 fresh1 (phi1 $ phi2)). rewrite <- (evar_open_size sig 0 fresh2 (phi1 $ phi2)). lia.
-  - simpl. simpl in Hsz. repeat rewrite pattern_interpretation_app_simpl.
-    simpl in HLs1, HLs2.
-    rewrite elem_of_union in HLs1, HLs2. apply not_or_and in HLs1. apply not_or_and in HLs2.
-    destruct HLs1, HLs2. 
-    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb1. inversion Hwfb1.
-    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb2. inversion Hwfb2.
-    erewrite IHsz. erewrite (IHsz phi2). reflexivity. lia. assumption. assumption. 
-    + apply (wfc_ind_wfc). assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + lia.
-    + assumption.
-    + assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + erewrite <- evar_open_size. erewrite <- evar_open_size. lia. exact sig. exact sig.
-    + erewrite <- evar_open_size. erewrite <- evar_open_size. lia. exact sig. exact sig.
-  - simpl. simpl in Hsz. repeat rewrite pattern_interpretation_imp_simpl.
-    simpl in HLs1, HLs2. rewrite elem_of_union in HLs1, HLs2. apply not_or_and in HLs1. apply not_or_and in HLs2.
-    destruct HLs1, HLs2. 
-    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb1. inversion Hwfb1.
-    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb2. inversion Hwfb2.
-    erewrite IHsz. erewrite (IHsz phi2). reflexivity. lia. assumption. assumption. 
-    + apply (wfc_ind_wfc). assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + lia.
-    + assumption.
-    + assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + erewrite <- evar_open_size. erewrite <- evar_open_size. simpl. lia. exact sig. exact sig.
-    + rewrite <- (evar_open_size sig n0 fresh1 (phi1 ---> phi2)). rewrite <- (evar_open_size sig 0 fresh2 (phi1 $ phi2)). simpl. lia.
-  - simpl. simpl in Hsz. repeat rewrite pattern_interpretation_imp_simpl.
-    simpl in HLs1, HLs2. rewrite elem_of_union in HLs1, HLs2. apply not_or_and in HLs1. apply not_or_and in HLs2.
-    destruct HLs1, HLs2. 
-    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb1. inversion Hwfb1.
-    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb2. inversion Hwfb2.
-    erewrite IHsz. erewrite (IHsz phi2). reflexivity. lia. assumption. assumption. 
-    + apply (wfc_ind_wfc). assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + lia.
-    + assumption.
-    + assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + apply (wfc_ind_wfc). assumption.
-    + rewrite <- (evar_open_size sig n0 fresh2 (phi1 ---> phi2)). rewrite <- (evar_open_size sig 0 fresh2 (phi1 $ phi2)). simpl. lia.
-    + rewrite <- (evar_open_size sig n0 fresh1 (phi1 ---> phi2)). rewrite <- (evar_open_size sig 0 fresh2 (phi1 $ phi2)). simpl. lia.
-  - simpl. repeat rewrite pattern_interpretation_ex_simpl. simpl.
-    remember (fresh_evar (evar_open (n0 + 1) fresh2 phi)) as fresh22.
-    remember (fresh_evar (evar_open (n0 + 1) fresh1 phi)) as fresh11.
-    apply Extensionality_Ensembles. apply FA_Union_same. intros. unfold Same_set, Included, In. split.
-    + intros. simpl in Hwfb1. apply wfc_ex_to_wfc_body in Hwfb1.
-      destruct (evar_eq fresh1 fresh2). 
-        * subst. auto.
-        * epose (IHsz (evar_open (n0 + 1) fresh1 phi) 0 _ fresh11 fresh22 _ _ _ _   
-          (update_evar_val fresh1 c eval) sval c0).
-          rewrite e in H. clear e.
-          rewrite update_evar_val_comm.
-          rewrite evar_open_comm. 2: lia.
-          
-          epose (IHsz (evar_open 0 fresh22 phi) (n0+1) _ fresh1 fresh2 _ _ _ _ 
-          (update_evar_val fresh22 c0 eval) sval c).
-          rewrite <- e. rewrite evar_open_comm. 2: lia.
-          rewrite update_evar_val_comm. assumption.
-          destruct (evar_eq fresh1 fresh22).
-          -- admit. (*TODO: Counterexample. *)
-          -- assumption.
-          -- admit. (* From Heqfresh22 *)
-
-Admitted. (* update_evar_val_shadow *)
-
 Lemma fresh_notin: 
   forall sz phi v w,
   le (size phi) sz ->
@@ -1389,3 +1267,133 @@ Proof.
 Admitted.
 
 End soundness_lemmas.
+
+
+
+Lemma update_val_fresh12 {sig : Signature} {m : Model}:
+  forall sz  phi n,
+  le (size phi) sz ->
+  forall fresh1 fresh2,
+   fresh1 ∉ (free_evars phi) -> fresh2 ∉ (free_evars phi) ->
+  well_formed_closed (evar_open n fresh1 phi) -> well_formed_closed (evar_open n fresh2 phi)
+  ->
+  forall evar_val svar_val c,
+  pattern_interpretation (update_evar_val fresh1 c evar_val) svar_val (evar_open n fresh1 phi) =
+  @pattern_interpretation sig m (update_evar_val fresh2 c evar_val) svar_val (evar_open n fresh2 phi).
+Proof. 
+  intros sz. generalize dependent sig.
+  (* Induction on size *)
+  induction sz; destruct phi; intros n0 Hsz fresh1 fresh2 HLs1 HLs2 Hwfb1 Hwfb2 eval sval c; auto; try inversion Hsz; subst.
+  - repeat rewrite evar_open_fresh. 
+    2, 3: unfold well_formed_closed; simpl; trivial.
+    repeat rewrite pattern_interpretation_free_evar_simpl.
+    unfold update_evar_val.
+    destruct (evar_eq fresh1 x) eqn:P; destruct (evar_eq fresh2 x) eqn:P1.
+    + rewrite e in HLs1. simpl in HLs1.
+      eapply not_elem_of_singleton_1 in HLs1. contradiction.
+    + rewrite e in HLs1. simpl in HLs1.
+      eapply not_elem_of_singleton_1 in HLs1. contradiction.
+    + rewrite e in HLs2. simpl in HLs2. 
+      eapply not_elem_of_singleton_1 in HLs2. contradiction.
+    + auto.
+  - unfold well_formed_closed in Hwfb1. simpl in Hwfb1.
+    assert (n = n0).
+    destruct (n =? n0) eqn:P.
+      + apply beq_nat_true in P. assumption.
+      + inversion Hwfb1.
+      + simpl. apply Nat.eqb_eq in H. rewrite H. repeat rewrite pattern_interpretation_free_evar_simpl. unfold update_evar_val.
+        destruct (evar_eq fresh1 fresh1) eqn:P. destruct (evar_eq fresh2 fresh2) eqn:P1.
+        auto. contradiction. contradiction.
+  - erewrite IHsz. reflexivity. assumption. assumption. assumption. assumption. assumption.
+  - erewrite IHsz. reflexivity. assumption. assumption. assumption. assumption. assumption.
+  - simpl. simpl in Hsz. repeat rewrite pattern_interpretation_app_simpl.
+    simpl in HLs1, HLs2.
+    rewrite elem_of_union in HLs1, HLs2. apply not_or_and in HLs1. apply not_or_and in HLs2.
+    destruct HLs1, HLs2. 
+    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb1. inversion Hwfb1.
+    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb2. inversion Hwfb2.
+    erewrite IHsz. erewrite (IHsz sig m phi2). reflexivity. lia. assumption. assumption. 
+    + apply (wfc_ind_wfc). assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + lia.
+    + assumption.
+    + assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + erewrite <- evar_open_size. erewrite <- evar_open_size. lia. exact sig. exact sig.
+    + rewrite <- (evar_open_size sig n0 fresh1 (phi1 $ phi2)). rewrite <- (evar_open_size sig 0 fresh2 (phi1 $ phi2)). lia.
+  - simpl. simpl in Hsz. repeat rewrite pattern_interpretation_app_simpl.
+    simpl in HLs1, HLs2.
+    rewrite elem_of_union in HLs1, HLs2. apply not_or_and in HLs1. apply not_or_and in HLs2.
+    destruct HLs1, HLs2. 
+    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb1. inversion Hwfb1.
+    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb2. inversion Hwfb2.
+    erewrite IHsz. erewrite (IHsz sig m phi2). reflexivity. lia. assumption. assumption. 
+    + apply (wfc_ind_wfc). assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + lia.
+    + assumption.
+    + assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + erewrite <- evar_open_size. erewrite <- evar_open_size. lia. exact sig. exact sig.
+    + erewrite <- evar_open_size. erewrite <- evar_open_size. lia. exact sig. exact sig.
+  - simpl. simpl in Hsz. repeat rewrite pattern_interpretation_imp_simpl.
+    simpl in HLs1, HLs2. rewrite elem_of_union in HLs1, HLs2. apply not_or_and in HLs1. apply not_or_and in HLs2.
+    destruct HLs1, HLs2. 
+    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb1. inversion Hwfb1.
+    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb2. inversion Hwfb2.
+    erewrite IHsz. erewrite (IHsz sig m phi2). reflexivity. lia. assumption. assumption. 
+    + apply (wfc_ind_wfc). assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + lia.
+    + assumption.
+    + assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + erewrite <- evar_open_size. erewrite <- evar_open_size. simpl. lia. exact sig. exact sig.
+    + rewrite <- (evar_open_size sig n0 fresh1 (phi1 ---> phi2)). rewrite <- (evar_open_size sig 0 fresh2 (phi1 $ phi2)). simpl. lia.
+  - simpl. simpl in Hsz. repeat rewrite pattern_interpretation_imp_simpl.
+    simpl in HLs1, HLs2. rewrite elem_of_union in HLs1, HLs2. apply not_or_and in HLs1. apply not_or_and in HLs2.
+    destruct HLs1, HLs2. 
+    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb1. inversion Hwfb1.
+    apply (wfc_wfc_ind (size (evar_open 0 fresh2 (phi1 $ phi2)))) in Hwfb2. inversion Hwfb2.
+    erewrite IHsz. erewrite (IHsz sig m phi2). reflexivity. lia. assumption. assumption. 
+    + apply (wfc_ind_wfc). assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + lia.
+    + assumption.
+    + assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + apply (wfc_ind_wfc). assumption.
+    + rewrite <- (evar_open_size sig n0 fresh2 (phi1 ---> phi2)). rewrite <- (evar_open_size sig 0 fresh2 (phi1 $ phi2)). simpl. lia.
+    + rewrite <- (evar_open_size sig n0 fresh1 (phi1 ---> phi2)). rewrite <- (evar_open_size sig 0 fresh2 (phi1 $ phi2)). simpl. lia.
+  - simpl. repeat rewrite pattern_interpretation_ex_simpl. simpl.
+    remember (fresh_evar (evar_open (n0 + 1) fresh2 phi)) as fresh22.
+    remember (fresh_evar (evar_open (n0 + 1) fresh1 phi)) as fresh11.
+    apply Extensionality_Ensembles. apply FA_Union_same. intros. unfold Same_set, Included, In. split.
+    + intros. simpl in Hwfb1. apply wfc_ex_to_wfc_body in Hwfb1.
+      destruct (evar_eq fresh1 fresh2). 
+        * subst. auto.
+        * epose (IHsz sig m (evar_open (n0 + 1) fresh1 phi) 0 _ fresh11 fresh22 _ _ _ _   
+          (update_evar_val fresh1 c eval) sval c0).
+          rewrite e in H. clear e.
+          rewrite update_evar_val_comm.
+          rewrite evar_open_comm. 2: lia.
+          epose (e := IHsz sig m (evar_open 0 fresh22 phi) (n0+1) _ fresh1 fresh2 _ _ _ _ 
+          (update_evar_val fresh22 c0 eval) sval c).
+          rewrite <- e. rewrite evar_open_comm. 2: lia.
+          rewrite update_evar_val_comm. assumption.
+          destruct (evar_eq fresh1 fresh22).
+          -- rewrite e0 in e. rewrite -> update_evar_val_shadow in e.
+             
+             (* instantiate IHsz with some signature and model to derive a contradiction *)
+             
+
+             (*evar_open 0 fresh22 (patt_b_evar 0) = free_evar fresh22*)
+             Search update_evar_val.
+             admit. (*TODO: Counterexample. *)
+          -- assumption.
+          -- admit. (* From Heqfresh22 *)
+
+Admitted. (* update_evar_val_shadow *)

--- a/src/AML_soundness_lemmas.v
+++ b/src/AML_soundness_lemmas.v
@@ -1184,7 +1184,7 @@ Admitted.
 Lemma proof_rule_prop_ex_right_sound {m : Model} (theory : Theory) (phi psi : Pattern)  
       (evar_val : evar -> Domain m) (svar_val : svar -> Power (Domain m)):
   (well_formed (patt_imp (patt_app (patt_exists phi) psi) (patt_exists (patt_app phi psi)))) ->
-  (well_formed phi) -> (@well_formed sig psi) ->
+  (well_formed (ex, phi)) -> (@well_formed sig psi) ->
   (forall axiom : Pattern,
      In Pattern theory axiom ->
      forall (evar_val : evar -> Domain m)
@@ -1210,16 +1210,23 @@ Proof.
     destruct H2 as [c Hext_re].
     exists c. rewrite pattern_interpretation_app_simpl. unfold app_ext.
     exists le, re.
-    assert ((evar_fresh (elements (union (free_evars phi) (free_evars psi)))) ∉ (free_evars psi)).
-    admit.
-    assert ((evar_fresh (elements (union (free_evars phi) (free_evars psi)))) ∉ (free_evars phi)).
-    admit.
-    rewrite evar_open_fresh in Hext_re; try assumption.
-    rewrite update_valuation_fresh in Hext_re; try assumption.
-    repeat rewrite evar_open_fresh; try assumption.
-    repeat rewrite update_valuation_fresh; try assumption.
-    repeat split; assumption.
-    admit. admit.
+    - split. 2: split.
+      + admit.
+      + rewrite evar_open_fresh. 
+        rewrite update_valuation_fresh.
+        assumption.
+        destruct H0. assumption.
+        assert (fresh_evar (phi $ psi) ∉ free_evars (phi $ psi)).
+        {
+          apply set_evar_fresh_is_fresh.
+        }
+        {
+          simpl in H2. rewrite -> elem_of_union in H2.
+          apply not_or_and in H2. destruct H2.
+          assumption.
+        }
+        destruct H0. assumption.
+    + assumption.
 Admitted.
 
 Lemma proof_rule_prop_ex_left_sound {m : Model} (theory : Theory) (phi psi : Pattern)  
@@ -1387,11 +1394,11 @@ Proof.
           destruct (evar_eq fresh1 fresh22).
           -- rewrite e0 in e. rewrite -> update_evar_val_shadow in e.
              
-             (* instantiate IHsz with some signature and model to derive a contradiction *)
              
+             (* instantiate IHsz with some signature and model to derive a contradiction *)
 
              (*evar_open 0 fresh22 (patt_b_evar 0) = free_evar fresh22*)
-             Search update_evar_val.
+             
              admit. (*TODO: Counterexample. *)
           -- assumption.
           -- admit. (* From Heqfresh22 *)


### PR DESCRIPTION
instead of taking the signature from the section. This way
we can come up with a counterexample.