### PR TITLE
Fixpoint reasoning - uniqueness of witnessing sequences.

### DIFF
--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -279,20 +279,19 @@ Section with_signature.
           rewrite -> last_drop with (x := lst).
           { reflexivity. }
           { apply Hlst. }
-          Search list lookup length.
           { apply lookup_lt_is_Some_1.
             rewrite Hm'. exists m'. reflexivity.
           }
           apply Hbase.
         }
         split.
-        { admit. }
+        { apply hd_drop_lookup. apply Hm'. }
         { rewrite tail_drop_comm.
           rewrite -zip_with_drop.
           apply Forall_drop.
           apply Hfa.
         }
-      Abort.
+      Qed.
       
 
       Lemma is_witnessing_sequence_iff_is_witnessing_sequence_old_reverse (m : Domain M) (l : list (Domain M)) :

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -275,7 +275,19 @@ Section with_signature.
       Proof.
         intros [[lst [Hlst Hbase]] [Hhd Hfa]] Hm' Hbase'.
         split.
-        { exists lst. split. Search last drop.
+        { exists lst. split. Check last_drop.
+          rewrite -> last_drop with (x := lst).
+          { reflexivity. }
+          { apply Hlst. }
+          Search list lookup length.
+          { apply lookup_lt_is_Some_1.
+            rewrite Hm'. exists m'. reflexivity.
+          }
+          apply Hbase.
+        }
+        split.
+        { admit. }
+        { Check Forall_drop. Search zip_with drop. }
       Abort.
       
 

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -1045,7 +1045,8 @@ Section with_signature.
             }
             lia.
           }
-          
+
+          (*assert (Hbasem': pattern_interpretation ρₑ ρₛ base lst).*)          
           
           assert (~ (length l₁ > length l₂)).
           {
@@ -1089,10 +1090,56 @@ Section with_signature.
               }
               lia.
             }
-            (* TODO *)
             (* `d0` is a member of `witnessed_elements` *)
+            epose proof (Hwd0 := witnessing_sequence_tail Hwsm).
+            simpl in Hwd0.
+            assert (Htmp: Some d0 = Some d0).
+            { reflexivity. }
+            specialize (Hwd0 Htmp). clear Htmp.
+            Check witnessed_elements.
+            assert (Hd0we : witnessed_elements d0).
+            { exists (d0::l). apply Hwd0. }
+
+            assert (Heqm'd : m' = d).
+            { unfold is_witnessing_sequence in Hwsm.
+              destruct Hwsm as [_ [H _]].
+              simpl in H. inversion H.
+              reflexivity.
+            }
+            subst m'.
+            (* TODO *)
             (* `m'=d` matches `app_ext (pattern_interpretation ρₑ ρₛ step) d0` *)
-            (* ==> contradiction *)
+            assert (app_ext
+                      (pattern_interpretation ρₑ ρₛ step)
+                      (Ensembles.Singleton (Domain M) d0)
+                      d).
+            {
+              unfold is_witnessing_sequence in Hwsm.
+              simpl in Hwsm.
+              destruct Hwsm as [_ [_ Hwsm]].
+              inversion Hwsm. subst.
+              simpl in H1.
+              apply H1.
+            }
+            unfold Ensembles_Ext.Empty_Intersection in Hbase_step_no_confusion.
+            apply Ensembles_Ext.eq_iff_Same_set in Hbase_step_no_confusion.
+            destruct Hbase_step_no_confusion as [H1 _].
+            unfold Included in H1.
+            specialize (H1 d).
+            unfold Ensembles.In in H1.
+            eapply Ensembles_Ext.Empty_is_Empty.
+            apply H1. clear H1.
+            split.
+            - apply Hlst2.
+            - unfold Ensembles.In.
+              unfold app_ext.
+              destruct H as [le' [re' [H1 [H2 H3]]]].
+              exists le'. exists d0.
+              split.
+              { apply H1. }
+              split.
+              { apply Hd0we. }
+              inversion H2. subst. apply H3.
           }
           
           Print is_witnessing_sequence.

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -292,6 +292,25 @@ Section with_signature.
           apply Hfa.
         }
       Qed.
+
+      Lemma witnessing_sequence_tail (m : Domain M) (l : list (Domain M)) (m' : Domain M) :
+        is_witnessing_sequence m l ->
+        head (tail l) = Some m' ->
+        is_witnessing_sequence m' (tail l).
+      Proof.
+        intros Hw Hhead.
+        unfold is_witnessing_sequence in Hw.
+        destruct Hw as [[lst [Hlst1 Hlst2]] Hw].
+        unfold is_witnessing_sequence.
+        split.
+        { exists lst.
+          split. 2: apply Hlst2.
+          eapply last_tail. 2: apply Hhead. apply Hlst1.
+        }
+        split.
+        { apply Hhead. }
+      Abort.
+      
       
 
       Lemma is_witnessing_sequence_iff_is_witnessing_sequence_old_reverse (m : Domain M) (l : list (Domain M)) :
@@ -1040,9 +1059,37 @@ Section with_signature.
             assert (Hlsteqm' : m' = lst).
             {
               assert (Some m' = Some lst).
-              { rewrite -Hm'. rewrite -Hlst1. reflexivity.  }
+              { rewrite -Hm'. rewrite -Hlst1. apply Hlast12.  }
+              inversion H. reflexivity.
             }
+            subst lst.
+            specialize (Hwsm Hlst2).
+            clear Hm' Hlst1.
 
+            destruct (drop (length l₂ - 1) l₁) eqn:Heq.
+            {
+              destruct Hwsm as [_ [Contra _]].
+              inversion Contra.
+            }
+            (* if `l` is empty, then length l₁ = length l₂ -> Contradiction *)
+            destruct l.
+            {
+              assert (Hlendrop: length (drop (length l₂ - 1) l₁) = 1).
+              { rewrite Heq. reflexivity. }
+              rewrite drop_length in Hlendrop.
+              assert (length l₂ <> 0).
+              { intros Hcontra'.
+                apply nil_length_inv in Hcontra'.
+                subst l₂.
+                destruct Hw₂ as [_ [HContra'' _]].
+                inversion HContra''.
+              }
+              lia.
+            }
+            (* TODO *)
+            (* `d0` is a member of `witnessed_elements` *)
+            (* `m'=d` matches `app_ext (pattern_interpretation ρₑ ρₛ step) d0` *)
+            (* ==> contradiction *)
           }
           
           Print is_witnessing_sequence.

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -850,9 +850,13 @@ Section with_signature.
 
       
       Section injective.
-        Hypothesis (Hbase_functional : @is_functional_pattern _ base M ρₑ ρₛ).
+        (*Hypothesis (Hbase_functional : @is_functional_pattern _ base M ρₑ ρₛ).*)
         Hypothesis (Hstep_total_function : @is_total_function _ M step witnessed_elements witnessed_elements ρₑ ρₛ).
         Hypothesis (Hstep_injective : @total_function_is_injective _ M step witnessed_elements ρₑ ρₛ).
+
+        Hypothesis (Hbase_step_no_confusion
+                    : Ensembles_Ext.Empty_Intersection (Domain M) (pattern_interpretation ρₑ ρₛ base)
+                                         (app_ext (pattern_interpretation ρₑ ρₛ step) witnessed_elements )).
 
         Lemma witnessed_elements_unique_seq :
           ∀ m l₁ l₂, is_witnessing_sequence m l₁ -> is_witnessing_sequence m l₂ -> l₁ = l₂.
@@ -991,6 +995,23 @@ Section with_signature.
               simpl. apply Hfa₂.
               apply Hwitb.
           }
+          assert (~ (length l₁ > length l₂)).
+          {
+            intros Hcontra.
+            epose proof (H := list_lookup_lookup_total_lt).
+            Unshelve. 3: { constructor. exact (nonempty_witness M). }
+            specialize (H l₁ (length l₂ - 1)).
+            assert (Hlt : length l₂ - 1 < length l₁).
+            { lia. }
+            specialize (H Hlt). clear Hlt.
+
+            Check  witnessing_sequence_middle.
+            pose proof (witnessing_sequence_middle Hw₁ H).
+            Search list length ex.
+            
+          }
+          
+          Print is_witnessing_sequence.
           
               
               

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -309,8 +309,11 @@ Section with_signature.
         }
         split.
         { apply Hhead. }
-      Abort.
-      
+        rewrite -tail_zip.
+        apply Forall_tail.
+        destruct Hw as [Hw1 Hw2].
+        apply Hw2.
+      Qed.
       
 
       Lemma is_witnessing_sequence_iff_is_witnessing_sequence_old_reverse (m : Domain M) (l : list (Domain M)) :

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -287,7 +287,11 @@ Section with_signature.
         }
         split.
         { admit. }
