### PR TITLE
Inductive generation (Fixpoint reasoning 2 )

### DIFF
--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -687,15 +687,28 @@ Section with_signature.
       Lemma witnessed_elements_included_in_interp:
         Included _ witnessed_elements (@pattern_interpretation Σ M ρₑ ρₛ patt_ind_gen).
       Proof.
-
-      Abort.
+        intros x H.
+        unfold Ensembles.In in H. unfold witnessed_elements in H.
+        destruct H as [wit Hwit].
+        assert (H': Ensembles.In (Domain M) (witnessed_elements_of_max_len (length wit)) x).
+        { unfold Ensembles.In. exists wit. split. apply Hwit. lia. }
+        destruct wit as [|y l'] eqn:Hl.
+        { unfold is_witnessing_sequence in Hwit. destruct Hwit. contradiction. }
+        eapply witnessed_elements_of_max_len_included_in_interp.
+        simpl in H'.
+        apply H'.
+      Qed.
         
       
       
       Lemma patt_ind_gen_simpl:
         @pattern_interpretation Σ M ρₑ ρₛ patt_ind_gen = witnessed_elements.
       Proof.
-      Abort.
+        apply Ensembles_Ext.eq_iff_Same_set.
+        split.
+        + apply interp_included_in_witnessed_elements.
+        + apply witnessed_elements_included_in_interp.
+      Qed.
 
     End with_interpretation.
   End inductive_generation.

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -315,23 +315,14 @@ Section with_signature.
           destruct H as [step' [m [H1 [H2 Happ]]]].
           unfold witnessed_elements in H2.
           destruct H2 as [l Hl].
-          unfold is_witnessing_sequence in Hl.
-          destruct Hl as [Hlast Hl].
-          destruct l as [|m₀ l'] eqn:Heql.
-          { contradiction. }
-          destruct Hl as [Hm₀ Hl].
 
           unfold witnessed_elements.
-          exists (l ++ [x]). unfold is_witnessing_sequence.
-          simpl. rewrite last_snoc.
-          split.
-          { reflexivity. }
-          rewrite Heql. simpl.
-          split.
-          { apply Hm₀. }
+          exists (l ++ [x]).
 
+          (* `l` is not empty *)
+          destruct l as [|m₀ l'] eqn:Heql.
+          { unfold is_witnessing_sequence in Hl. destruct Hl. simpl in H. inversion H. }
 
-          (* We also need to show/assume that `step` does not contain `fresh_svar patt_ind_gen_body` *)
           rewrite pattern_interpretation_svar_open_nest_mu in H1.
           {
             eapply svar_is_fresh_in_richer.
@@ -339,8 +330,9 @@ Section with_signature.
             solve_free_svars_inclusion 2.
           }
           
-          assert (Hlink: app_ext (pattern_interpretation ρₑ ρₛ step) (Ensembles.Singleton (Domain M) m) x).
-      Abort.
+          exact (@witnessing_sequence_extend _ _ _ _ _ Hl H1 Happ).
+      Qed.
+      
       
       Lemma patt_ind_gen_simpl:
         @pattern_interpretation Σ M ρₑ ρₛ patt_ind_gen = witnessed_elements.

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -307,40 +307,44 @@ Section with_signature.
         - intros [Hlast H].
           unfold is_witnessing_sequence in H.
           destruct H as [_ H].
-          move: x Hlast H.
-          induction l.
-          + intros x Hlast H.
-            simpl in Hlast. inversion Hlast. subst. clear Hlast.
-            simpl in H. destruct H as [Hm Hall].
-            inversion Hall. subst. clear H2.
+          remember (length l) as len.
+          assert (Hlen: length l <= len).
+          { lia. }
+          clear Heqlen. simpl in H.
+          destruct H as [Hbase Hall].
+          unfold is_witnessing_sequence.
+          apply and_assoc.
+          split.
+          { apply Hlast. }
+          apply and_assoc.
+          split.
+          { apply Hbase. }
+          clear Hbase.
+          
+          move: x l Hlast Hall Hlen.
+          induction len.
+          + intros x l Hlast Hall Hlen.
+            destruct l.
+            2: { simpl in Hlen. lia.  }
+            simpl. simpl in Hall.
+            split.
+            { apply Forall_nil. exact I. }
+            inversion Hall. subst. clear Hall. clear H2.
             destruct H1 as [step' [m'' [Hstep' [Hm'm'' Hstep'm'']]]].
             inversion Hm'm''. subst. clear Hm'm''.
-            split.
-            2: { exists step'. split. apply Hstep'. apply Hstep'm''. }
-            split.
-            { reflexivity. }
-            split.
-            { apply Hm. }
-            simpl. apply Forall_nil. exact I.
-          + intros x Hlast H.
+            exists step'. split. apply Hstep'.
+            simpl in Hlast. inversion Hlast. subst.
+            apply Hstep'm''.
+          + intros x l Hlast Hall Hlen.
             destruct l as [|x' l'].
             { simpl in Hlast. inversion Hlast. clear Hlast. subst.
-              simpl in H. destruct H as [Hx Hall].
+              simpl in Hall.
               inversion Hall. subst. clear Hall.
-              inversion H2. subst. clear H2. clear H4.
+              clear H2.
+              simpl.
               split.
-              {
-                split.
-                { reflexivity. }
-                split.
-                { apply Hx. }
-                simpl.
-                apply Forall_cons.
-                split.
-                2: { apply Forall_nil. exact I. }
-                apply H1.
-              }
-              destruct H3 as [step' Hstep'].
+              { apply Forall_nil. exact I. }
+              destruct H1 as [step' Hstep'].
               exists step'.
               destruct Hstep' as [m'' [Hstep' [Hmm'' Hm'']]].
               split.
@@ -348,11 +352,16 @@ Section with_signature.
               inversion Hmm''. subst.
               apply Hm''.
             }
-            simpl in Hlast. simpl in IHl. specialize (IHl Hlast).
-            simpl in H.
-            Print "/\".
-            
-            
+            simpl in Hall. simpl in IHlen. simpl in Hlast.
+            inversion Hall. subst. clear Hall.
+            specialize (IHlen x' l' Hlast H2).
+            simpl.
+            rewrite Forall_cons.
+            apply and_assoc.
+            split.
+            { apply H1. }
+            apply IHlen.
+            simpl in Hlen. lia.
       Qed.
       
       

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -447,11 +447,31 @@ Section with_signature.
       Qed.
       
 
+      Lemma rev_tail_rev_app A (l : list A) (a : A) :
+        l <> [] -> rev (tail (l ++ [a])) = a :: rev (tail l).
+      Proof.
+        remember (length l) as len.
+        assert (length l <= len).
+        { lia. }
+        clear Heqlen.
+        move: l H.
+        induction len; intros l; destruct l.
+        - simpl. intros _ H. contradiction.
+        - simpl. intros H. lia.
+        - intros _ H. contradiction.
+        - simpl. intros _ _.
+          destruct l.
+          + reflexivity.
+          + simpl. rewrite rev_app_distr.
+            reflexivity.
+      Qed.
+        
+      
       (* [1,2,3,4,5] -> [5,4,3,2,1] -> [4,3,2,1] -> [1,2,3,4] *)
       Lemma rev_tail_rev_app_last A (l : list A) (xlast : A):
         last l = Some xlast ->
         rev (tail (rev l)) ++ [xlast] = l.
-      Proof.
+      Proof.        
         move: xlast.
         induction l.
         - intros xlast. simpl. intros H. inversion H.
@@ -465,10 +485,18 @@ Section with_signature.
             { reflexivity. }
             assert (Hxlast: [xlast] = rev [xlast]).
             { reflexivity. }
-            
+            specialize (IHl xlast H).
+            rewrite -IHl.
             rewrite Hxlast.
-            rewrite -rev_app_distr.
-      Admitted.
+            rewrite rev_tail_rev_app.
+            { intros Contra.
+              assert (Heqlen: length (rev l' ++ [b]) = @length A []).
+              { rewrite Contra. reflexivity. }
+              rewrite app_length in Heqlen. simpl in Heqlen. lia.
+            }
+            simpl. reflexivity.
+      Qed.
+      
 
       Lemma length_tail_zero A l: @length A (tail l) = 0 <-> (@length A l = 0 \/ @length A l = 1).
       Proof.

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -253,6 +253,75 @@ Section with_signature.
                            
          end).
 
+      Definition is_witnessing_sequence_alt (m : Domain M) (l : list (Domain M)) :=
+        (∃ lst, last l = Some lst /\ @pattern_interpretation Σ M ρₑ ρₛ base lst)
+          /\
+          hd_error l = Some m
+          /\
+          ((@Forall _
+                    (λ (x : (Domain M) * (Domain M)),
+                     let (new, old) := x in
+                     app_ext
+                       (@pattern_interpretation Σ M ρₑ ρₛ step)
+                       (Ensembles.Singleton _ old)
+                       new
+                    )
+                    (zip l (tail l))
+          )).
+
+      Lemma witnessing_sequence_alt_extend (m m' : Domain M) (l : list (Domain M)) :
+        (is_witnessing_sequence_alt m l
+         /\ (∃ step', pattern_interpretation ρₑ ρₛ step step' /\ app_interp step' m m')
+        ) <-> (is_witnessing_sequence_alt m' (m'::l) /\ l ≠ []).
+      Proof.
+        split.
+        - intros [[[lst [Hlst Hbase]] [Hhd Hwit]] [step' [Hstep' Hm']]].
+          split.
+          2: { destruct l. simpl in Hhd. inversion Hhd. discriminate. }
+          move: m Hhd m' step' Hm' Hstep'.
+          induction l; intros m Hhd m' step' Hm' Hstep'.
+          + simpl in Hhd. inversion Hhd.
+          + simpl in Hhd. inversion Hhd. subst a. clear Hhd.
+            unfold is_witnessing_sequence_alt.
+            destruct l.
+            { simpl in Hlst. inversion Hlst. subst m. clear Hlst.
+              split.
+              { exists lst. simpl. split. reflexivity. apply Hbase. }
+              simpl. split. reflexivity. apply Forall_cons.
+              split. exists step'. exists lst. split.
+              apply Hstep'. split. constructor. apply Hm'.
+              apply Forall_nil. exact I.
+            }
+            split.
+            { exists lst. split. simpl. simpl in Hlst. apply Hlst. apply Hbase. }
+            split.
+            { reflexivity. }
+            simpl in Hwit. simpl.
+            apply Forall_cons.
+            simpl in IHl. simpl in Hlst.
+            specialize (IHl Hlst).
+            inversion Hwit. subst. clear Hwit.
+            specialize (IHl H2). clear Hlst H2.
+            split.
+            { exists step'. exists m. split. apply Hstep'. split. constructor. apply Hm'. }
+            apply Forall_cons.
+            split.
+            { apply H1. }
+            specialize (IHl d).
+            specialize (IHl (eq_refl (Some d))).
+            destruct H1 as [step'' [d'' [Hstep'' [Hd'' Hstep''d'']]]].
+            inversion Hd''. subst d''. clear Hd''.
+            specialize (IHl m step'' Hstep''d'' Hstep'').
+            unfold is_witnessing_sequence_alt in IHl.
+            simpl in IHl.
+            destruct IHl as [_ [_ Hforall]].
+            inversion Hforall. subst. apply H2.
+        -            
+      Abort.
+            
+          
+
+
       Lemma witnessing_sequence_extend
             (m x m' : Domain M) (l : list (Domain M)):
         (is_witnessing_sequence m (x::l) /\

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -82,3 +82,108 @@ Proof.
   pose proof (H' := @elem_of_list_to_set K (gset K) _ _ _ _ _ x (mapset_elements X)).
   rewrite -> H'. apply gset_to_list_elem_of.
 Qed.
+
+
+Lemma rev_tail_rev_app A (l : list A) (a : A) :
+  l <> [] -> rev (tail (l ++ [a])) = a :: rev (tail l).
+Proof.
+  remember (length l) as len.
+  assert (length l <= len).
+  { lia. }
+  clear Heqlen.
+  move: l H.
+  induction len; intros l; destruct l.
+  - simpl. intros _ H. contradiction.
+  - simpl. intros H. lia.
+  - intros _ H. contradiction.
+  - simpl. intros _ _.
+    destruct l.
+    + reflexivity.
+    + simpl. rewrite rev_app_distr.
+      reflexivity.
+Qed.
+
+
+(* [1,2,3,4,5] -> [5,4,3,2,1] -> [4,3,2,1] -> [1,2,3,4] *)
+Lemma rev_tail_rev_app_last A (l : list A) (xlast : A):
+  last l = Some xlast ->
+  rev (tail (rev l)) ++ [xlast] = l.
+Proof.        
+  move: xlast.
+  induction l.
+  - intros xlast. simpl. intros H. inversion H.
+  - intros xlast. intros H. simpl.
+    destruct l as [|b l'].
+    + simpl. simpl in H. inversion H. reflexivity.
+    + simpl. simpl in IHl. simpl in H.
+      assert (Ha: [a] = rev [a]).
+      { reflexivity. }
+      assert (Hb: [b] = rev [b]).
+      { reflexivity. }
+      assert (Hxlast: [xlast] = rev [xlast]).
+      { reflexivity. }
+      specialize (IHl xlast H).
+      rewrite -IHl.
+      rewrite Hxlast.
+      rewrite rev_tail_rev_app.
+      { intros Contra.
+        assert (Heqlen: length (rev l' ++ [b]) = @length A []).
+        { rewrite Contra. reflexivity. }
+        rewrite app_length in Heqlen. simpl in Heqlen. lia.
+      }
+      simpl. reflexivity.
+Qed.
+
+
+Lemma length_tail_zero A l: @length A (tail l) = 0 <-> (@length A l = 0 \/ @length A l = 1).
+Proof.
+  destruct l.
+  - simpl. split. intros H. left. apply H.
+    intros [H|H]. apply H. inversion H.
+  - simpl. split.
+    + intros H. rewrite H. right. reflexivity.
+    + intros [H|H]. inversion H. lia.
+Qed.
+
+Lemma hd_error_app A (a b : A) (l : list A) :
+  hd_error ((l ++ [a]) ++ [b]) = hd_error (l ++ [a]).
+Proof.
+  induction l.
+  - reflexivity.
+  - reflexivity.
+Qed.
+
+
+Lemma last_rev_head A (l : list A) (x : A) : last (x :: l) = hd_error (rev l ++ [x]).
+Proof.
+  remember (length l) as len.
+  assert (Hlen: length l <= len).
+  { lia. }
+  clear Heqlen.
+  move: l Hlen x.
+  induction len; intros l Hlen x; destruct l eqn:Hl.
+  - reflexivity.
+  - simpl in Hlen. lia.
+  - reflexivity.
+  - simpl.
+    rewrite hd_error_app.
+    rewrite - (IHlen l0).
+    { simpl in Hlen. lia. }
+    simpl. reflexivity.
+Qed.
+
+Lemma hd_error_lookup A (l : list A) :
+  l !! 0 = hd_error l.
+Proof.
+  destruct l; reflexivity.
+Qed.
+
+Lemma list_len_slice A (l1 l2 : list A) (a b : A) :
+  a :: l1 = l2 ++ [b] -> length l1 = length l2.
+Proof.
+  intros H1.
+  assert (H2: length (a :: l1) = length (l2 ++ [b])).
+  { rewrite H1. reflexivity. }
+  simpl in H2.
+  rewrite app_length in H2. simpl in H2. lia.
+Qed.


### PR DESCRIPTION
We add support for patterns of the shape `mu X. base \/ step X`, and prove that this pattern is interpreted as the set of all elements for which exists a sequence of elements starting in `base` such that every two consecutive elements are connected via `step`.