-        { Check Forall_drop. Search zip_with drop. }
+        { rewrite tail_drop_comm.
+          rewrite -zip_with_drop.
+          apply Forall_drop.
+          apply Hfa.
+        }
       Abort.
       
 

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -848,6 +848,12 @@ Section with_signature.
             destruct l₂ as [|m₂ l₂].
             { simpl in Hlst₂. inversion Hlst₂. }
             simpl in Hhd₂. inversion Hhd₂. subst. clear Hhd₂.
+            
+            simpl.
+            destruct (decide (m=m)).
+            2: { contradiction. }
+            clear e.
+            apply f_equal.
         Abort.
         (*
               destruct Hw₁ as [_ Hcontra]. contradiction.

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -709,7 +709,16 @@ Section with_signature.
         + apply witnessed_elements_included_in_interp.
       Qed.
 
+      
+      Section injective.
+        (* `base` is functional, and `step` is an injective function on witnessed_elements. *)
+      End injective.
+      
     End with_interpretation.
+
+    
+
+    
   End inductive_generation.
   
   

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -1107,7 +1107,7 @@ Section with_signature.
               reflexivity.
             }
             subst m'.
-            (* TODO *)
+
             (* `m'=d` matches `app_ext (pattern_interpretation ρₑ ρₛ step) d0` *)
             assert (app_ext
                       (pattern_interpretation ρₑ ρₛ step)
@@ -1141,35 +1141,12 @@ Section with_signature.
               { apply Hd0we. }
               inversion H2. subst. apply H3.
           }
-          
-          Print is_witnessing_sequence.
-          
-              
-              
-        Abort.
-        (*
-              destruct Hw₁ as [_ Hcontra]. contradiction.
-            - destruct Hw₂ as [_ Hcontra]. contradiction.
-            - simpl in Hlen₂. lia.
-            - simpl in Hlen12. lia.
-            - simpl in Hlen12. lia.
-            - destruct Hw₂ as [_ Hcontra]. contradiction.
-            - rewrite 2!reverse_cons.
-              rename d into d₁. rename d0 into d₂.
-              simpl in Hlen₂.
-              assert (Hlen₂': length l₂ <= len₂).
-              { lia. }
-              simpl in Hlen12.
-              assert (Hlen12': len₂ <= length l₁).
-              { lia. }
-              specialize (IHlen₂ l₁ l₂ Hlen₂' Hlen12').
-              (* Problem: l₁ and l₂ are not witnessing sequences. 
-                 We probably want to weaken the condition, because
-                 we only need to know that they are `step`-sequences *)
-          
-        Abort.
-        *)
-        
+          assert (Hlength12: length l₁ = length l₂).
+          { lia. }
+          clear Hlen12 H.
+
+          apply (common_length_impl_eq _ _ Hlength12 Hlcom).
+        Qed.        
         
       End injective.
       

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -789,11 +789,29 @@ Section with_signature.
         simpl in H'.
         apply H'.
       Qed.
-      
+
+      Definition witnessed_elements : Ensemble (Domain M) :=
+        λ m, ∃ l, is_witnessing_sequence m l.
+
+      Lemma witnessed_elements_old_eq_witnessed_elements :
+        witnessed_elements_old = witnessed_elements.
+      Proof.
+        apply (@Extensionality_Ensembles _).
+        split; unfold Included; unfold Ensembles.In;
+          unfold witnessed_elements_old; unfold witnessed_elements; intros m; intros [l H].
+        + exists (reverse l).
+          apply is_witnessing_sequence_iff_is_witnessing_sequence_old_reverse.
+          rewrite reverse_involutive.
+          exact H.
+        + exists (reverse l).
+          apply is_witnessing_sequence_iff_is_witnessing_sequence_old_reverse.
+          apply H.
+      Qed.
       
       Lemma patt_ind_gen_simpl:
-        @pattern_interpretation Σ M ρₑ ρₛ patt_ind_gen = witnessed_elements_old.
+        @pattern_interpretation Σ M ρₑ ρₛ patt_ind_gen = witnessed_elements.
       Proof.
+        rewrite -witnessed_elements_old_eq_witnessed_elements.
         apply Ensembles_Ext.eq_iff_Same_set.
         split.
         + apply interp_included_in_witnessed_elements_old.
@@ -804,11 +822,11 @@ Section with_signature.
       Section injective.
         (* `base` is functional, and `step` is an injective function on witnessed_elements. *)
         Hypothesis (Hbase_functional : @is_functional_pattern _ base M ρₑ ρₛ).
-        Hypothesis (Hstep_total_function : @is_total_function _ M step witnessed_elements_old witnessed_elements_old ρₑ ρₛ).
+        Hypothesis (Hstep_total_function : @is_total_function _ M step witnessed_elements witnessed_elements ρₑ ρₛ).
         (* TODO we need a hypothesis for injectivity *)
 
         Lemma witnessed_elements_unique_seq :
-          ∀ m l₁ l₂, is_witnessing_sequence_old m l₁ -> is_witnessing_sequence_old m l₂ -> l₁ = l₂.
+          ∀ m l₁ l₂, is_witnessing_sequence m l₁ -> is_witnessing_sequence m l₂ -> l₁ = l₂.
         Proof.
           intros m l₁ l₂.
           wlog: l₁ l₂ / (length l₂ <= length l₁).
@@ -819,35 +837,17 @@ Section with_signature.
           }
           intros Hlen12 Hw₁ Hw₂.
 
-          assert (Hlcom:  ( @common_length _ (@Domain_eq_dec _ M) (reverse l₁) (reverse l₂) = length l₂)).
+          assert (Hlcom:  ( @common_length _ (@Domain_eq_dec _ M) l₁ l₂ = length l₂)).
           {
-            unfold is_witnessing_sequence in Hw₁.
+            destruct Hw₁ as [[lst₁ [Hlst₁ Hbase₁]] [Hhd₁ Hfa₁]].
             destruct l₁ as [|m₁ l₁].
-            { destruct Hw₁. contradiction. }
-            destruct Hw₁ as [Hlast₁ [Hbase₁ Hstep₁]].
+            { simpl in Hlst₁. inversion Hlst₁. }
+            simpl in Hhd₁. inversion Hhd₁. subst. clear Hhd₁.
 
-            unfold is_witnessing_sequence in Hw₂.
+            destruct Hw₂ as [[lst₂ [Hlst₂ Hbase₂]] [Hhd₂ Hfa₂]].
             destruct l₂ as [|m₂ l₂].
-            { destruct Hw₂. contradiction. }
-            destruct Hw₂ as [Hlast₂ [Hbase₂ Hstep₂]].
-
-            
-            
-            remember (length l₂) as len₂.
-            assert (Hlen₂: length l₂ <= len₂).
-            { lia. }
-            clear Heqlen₂.
-            move: l₁ l₂ Hlast₁ Hlast₂ Hstep₁ Hstep₂ Hlen₂ Hlen12.
-            induction len₂; intros l₁ l₂ Hlast₁ Hlast₂ Hstep₁ Hstep₂ Hlen₂ Hlen12; destruct l₁,l₂; simpl.
-            - simpl in Hlast₁. simpl in Hlast₂. inversion Hlast₁. inversion Hlast₂. subst.
-              destruct (decide (m=m)).
-              { reflexivity. }
-              contradiction.
-            - simpl in Hlen₂. lia.
-            - simpl in Hlast₁. simpl in Hlast₂. inversion Hlast₂. subst.
-              rewrite 2!reverse_cons.
-              destruct l₁.
-              { simpl. inversion Hlast₁. subst. destruct (decide (m=m)). reflexivity. contradiction. }
+            { simpl in Hlst₂. inversion Hlst₂. }
+            simpl in Hhd₂. inversion Hhd₂. subst. clear Hhd₂.
         Abort.
         (*
               destruct Hw₁ as [_ Hcontra]. contradiction.

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -257,14 +257,12 @@ Section with_signature.
           /\
           hd_error l = Some m
           /\
-          ((@Forall _
-                    (λ (x : (Domain M) * (Domain M)),
-                     let (new, old) := x in
+          ((@Forall _ (curry (λ new old,
                      app_ext
                        (@pattern_interpretation Σ M ρₑ ρₛ step)
                        (Ensembles.Singleton _ old)
                        new
-                    )
+                    ))
                     (zip l (tail l))
           )).
 
@@ -304,7 +302,6 @@ Section with_signature.
           split.
           { apply Hbase. }
           clear Hbase.
-          (*clear Heq.*)
 
           pose proof (Heq' := f_equal reverse Heq).
           rewrite reverse_involutive in Heq'.
@@ -313,7 +310,19 @@ Section with_signature.
           rewrite -> Heq'' at 2. clear Heq''.
           rewrite -Heq.
           clear Heq' Heq l0.
-          Check flip.
+          apply Forall_zip_flip_reverse in Hfa.
+          clear Hlast.
+
+          assert (Feq: (curry (flip (λ new old : Domain M, app_ext (pattern_interpretation ρₑ ρₛ step) (Ensembles.Singleton (Domain M) old) new)))
+                       =  (λ x : Domain M * Domain M, let (old, new) := x in app_ext (pattern_interpretation ρₑ ρₛ step) (Ensembles.Singleton (Domain M) old) new) ).
+          { apply functional_extensionality. intros [x₁ x₂].
+            reflexivity.
+          }
+          rewrite Feq in Hfa.
+          apply Hfa.
+        - intros H.
+      Abort.
+      
           
 
       Lemma witnessing_sequence_alt_extend (m m' : Domain M) (l : list (Domain M)) :
@@ -762,6 +771,7 @@ Section with_signature.
         (* `base` is functional, and `step` is an injective function on witnessed_elements. *)
         Hypothesis (Hbase_functional : @is_functional_pattern _ base M ρₑ ρₛ).
         Hypothesis (Hstep_total_function : @is_total_function _ M step witnessed_elements witnessed_elements ρₑ ρₛ).
+        (* TODO we need a hypothesis for injectivity *)
 
         Lemma witnessed_elements_unique_seq :
           ∀ m l₁ l₂, is_witnessing_sequence m l₁ -> is_witnessing_sequence m l₂ -> l₁ = l₂.
@@ -805,7 +815,8 @@ Section with_signature.
               destruct l₁.
               { simpl. inversion Hlast₁. subst. destruct (decide (m=m)). reflexivity. contradiction. }
               Search reverse last.
-              
+        Abort.
+        (*
               destruct Hw₁ as [_ Hcontra]. contradiction.
             - destruct Hw₂ as [_ Hcontra]. contradiction.
             - simpl in Hlen₂. lia.
@@ -826,6 +837,7 @@ Section with_signature.
                  we only need to know that they are `step`-sequences *)
           
         Abort.
+        *)
         
         
       End injective.

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -712,6 +712,52 @@ Section with_signature.
       
       Section injective.
         (* `base` is functional, and `step` is an injective function on witnessed_elements. *)
+        Hypothesis (Hbase_functional : @is_functional_pattern _ base M ρₑ ρₛ).
+        Hypothesis (Hstep_total_function : @is_total_function _ M step witnessed_elements witnessed_elements ρₑ ρₛ).
+
+        Lemma witnessed_elements_unique_seq :
+          ∀ m l₁ l₂, is_witnessing_sequence m l₁ -> is_witnessing_sequence m l₂ -> l₁ = l₂.
+        Proof.
+          intros m l₁ l₂.
+          wlog: l₁ l₂ / (length l₂ <= length l₁).
+          { intros H Hw₁ Hw₂.
+            destruct (decide (length l₁ <= length l₂)).
+            - symmetry. apply H; auto.
+            - apply H. lia. auto. auto.
+          }
+          intros Hlen12 Hw₁ Hw₂.
+          Print Model.
+          assert (Hlcom:  ( @common_length _ (@Domain_eq_dec _ M) (reverse l₁) (reverse l₂) = length l₂)).
+          {
+            remember (length l₂) as len₂.
+            assert (Hlen₂: length l₂ <= len₂).
+            { lia. }
+            clear Heqlen₂.
+            move: l₁ l₂ Hlen₂ Hlen12 Hw₁ Hw₂.
+            induction len₂; intros l₁ l₂ Hlen₂ Hlen12 Hw₁ Hw₂;destruct l₁,l₂; simpl.
+            - reflexivity.
+            - destruct Hw₁ as [_ Hcontra]. contradiction.
+            - destruct Hw₂ as [_ Hcontra]. contradiction.
+            - simpl in Hlen₂. lia.
+            - simpl in Hlen12. lia.
+            - simpl in Hlen12. lia.
+            - destruct Hw₂ as [_ Hcontra]. contradiction.
+            - rewrite 2!reverse_cons.
+              rename d into d₁. rename d0 into d₂.
+              simpl in Hlen₂.
+              assert (Hlen₂': length l₂ <= len₂).
+              { lia. }
+              simpl in Hlen12.
+              assert (Hlen12': len₂ <= length l₁).
+              { lia. }
+              specialize (IHlen₂ l₁ l₂ Hlen₂' Hlen12').
+              (* Problem: l₁ and l₂ are not witnessing sequences. 
+                 We probably want to weaken the condition, because
+                 we only need to know that they are `step`-sequences *)
+          
+        Abort.
+        
+        
       End injective.
       
     End with_interpretation.

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -275,7 +275,7 @@ Section with_signature.
       Proof.
         intros [[lst [Hlst Hbase]] [Hhd Hfa]] Hm' Hbase'.
         split.
-        { exists lst. split. Check last_drop.
+        { exists lst. split.
           rewrite -> last_drop with (x := lst).
           { reflexivity. }
           { apply Hlst. }
@@ -869,22 +869,8 @@ Section with_signature.
         + apply interp_included_in_witnessed_elements_old.
         + apply witnessed_elements_old_included_in_interp.
       Qed.
-
-      (*
-      Lemma last_matches_base m l m':
-        is_witnessing_sequence m l ->
-        l !! (length l - 1) = Some m' ->
-        pattern_interpretation ρₑ ρₛ base m'.
-      Proof.
-        unfold is_witnessing_sequence.
-        Check last.
-        Search last length.
-        intros H.
-      Abort.
-      *)
       
       Section injective.
-        (*Hypothesis (Hbase_functional : @is_functional_pattern _ base M ρₑ ρₛ).*)
         Hypothesis (Hstep_total_function : @is_total_function _ M step witnessed_elements witnessed_elements ρₑ ρₛ).
         Hypothesis (Hstep_injective : @total_function_is_injective _ M step witnessed_elements ρₑ ρₛ).
 
@@ -1096,7 +1082,7 @@ Section with_signature.
             assert (Htmp: Some d0 = Some d0).
             { reflexivity. }
             specialize (Hwd0 Htmp). clear Htmp.
-            Check witnessed_elements.
+
             assert (Hd0we : witnessed_elements d0).
             { exists (d0::l). apply Hwd0. }
 

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -264,6 +264,21 @@ Section with_signature.
                     (zip l (tail l))
           )).
 
+      (* If we have a witnessing sequence x₁ x₂ ... xₙ xₙ₊₁ ... xlast
+         and xₙ matches `base`, then xₙ xₙ₊₁ is a witnessing sequence, too.
+       *)
+      Lemma witnessing_sequence_middle (m : Domain M) (l : list (Domain M)) (n : nat) (m' : Domain M) :
+        is_witnessing_sequence m l ->
+        l !! n = Some m' ->
+        @pattern_interpretation Σ M ρₑ ρₛ base m' ->
+        is_witnessing_sequence m' (drop n l).
+      Proof.
+        intros [[lst [Hlst Hbase]] [Hhd Hfa]] Hm' Hbase'.
+        split.
+        { exists lst. split. Search last drop.
+      Abort.
+      
+
       Lemma is_witnessing_sequence_iff_is_witnessing_sequence_old_reverse (m : Domain M) (l : list (Domain M)) :
         is_witnessing_sequence m l <-> is_witnessing_sequence_old m (reverse l).
       Proof.

--- a/src/FixpointReasoning.v
+++ b/src/FixpointReasoning.v
@@ -848,6 +848,18 @@ Section with_signature.
         + apply witnessed_elements_old_included_in_interp.
       Qed.
 
+      (*
+      Lemma last_matches_base m l m':
+        is_witnessing_sequence m l ->
+        l !! (length l - 1) = Some m' ->
+        pattern_interpretation ρₑ ρₛ base m'.
+      Proof.
+        unfold is_witnessing_sequence.
+        Check last.
+        Search last length.
+        intros H.
+      Abort.
+      *)
       
       Section injective.
         (*Hypothesis (Hbase_functional : @is_functional_pattern _ base M ρₑ ρₛ).*)
@@ -995,20 +1007,42 @@ Section with_signature.
               simpl. apply Hfa₂.
               apply Hwitb.
           }
+
+          assert (Hlast12: l₁ !! (length l₂ - 1) = l₂ !! (length l₂ - 1)).
+          {
+            eapply equal_up_to_common_length.
+            erewrite Hlcom.
+            assert (length l₂ > 0).
+            {
+              destruct l₂.
+              { unfold is_witnessing_sequence in Hw₂.
+                simpl in Hw₂. destruct Hw₂ as [_ [Contra _]].
+                inversion Contra.
+              }
+              simpl. lia.
+            }
+            lia.
+          }
+          
+          
           assert (~ (length l₁ > length l₂)).
           {
             intros Hcontra.
-            epose proof (H := list_lookup_lookup_total_lt).
-            Unshelve. 3: { constructor. exact (nonempty_witness M). }
-            specialize (H l₁ (length l₂ - 1)).
             assert (Hlt : length l₂ - 1 < length l₁).
             { lia. }
-            specialize (H Hlt). clear Hlt.
+            pose proof (Hexm := list_ex_elem l₁ (length l₂ - 1) Hlt). clear Hlt.
+            destruct Hexm as [m' Hm'].
+            pose proof (Hwsm := witnessing_sequence_middle Hw₁ Hm').
+            pose proof (Hw₂' := Hw₂).
+            unfold is_witnessing_sequence in Hw₂'.
+            destruct Hw₂' as [[lst [Hlst1 Hlst2]] _].
+            rewrite list_last_length in Hlst1.
+            assert (Hlsteqm' : m' = lst).
+            {
+              assert (Some m' = Some lst).
+              { rewrite -Hm'. rewrite -Hlst1. reflexivity.  }
+            }
 
-            Check  witnessing_sequence_middle.
-            pose proof (witnessing_sequence_middle Hw₁ H).
-            Search list length ex.
-            
           }
           
           Print is_witnessing_sequence.

--- a/src/Semantics.v
+++ b/src/Semantics.v
@@ -29,7 +29,8 @@ Section semantics.
       (* TODO think about whether or not to make it an existential formula. Because that would affect the equality,
      due to proof irrelevance. *)
       nonempty_witness : Domain;
-      Domain_eq_dec : forall (a b : Domain), {a = b} + {a <> b};
+      (*Domain_eq_dec : forall (a b : Domain), {a = b} + {a <> b};*)
+      Domain_eq_dec : EqDecision Domain;
       app_interp : Domain -> Domain -> Power Domain;
       sym_interp (sigma : symbols) : Power Domain;
                    }.
@@ -2666,13 +2667,16 @@ Definition rel_of M ρₑ ρₛ ϕ: Domain M -> Ensemble (Domain M) :=
   (app_ext (@pattern_interpretation M ρₑ ρₛ ϕ) (Ensembles.Singleton (Domain M) m₁)).
 
 
-Definition is_total_function M f d c ρₑ ρₛ :=
+Definition is_total_function M f (d c : Ensemble (Domain M)) ρₑ ρₛ :=
   ∀ (m₁ : Domain M),
     d m₁ ->
     ∃ (m₂ : Domain M),
       c m₂ /\
       app_ext (@pattern_interpretation M ρₑ ρₛ f) (Ensembles.Singleton (Domain M) m₁)
       = Ensembles.Singleton (Domain M) m₂.
+
+Definition is_functional_pattern ϕ M ρₑ ρₛ :=
+  ∃ (m : Domain M), @pattern_interpretation M ρₑ ρₛ ϕ = Ensembles.Singleton (Domain M) m.
 
 End semantics.
 

--- a/src/Semantics.v
+++ b/src/Semantics.v
@@ -2666,6 +2666,14 @@ Definition rel_of M ρₑ ρₛ ϕ: Domain M -> Ensemble (Domain M) :=
   (app_ext (@pattern_interpretation M ρₑ ρₛ ϕ) (Ensembles.Singleton (Domain M) m₁)).
 
 
+Definition is_total_function M f d c ρₑ ρₛ :=
+  ∀ (m₁ : Domain M),
+    d m₁ ->
+    ∃ (m₂ : Domain M),
+      c m₂ /\
+      app_ext (@pattern_interpretation M ρₑ ρₛ f) (Ensembles.Singleton (Domain M) m₁)
+      = Ensembles.Singleton (Domain M) m₂.
+
 End semantics.
 
 

--- a/src/Semantics.v
+++ b/src/Semantics.v
@@ -2675,6 +2675,14 @@ Definition is_total_function M f (d c : Ensemble (Domain M)) ρₑ ρₛ :=
       app_ext (@pattern_interpretation M ρₑ ρₛ f) (Ensembles.Singleton (Domain M) m₁)
       = Ensembles.Singleton (Domain M) m₂.
 
+ Definition total_function_is_injective M f (d : Ensemble (Domain M)) ρₑ ρₛ :=
+   ∀ (m₁ : Domain M),
+     d m₁ ->
+     ∀ (m₂ : Domain M),
+       d m₂ ->
+         (rel_of ρₑ ρₛ f) m₁ = (rel_of ρₑ ρₛ f) m₂ ->
+          m₁ = m₂.
+
 Definition is_functional_pattern ϕ M ρₑ ρₛ :=
   ∃ (m : Domain M), @pattern_interpretation M ρₑ ρₛ ϕ = Ensembles.Singleton (Domain M) m.
 

--- a/src/Semantics.v
+++ b/src/Semantics.v
@@ -2678,6 +2678,19 @@ Definition is_total_function M f (d c : Ensemble (Domain M)) ρₑ ρₛ :=
 Definition is_functional_pattern ϕ M ρₑ ρₛ :=
   ∃ (m : Domain M), @pattern_interpretation M ρₑ ρₛ ϕ = Ensembles.Singleton (Domain M) m.
 
+Lemma functional_pattern_inj ϕ M ρₑ ρₛ m₁ m₂ :
+  @is_functional_pattern ϕ M ρₑ ρₛ ->
+  @pattern_interpretation M ρₑ ρₛ ϕ m₁ ->
+  @pattern_interpretation M ρₑ ρₛ ϕ m₂ ->
+  m₁ = m₂.
+Proof.
+  intros [m Hm] Hm₁ Hm₂.
+  rewrite Hm in Hm₁. inversion Hm₁. subst. clear Hm₁.
+  rewrite Hm in Hm₂. inversion Hm₂. subst. clear Hm₂.
+  reflexivity.
+Qed.
+
+
 End semantics.
 
 

--- a/src/Theories/Sorts.v
+++ b/src/Theories/Sorts.v
@@ -746,13 +746,9 @@ Section sorts.
 
     Lemma interp_total_function_injective f s ρₑ ρₛ :
       @pattern_interpretation sig M ρₑ ρₛ (patt_total_function_injective f s) = Full <->
-      ∀ (m₁ : Domain M),
-        Minterp_inhabitant s ρₑ ρₛ m₁ ->
-        ∀ (m₂ : Domain M),          
-          Minterp_inhabitant s ρₑ ρₛ m₂ ->
-          (rel_of ρₑ ρₛ f) m₁ = (rel_of ρₑ ρₛ f) m₂ ->
-          m₁ = m₂.
+      total_function_is_injective f (Minterp_inhabitant s ρₑ ρₛ) ρₑ ρₛ.
     Proof.
+      unfold total_function_is_injective.
       unfold patt_partial_function_injective.
       rewrite pattern_interpretation_forall_of_sort_predicate. 2: { eauto 8. }
       remember

--- a/src/Theories/Sorts.v
+++ b/src/Theories/Sorts.v
@@ -430,13 +430,9 @@ Section sorts.
     
     Lemma interp_total_function f s₁ s₂ ρₑ ρₛ :
       @pattern_interpretation sig M ρₑ ρₛ (patt_total_function f s₁ s₂) = Full <->
-      ∀ (m₁ : Domain M),
-        Minterp_inhabitant s₁ ρₑ ρₛ m₁ ->                 
-        ∃ (m₂ : Domain M),
-          Minterp_inhabitant s₂ ρₑ ρₛ m₂ /\
-          app_ext (@pattern_interpretation sig M ρₑ ρₛ f) (Ensembles.Singleton (Domain M) m₁)
-          = Ensembles.Singleton (Domain M) m₂.
-    Proof.      
+      @is_total_function sig M f (Minterp_inhabitant s₁ ρₑ ρₛ) (Minterp_inhabitant s₂ ρₑ ρₛ) ρₑ ρₛ.
+    Proof.
+      unfold is_total_function.
       rewrite pattern_interpretation_forall_of_sort_predicate.
       2: { eauto. }
 

--- a/src/Utils/Ensembles_Ext.v
+++ b/src/Utils/Ensembles_Ext.v
@@ -743,5 +743,6 @@ Proof.
   auto.
 Qed.
 
-  
+Definition Empty_Intersection T A B : Prop :=
+  Intersection T A B = Empty_set T.
   

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -312,25 +312,6 @@ Proof.
   reflexivity.
 Qed.
 
-Lemma reverse_zip_with {A B C : Type} (f : A -> B -> C) (l₁ : list A) (l₂ : list B) :
-  reverse (zip_with f l₁ l₂) = zip_with f (reverse l₁) (reverse l₂).
-Proof.
-  move: l₂.
-  induction l₁; intros l₂.
-  - reflexivity.
-  - simpl.
-    destruct l₂.
-    { rewrite !reverse_nil.
-      rewrite zip_with_nil_r.
-      reflexivity.
-    }
-    rewrite !reverse_cons.
-    rewrite IHl₁.
-    Search zip_with app.
-    rewrite zip_with_app_r.
-    (* Oops *)
-Abort.
-
 Lemma forall_zip_flip {A B : Type} (f : A -> B -> Prop) (xs : list A) (ys: list B) :
   Forall (curry f) (zip xs ys) <-> Forall (curry (flip f)) (zip ys xs).
 Proof.
@@ -440,7 +421,7 @@ Proof.
     remember (length (tail (reverse (x' :: l')))) as len'.
 
     assert (len' = length l').
-    { rewrite Heqlen'. Search length tail.
+    { rewrite Heqlen'.
       rewrite length_tail.
       rewrite reverse_length.
       simpl.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -221,3 +221,39 @@ Proof.
   apply skip_eq_head_not_eq in H.
   apply H.
 Qed.
+
+Fixpoint common_length {A} {eqdec: EqDecision A} (l₁ l₂ : list A) :=
+  match l₁,l₂ with
+  | nil,nil => 0
+  | nil,_ => 0
+  | _,nil => 0
+  | (x::xs),(y::ys) =>
+    match (decide (x=y)) with
+    | left _ => S (@common_length _ eqdec xs ys)
+    | right _ => 0
+    end
+  end.
+
+Lemma common_length_l_nil {A} {eqdec: EqDecision A} (l₁ : list A) :
+  common_length l₁ nil = 0.
+Proof.
+  induction l₁; reflexivity.
+Qed.
+
+Lemma common_length_sym {A} {eqdec: EqDecision A} (l₁ l₂ : list A) :
+  common_length l₁ l₂ = common_length l₂ l₁.
+Proof.
+  induction l₁; destruct l₂; simpl; try reflexivity.
+  - rename IHl₁ into IH. simpl in IH.
+    destruct (decide (a=a0)),(decide (a0=a)).
+    + apply f_equal. destruct l₁.
+      * simpl. rewrite common_length_l_nil. destruct l₂; reflexivity.
+      * subst. destruct l₂.
+        {rewrite common_length_l_nil. reflexivity. }
+        simpl.
+        destruct (decide (a1 = a)),(decide (a = a1)).
+        4: reflexivity.
+        3: { subst. contradiction. }
+        2: { subst. contradiction.  }
+        apply f_equal.
+Abort.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -478,9 +478,6 @@ Proof.
     reflexivity.
 Qed.
 
-    
-
-
 Lemma Forall_zip_flip_reverse {A : Type} (f : A -> A -> Prop) (m : A) (l : list A) :
   Forall (curry f) (zip (m::l) (tail (m::l)))
   <->
@@ -488,13 +485,6 @@ Lemma Forall_zip_flip_reverse {A : Type} (f : A -> A -> Prop) (m : A) (l : list 
 Proof.
   rewrite -forall_zip_flip.
   rewrite -Forall_reverse.
-  Search tail zip.
-  Search zip_with.
-  Search tail drop.
-  Check Forall_rev.
-  split.
-  - intros H.
-    rewrite reverse_cons.
-    Check Forall_rev.
-    Check Forall_forall.
-Abort.
+  rewrite reverse_zip_tail_r.
+  reflexivity.
+Qed.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -469,3 +469,23 @@ Proof.
   rewrite reverse_zip_tail_r.
   reflexivity.
 Qed.
+
+Lemma Forall_drop {A : Type} (P : A -> Prop) (n : nat) (l : list A) :
+  Forall P l -> Forall P (drop n l).
+Proof.
+  remember (length l) as len.
+  assert (Hlen: length l <= len).
+  { lia. }
+  clear Heqlen.
+  move: n l Hlen.
+  induction len; intros n l Hlen H.
+  - destruct l as [|x l].
+    { rewrite drop_nil. apply H. }
+    simpl in Hlen. lia.
+  - destruct l as [|x l], n.
+    { simpl. apply Forall_nil. exact I. }
+    { rewrite drop_nil. apply Forall_nil. exact I. }
+    { simpl. apply H. }
+    simpl. apply IHlen. simpl in Hlen. lia.
+    inversion H. assumption.
+Qed.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -599,22 +599,20 @@ Proof.
 Qed.
 
 Lemma list_last_length {A : Type} (l : list A):
-  l <> [] ->
   last l = l !! (length l - 1).
 Proof.
-  intros Hneq.
   remember (length l) as len.
   rewrite Heqlen.
   assert (Hlen : length l <= len).
   { lia. }
   clear Heqlen.
 
-  move: l Hneq Hlen.
-  induction len; simpl; intros l Hneq Hlen.
+  move: l Hlen.
+  induction len; simpl; intros l Hlen.
   - assert (length l = 0).
     { lia. }
     apply nil_length_inv in H.
-    contradiction.
+    rewrite H. reflexivity.
   - destruct l.
     { reflexivity. }
     destruct l.
@@ -623,9 +621,7 @@ Proof.
     specialize (IHlen (a0::l)).
     assert (Hneq' : a0 :: l <> []).
     { discriminate. }
-    specialize (IHlen Hneq').
     simpl in IHlen.
-    Search "-" 0.
     rewrite Nat.sub_0_r in IHlen.
     apply IHlen.
     simpl in Hlen. lia.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -528,3 +528,11 @@ Proof.
     { simpl in Hlast. simpl. apply Hlast. }
     lia.
 Qed.
+
+Lemma tail_drop {A : Type} (l : list A) (n : nat) :
+  tail (drop n l) = drop n (tail l).
+Proof.
+Abort.
+
+
+  

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -489,3 +489,42 @@ Proof.
     simpl. apply IHlen. simpl in Hlen. lia.
     inversion H. assumption.
 Qed.
+
+Lemma last_drop {A : Type} (l : list A) (n : nat) (x : A) :
+  last l = Some x ->
+  n < length l ->
+  last (drop n l) = Some x.
+Proof.
+  remember (length l) as len.
+  assert (Hlen: length l <= len).
+  { lia. }
+
+  move: l Hlen n x Heqlen.
+  induction len; intros l Hlen n x Heqlen Hlast Hless.
+  - inversion Hless.
+  - destruct l as [|y l].
+    { simpl in Hlast. inversion Hlast. }
+    destruct n.
+    { simpl. simpl in Hlast. apply Hlast. }
+    rewrite skipn_cons.
+    assert (n < len).
+    { lia. }
+    clear Hless.
+    rename H into Hless.
+
+    simpl in Hlen.
+    assert (length l > 0).
+    { simpl in Heqlen. lia. }
+
+    destruct l.
+    { simpl in H. lia. }
+
+    simpl in Heqlen. inversion Heqlen. clear Heqlen.
+    assert (length (a :: l) ≤ len).
+    { simpl. lia. }
+    apply IHlen.
+    { simpl in Hlen. lia. }
+    { simpl in Hlast. simpl. apply H1. }
+    { simpl in Hlast. simpl. apply Hlast. }
+    lia.
+Qed.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -597,3 +597,36 @@ Proof.
         { lia. }
         apply IHlen. lia. lia.
 Qed.
+
+Lemma list_last_length {A : Type} (l : list A):
+  l <> [] ->
+  last l = l !! (length l - 1).
+Proof.
+  intros Hneq.
+  remember (length l) as len.
+  rewrite Heqlen.
+  assert (Hlen : length l <= len).
+  { lia. }
+  clear Heqlen.
+
+  move: l Hneq Hlen.
+  induction len; simpl; intros l Hneq Hlen.
+  - assert (length l = 0).
+    { lia. }
+    apply nil_length_inv in H.
+    contradiction.
+  - destruct l.
+    { reflexivity. }
+    destruct l.
+    { reflexivity. }
+    simpl.
+    specialize (IHlen (a0::l)).
+    assert (Hneq' : a0 :: l <> []).
+    { discriminate. }
+    specialize (IHlen Hneq').
+    simpl in IHlen.
+    Search "-" 0.
+    rewrite Nat.sub_0_r in IHlen.
+    apply IHlen.
+    simpl in Hlen. lia.
+Qed.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -597,9 +597,3 @@ Proof.
         { lia. }
         apply IHlen. lia. lia.
 Qed.
-    
-
-  
-  induction l; simpl; intros H.
-  - lia.
-  - 

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -650,3 +650,41 @@ Proof.
       * subst. apply IHn. lia.
       * lia.
 Qed.
+
+Lemma last_tail {A : Type} (l : list A) (lst m : A) :
+  last l = Some lst ->
+  head (tail l) = Some m ->
+  last (tail l) = Some lst.
+Proof.
+  remember (length l) as len.
+  assert (Hlen: length l <= len).
+  { lia. }
+  clear Heqlen.
+
+  move: l Hlen m.
+  induction len; intros l Hlen m Hlast Hhd.
+  - destruct l.
+    + auto.
+    + simpl in Hlen. lia.
+  - destruct l.
+    { simpl. auto. }
+    simpl.
+    simpl in Hhd.
+    simpl in Hlast.
+    simpl in Hlen.
+    destruct l.
+    { simpl in Hhd. inversion Hhd. }
+    simpl in Hlen.
+    assert (Hlen' : S (length l) <= len).
+    { lia. }
+
+    destruct l.
+    { apply Hlast. }
+
+    specialize (IHlen (a0::a1::l)).
+    simpl in IHlen. simpl.
+    apply IHlen with (m := a1).
+    { simpl in Hlen. lia. }
+    simpl in Hlast. apply Hlast.
+    reflexivity.
+Qed.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -530,9 +530,31 @@ Proof.
 Qed.
 
 Lemma tail_drop {A : Type} (l : list A) (n : nat) :
+  tail (drop n l) = drop (S n) l.
+Proof.
+  move: n.
+  induction l; intros n.
+  - simpl. rewrite drop_nil. reflexivity.
+  - simpl.
+    destruct n.
+    { by rewrite drop_0. }
+      by rewrite -IHl.
+Qed.
+
+Lemma drop_tail {A : Type} (l : list A) (n : nat) :
+  drop n (tail l) = drop (S n) l.
+Proof.
+  move: n.
+  induction l; intros n.
+  - simpl. rewrite drop_nil. reflexivity.
+  - simpl.
+    destruct n.
+    { by rewrite drop_0. }
+      by rewrite -IHl.
+Qed.
+
+Lemma tail_drop_comm {A : Type} (l : list A) (n : nat) :
   tail (drop n l) = drop n (tail l).
 Proof.
-Abort.
-
-
-  
+    by rewrite tail_drop drop_tail.
+Qed.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -704,3 +704,23 @@ Lemma tail_zip {A : Type} (l₁ l₂ : list A) :
 Proof.
   apply tail_zip_with.
 Qed.
+
+Lemma common_length_impl_eq {A : Type} {eqdec: EqDecision A} (l₁ l₂ : list A) :
+  length l₁ = length l₂ ->
+  common_length l₁ l₂ = length l₂ ->
+  l₁ = l₂.
+Proof.
+  intros Hlength Hcommlength.
+  Search list length lt eq lookup.
+  eapply list_eq_same_length.
+  2: apply Hlength.
+  { reflexivity. }
+  intros i x y Hi Hl₁ Hl₂.
+  assert (H: Some x = Some y).
+  { rewrite -Hl₁ -Hl₂.
+    apply equal_up_to_common_length.
+    lia.
+  }
+  inversion H.
+  reflexivity.
+Qed.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -187,3 +187,37 @@ Proof.
   simpl in H2.
   rewrite app_length in H2. simpl in H2. lia.
 Qed.
+
+Fixpoint skip_eq {A} {eqdec: EqDecision A} (l : list (A * A)) :=
+  match l with
+  | nil => nil
+  | (x,y) :: xs =>
+    match (decide (x=y)) with
+    | left _ => @skip_eq _ eqdec xs
+    | right _ => l
+    end
+  end.
+
+Lemma skip_eq_head_not_eq {A} {eqdec: EqDecision A} (l : list (A * A)) :
+  ∀ x y, hd_error (skip_eq l) = Some (x,y) -> x <> y.
+Proof.
+  induction l; intros x y; simpl; intros H.
+  - inversion H.
+  - destruct a as [a₁ a₂].
+    destruct (decide (a₁ = a₂)) eqn:Heq.
+    + apply IHl. apply H.
+    + simpl in H. inversion H. subst. apply n.
+Qed.
+
+Definition tail_skip_eq {A} {eqdec: EqDecision A} (l : list (A * A)) :=
+  reverse (skip_eq (reverse l)).
+
+Lemma tail_skip_eq_last_not_eq {A} {eqdec: EqDecision A} (l : list (A * A)) :
+  ∀ x y, last (tail_skip_eq l) = Some (x, y) -> x <> y.
+Proof.
+  intros x y H.
+  unfold tail_skip_eq in H.
+  rewrite last_reverse in H.
+  apply skip_eq_head_not_eq in H.
+  apply H.
+Qed.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -572,3 +572,34 @@ Proof.
     intros H.
     by rewrite IHn.
 Qed.
+
+Lemma list_ex_elem {A : Type} (l : list A) (n : nat) :
+  n < length l -> exists x, l!!n = Some x.
+Proof.
+  remember (length l) as len.
+  rewrite Heqlen.
+  assert (Hlen: length l <= len).
+  { lia. }
+  clear Heqlen.
+
+  move: l n Hlen.
+  induction len; intros l n Hlen.
+  - destruct l; intros H; lia.
+  - destruct l; simpl.
+    + simpl in IHlen.
+      intros H. apply IHlen. lia. apply H.
+    + intros H. destruct n.
+      * simpl. exists a. reflexivity.
+      * simpl.
+        specialize (IHlen l).
+        simpl in Hlen.
+        assert (Hlen': length l <= len).
+        { lia. }
+        apply IHlen. lia. lia.
+Qed.
+    
+
+  
+  induction l; simpl; intros H.
+  - lia.
+  - 

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -626,3 +626,27 @@ Proof.
     apply IHlen.
     simpl in Hlen. lia.
 Qed.
+
+Lemma equal_up_to_common_length {A : Type} {eqdec: EqDecision A} (l₁ l₂ : list A) :
+  forall (n:nat),
+    n < common_length l₁ l₂ ->
+    l₁ !! n = l₂ !! n.
+Proof.
+  intros n.
+  move: l₁ l₂.
+  induction n; intros l₁ l₂ H.
+  - destruct l₁,l₂; simpl.
+    + reflexivity.
+    + simpl in H. lia.
+    + simpl in H. lia.
+    + simpl in H. destruct (decide (a = a0)).
+      * subst. reflexivity.
+      * lia.
+  - destruct l₁,l₂; simpl.
+    + reflexivity.
+    + simpl in H. lia.
+    + simpl in H. lia.
+    + simpl in H. destruct (decide (a = a0)).
+      * subst. apply IHn. lia.
+      * lia.
+Qed.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -558,3 +558,17 @@ Lemma tail_drop_comm {A : Type} (l : list A) (n : nat) :
 Proof.
     by rewrite tail_drop drop_tail.
 Qed.
+
+Lemma hd_drop_lookup {A : Type} (l : list A) (n : nat) (m : A) :
+  l !! n = Some m ->
+  hd_error (drop n l) = Some m.
+Proof.
+  move: l.
+  induction n; intros l.
+  - rewrite drop_0. by rewrite hd_error_lookup.
+  - destruct l as [|x l].
+    { simpl. intros H. exact H. }
+    simpl.
+    intros H.
+    by rewrite IHn.
+Qed.

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -1,6 +1,6 @@
 (* Extensions to the stdpp library *)
 From Coq Require Import ssreflect.
-From stdpp Require Import pmap gmap mapset fin_sets sets.
+From stdpp Require Import pmap gmap mapset fin_sets sets list.
 
 Lemma not_elem_of_singleton_1 `{SemiSet A C} x y : ~ elem_of x ((singleton y) : C) -> ~ x = y.
 Proof.
@@ -330,6 +330,38 @@ Proof.
     rewrite zip_with_app_r.
     (* Oops *)
 Abort.
+
+Lemma forall_zip_flip {A B : Type} (f : A -> B -> Prop) (xs : list A) (ys: list B) :
+  Forall (curry f) (zip xs ys) <-> Forall (curry (flip f)) (zip ys xs).
+Proof.
+  split.
+  - intros H.
+    move: ys H.
+    induction xs as [|x xs]; intros ys H.
+    + rewrite zip_with_nil_r.
+      apply Forall_nil.
+      exact I.
+    + destruct ys as [|y ys].
+      { simpl. apply Forall_nil. exact I. }
+      simpl in H. simpl.
+      inversion H. subst. simpl in H2.
+      apply Forall_cons. split.
+      { simpl. apply H2. }
+      apply IHxs. apply H3.
+  - intros H.
+    move: ys H.
+    induction xs as [|x xs]; intros ys H.
+    + simpl. apply Forall_nil. exact I.
+    + destruct ys as [|y ys].
+      { simpl. apply Forall_nil. exact I. }
+      simpl in H. simpl.
+      inversion H. subst. simpl in H2.
+      apply Forall_cons. split.
+      { simpl. apply H2. }
+      apply IHxs. apply H3.
+Qed.
+
+      
 
 Lemma Forall_zip_flip_reverse {A : Type} (f : A -> A -> Prop) (m : A) (l : list A) :
   Forall (curry f) (zip (m::l) (tail (m::l)))

--- a/src/Utils/stdpp_ext.v
+++ b/src/Utils/stdpp_ext.v
@@ -688,3 +688,19 @@ Proof.
     simpl in Hlast. apply Hlast.
     reflexivity.
 Qed.
+
+Lemma tail_zip_with {A B C : Type} (f : A -> B -> C) (l₁ : list A) (l₂ : list B) :
+  tail (zip_with f l₁ l₂) = zip_with f (tail l₁) (tail l₂).
+Proof.
+  destruct l₁.
+  { reflexivity. }
+  destruct l₂.
+  { simpl. rewrite zip_with_nil_r. reflexivity. }
+  reflexivity.
+Qed.
+
+Lemma tail_zip {A : Type} (l₁ l₂ : list A) :
+  tail (zip l₁ l₂) = zip (tail l₁) (tail l₂).
+Proof.
+  apply tail_zip_with.
+Qed.


### PR DESCRIPTION
1. Again, we consider a set denoted by the pattern `Phi = mu X. base \/ (step X)`, where `base` and `step` are patterns.
This time, we assume that `step` is an injective total function and that there is "no confusion" between `base` and `step` (i.e., `base /\ (step X) = \bot`), and prove that the sequence witnessing that an element is matched by `Phi` is unique (if any). E.g., for natural numbers, where `base = 0` and `step = \lambda x. x + 1`, this means that for any natural number `n`, the sequence
  ```
  0, 1, 2, ..., n
  ```
  is unique. This is represented by the lemma `witnessed_elements_unique_seq` in `FixpointReasoning.v`

2. There have been some issues with the representation of witnessing sequences as lists where the head is matched by the base pattern and the last element is the one whose belonging to the set matched by `Phi` the sequence witnesses. Therefore I created another witnessing sequence kind - one where the head is the witnessed element and the last element is base - and proved the two equivalent. So now we have two definitions: `is_witnessing_sequence_old` and `is_witnessing_sequence`. The latter is to be used in the new code; the former is here only it would take too much time to rewrite everything in terms of the latter/new definition.