### PR TITLE
The if-and-only-if equivalence is a congruence with respect to any propositional/implicative context.

### DIFF
--- a/src/Helpers/FOL_helpers.v
+++ b/src/Helpers/FOL_helpers.v
@@ -1888,25 +1888,27 @@ Qed. *)
     well_formed p ->
     well_formed q ->
     is_implicative_context C ->
-    Γ ⊢ ((p <---> q) ---> ((emplace C p) <---> (emplace C q))).
+    Γ ⊢ (p <---> q) ->
+    Γ ⊢ (((emplace C p) <---> (emplace C q))).
   Proof.
-    intros wfp wfq impC.
+    intros wfp wfq impC Hiff.
     destruct C.
     induction pcPattern; simpl; unfold is_implicative_context in impC; simpl in impC; inversion impC;
       unfold emplace; simpl.
-    - destruct (evar_eqdec pcEvar x); simpl.
+    - destruct (evar_eqdec pcEvar x); simpl. exact Hiff. apply pf_iff_equiv_refl. auto.
+      (*
       + apply A_impl_A. unfold patt_iff. auto.
-      + apply prf_conclusion; auto. unfold patt_iff. auto. apply pf_iff_equiv_refl. auto.
-    - apply prf_conclusion; auto. unfold patt_iff. auto. apply pf_iff_equiv_refl. auto.
+      + apply prf_conclusion; auto. unfold patt_iff. auto. apply pf_iff_equiv_refl. auto.*)
+    - apply pf_iff_equiv_refl. auto.  (*apply prf_conclusion; auto unfold patt_iff. auto. apply pf_iff_equiv_refl. auto.*)
     - unfold emplace in *. simpl in *.
       pose proof (pwf := pcPattern_wf).
       unfold well_formed,well_formed_closed in pwf. simpl in pwf.
       apply andb_prop in pwf. destruct pwf as [pwf1 pwf2].
       apply andb_prop in pwf1. destruct pwf1 as [pwfp1 pwfp2].
       apply andb_prop in pwf2. destruct pwf2 as [pwfc1 pwfc2].
-      assert (well_formed pcPattern1).
+      assert (Hwf1 : well_formed pcPattern1).
       { unfold well_formed,well_formed_closed. rewrite pwfp1 pwfc1. reflexivity. }
-      assert (well_formed pcPattern2).
+      assert (Hwf2 : well_formed pcPattern2).
       { unfold well_formed,well_formed_closed. rewrite pwfp2 pwfc2. reflexivity. }
       
       destruct (decide (count_evar_occurrences pcEvar pcPattern1 ≠ 0)),
@@ -1925,6 +1927,13 @@ Qed. *)
         clear IHpcPattern2. (* Can't specialize. *)
         (* There is no occurrence of pcEvar in pcPattern2 (by [n0]).
            Therefore, p2 = q2. We need a lemma for that. *)
+        pose proof (Hnoocp := @free_evar_subst_no_occurrence _ pcEvar pcPattern2 p ltac:(lia)).
+        pose proof (Hnoocq := @free_evar_subst_no_occurrence _ pcEvar pcPattern2 q ltac:(lia)).
+        subst p2 q2. rewrite Hnoocp Hnoocq.
+        unfold patt_iff.
+        Search free_evar_subst.
+        apply conj_intro_meta; auto.
+        
   Abort.
   
       

--- a/src/Helpers/FOL_helpers.v
+++ b/src/Helpers/FOL_helpers.v
@@ -1786,7 +1786,55 @@ Qed. *)
       eapply prf_strenghten_premise_meta_meta. 5: apply H. all: auto.
       apply reorder; auto.
   Qed.
+
+  Lemma prf_add_proved_to_assumptions_meta Γ l a g:
+    wf l ->
+    well_formed a ->
+    well_formed g ->
+    Γ ⊢ a ->
+    Γ ⊢ (foldr patt_imp g (a::l)) ->
+    Γ ⊢ (foldr patt_imp g l).
+  Proof.
+    intros.
+    eapply Modus_ponens.
+    4: eapply prf_add_proved_to_assumptions.
+    3: apply H3.
+    all: auto.
+  Qed.
   
+  Lemma MyGoal_add Γ l g h:
+    Γ ⊢ h ->
+    wf l ->
+    well_formed g ->
+    well_formed h ->
+    mkMyGoal Γ (h::l) g ->
+    mkMyGoal Γ l g.
+  Proof.
+    intros.
+    apply prf_add_proved_to_assumptions_meta with (a := h).
+    all: auto.
+  Qed.
+
+  Tactic Notation "mgAdd" ident(n) :=
+    match goal with
+    | |- of_MyGoal (mkMyGoal ?Ctx ?l ?g) =>
+      apply (MyGoal_add Ctx l g _ n)
+    end.
+
+  Lemma test_mgAdd Γ l g h:
+    wf l ->
+    well_formed g ->
+    well_formed h ->
+    Γ ⊢ (h ---> g) ->
+    Γ ⊢ h ->
+    Γ ⊢ g.
+  Proof.
+    intros. toMyGoal.
+    mgAdd H3; [auto|auto|auto|].
+    mgAdd H2; [auto|auto|auto|].
+    mgApply' 0 5. mgExactn 1.
+  Qed.
+
   Lemma conclusion_anyway Γ A B:
     well_formed A ->
     well_formed B ->

--- a/src/Helpers/FOL_helpers.v
+++ b/src/Helpers/FOL_helpers.v
@@ -2035,13 +2035,51 @@ Qed. *)
         Unshelve. 2,3,4,5: subst; auto.
         
         apply conj_intro_meta. 1,2: subst; auto.
-        unfold patt_iff in IHpcPattern1. Search patt_and.
+        unfold patt_iff in IHpcPattern1.
+
+        * toMyGoal. mgIntro. mgIntro. mgAdd H2. 1,2,3: subst; auto.
+          mgApply' 1 5. 1,2: subst; auto.
+          mgApply' 0 5. 1,2,3: subst; auto.
+          mgExactn 2; subst; auto.
+
+        * toMyGoal. mgIntro. mgIntro. mgAdd H1. 1,2,3: subst; auto.
+          mgApply' 1 5. 1,2: subst; auto.
+          mgApply' 0 5. 1,2,3: subst; auto.
+          mgExactn 2; subst; auto.
+      + remember (free_evar_subst pcPattern1 p pcEvar) as p1.
+        remember (free_evar_subst pcPattern2 p pcEvar) as p2.
+        remember (free_evar_subst pcPattern1 q pcEvar) as q1.
+        remember (free_evar_subst pcPattern2 q pcEvar) as q2.
+        assert (pcOneOcc1 : count_evar_occurrences pcEvar pcPattern2 = 1).
+        { lia. }
+        specialize (IHpcPattern2 ltac:(auto) ltac:(lia)).
+        unfold is_implicative_context in IHpcPattern1.
+        simpl in IHpcPattern1.
+        simpl in impC. (*rewrite andbT in impC.*)
+        specialize (IHpcPattern2 impC).
+        clear IHpcPattern1. (* Can't specialize. *)
+        pose proof (Hnoocp := @free_evar_subst_no_occurrence _ pcEvar pcPattern1 p ltac:(lia)).
+        pose proof (Hnoocq := @free_evar_subst_no_occurrence _ pcEvar pcPattern1 q ltac:(lia)).
+        subst p1 q1. rewrite Hnoocp Hnoocq.
+        unfold patt_iff.
+
+        epose proof (H1 := pf_conj_elim_l_meta _ _ _ _ _ IHpcPattern2).
+        epose proof (H2 := pf_conj_elim_r_meta _ _ _ _ _ IHpcPattern2).
+        Unshelve. 2,3,4,5: subst; auto.
         
-        (* We need to add H1 or H2 to the assumptions
-           and then use the proof mode to reason about them. *)
+        apply conj_intro_meta. 1,2: subst; auto.
+        unfold patt_iff in IHpcPattern2.
         
-  Abort.
-  
+        * toMyGoal. mgIntro. mgIntro. mgAdd H1. 1,2,3: subst; auto.
+          mgApply' 0 5. 1,2,3: subst; auto.
+          mgApply' 1 5. 1,2: subst; auto.
+          mgExactn 2; subst; auto.
+
+        * toMyGoal. mgIntro. mgIntro. mgAdd H2. 1,2,3: subst; auto.
+          mgApply' 0 5. 1,2,3: subst; auto.
+          mgApply' 1 5. 1,2: subst; auto.
+          mgExactn 2; subst; auto.      
+  Qed.
       
     
   Lemma prf_prop_bott_iff Γ AC:

--- a/src/MLTauto.v
+++ b/src/MLTauto.v
@@ -510,6 +510,21 @@ Section ml_tauto.
           fold (patt_not p3) in *. fold (patt_not (patt_not p3)) in *.
           fold (patt_not p4) in *. fold (patt_or (patt_not p3) (patt_not p4)) in *.
           fold (patt_not (patt_or (patt_not p3) (patt_not p4))) in *.
+          pose proof (Hwfp' := Hwfp).
+          (* TODO automate this ugly thing *)
+          unfold well_formed, well_formed_closed in Hwfp'. simpl in Hwfp'.
+          rewrite !andbT in Hwfp'.
+          apply andb_prop in Hwfp'. destruct Hwfp' as [Hwfp' Hwfc'].
+          apply andb_prop in Hwfp'. destruct Hwfp' as [Hwfpp3 Hwfpp4].
+          apply andb_prop in Hwfc'. destruct Hwfc' as [Hwfcp3 Hwfcp4].
+          assert (Hwfp3: well_formed p3).
+          { unfold well_formed, well_formed_closed. rewrite Hwfpp3 Hwfcp3. reflexivity. }
+          assert (Hwfp4: well_formed p4).
+          { unfold well_formed, well_formed_closed. rewrite Hwfpp4 Hwfcp4. reflexivity. }
+          simpl in Hsz.
+          pose proof (IHp3 := IHsz p3 ltac:(auto) ltac:(lia)).
+          pose proof (IHp4 := IHsz p4 ltac:(auto) ltac:(lia)).
+          
           (*Search evar.
           
           Print countable.Countable.*)

--- a/src/Syntax.v
+++ b/src/Syntax.v
@@ -4098,7 +4098,7 @@ Section syntax.
   Qed.
       
 
-  Lemma well_formed_free_evar_subst' x p q n1 n2:
+  Lemma Private_well_formed_free_evar_subst' x p q n1 n2:
     well_formed q ->
     well_formed_positive p && well_formed_closed_aux p n1 n2 ->
     no_negative_occurrence_db_b n2 (free_evar_subst p q x) && no_positive_occurrence_db_b n2 (free_evar_subst p q x) &&
@@ -4170,13 +4170,20 @@ Section syntax.
       apply andb_prop in IHn1. destruct IHn1 as [IHn11 IHn12].
       rewrite IHn12 IHn11. simpl. rewrite IHn2.
       rewrite IHc.
-      Check wfc_impl_no_neg_pos_occ.
-      pose proof (wfc_impl_no_neg_pos_occ IHc).
-      unfold well_formed_positive in IHp
-      Search "no_negative_occurrence" "subst".
-      reflexivity.
-  Abort.
+      rewrite free_evar_subst_preserves_no_negative_occurrence; auto.
+  Qed.
 
+  Lemma well_formed_free_evar_subst x p q:
+    well_formed q ->
+    well_formed p ->
+    well_formed (free_evar_subst p q x).
+  Proof.
+    intros wfp wfq.
+    pose proof (H := Private_well_formed_free_evar_subst' x wfp wfq).
+    unfold well_formed, well_formed_closed.
+    apply andb_prop in H. destruct H as [H H2]. rewrite H2. clear H2.
+    apply andb_prop in H. destruct H as [H H2]. rewrite H2. reflexivity.
+  Qed.
   
 
 End syntax.

--- a/src/Syntax.v
+++ b/src/Syntax.v
@@ -4066,6 +4066,37 @@ Section syntax.
     intros. apply (Private_svar_open_free_svar_subst_comm) with (sz := (size phi)); try lia; try assumption.
   Qed.
 
+  Lemma free_evar_subst_preserves_no_negative_occurrence x p q n:
+    well_formed q ->
+    no_negative_occurrence_db_b n p ->
+    no_negative_occurrence_db_b n (free_evar_subst p q x)
+  with
+  free_evar_subst_preserves_no_positive_occurrence x p q n:
+    well_formed q ->
+    no_positive_occurrence_db_b n p ->
+    no_positive_occurrence_db_b n (free_evar_subst p q x)
+  .
+  Proof.
+    - intros wfq nno.
+      induction p; simpl; auto.
+      + destruct (evar_eqdec x x0); simpl; auto.
+        apply andb_prop in wfq. destruct wfq as [wfpq wfcq].
+        apply wfc_impl_no_neg_occ. apply wfcq.
+      + simpl in nno. apply andb_prop in nno. destruct nno as [nnop1 nnop2].
+        rewrite IHp1. auto. rewrite IHp2. auto. reflexivity.
+      + simpl in nno. apply andb_prop in nno. destruct nno as [nnop1 nnop2].
+        rewrite IHp2. assumption. rewrite free_evar_subst_preserves_no_positive_occurrence; auto.
+    - intros wfq npo.
+      induction p; simpl; auto.
+      + destruct (evar_eqdec x x0); simpl; auto.
+        apply andb_prop in wfq. destruct wfq as [wfpq wfcq].
+        apply wfc_impl_no_pos_occ. apply wfcq.
+      + simpl in npo. apply andb_prop in npo. destruct npo as [npop1 npop2].
+        rewrite IHp1. auto. rewrite IHp2. auto. reflexivity.
+      + simpl in npo. apply andb_prop in npo. destruct npo as [npop1 npop2].
+        rewrite IHp2. assumption. rewrite free_evar_subst_preserves_no_negative_occurrence; auto.
+  Qed.
+      
 
   Lemma well_formed_free_evar_subst' x p q n1 n2:
     well_formed q ->

--- a/src/Syntax.v
+++ b/src/Syntax.v
@@ -2419,7 +2419,21 @@ Section syntax.
     unfold PatternCtx2ApplicationContext, ApplicationContext2PatternCtx.
     apply ApplicationContext2PatternCtx2ApplicationContext'.
   Qed.
-  
+
+  Fixpoint is_implicative_context' (box_evar : evar) (phi : Pattern) : bool :=
+    match phi with
+    | patt_bott => true
+    | patt_free_evar _ => true
+    | patt_imp phi1 phi2 =>
+      (if decide(count_evar_occurrences box_evar phi1 <> 0)
+       then is_implicative_context' box_evar phi1 else true) &&
+      (if decide(count_evar_occurrences box_evar phi2 <> 0)
+       then is_implicative_context' box_evar phi2 else true)
+    | _ => false
+    end.
+
+  Definition is_implicative_context (C : PatternCtx) :=
+    is_implicative_context' (pcEvar C) (pcPattern C).
     
 
   Inductive is_subformula_of_ind : Pattern -> Pattern -> Prop :=

--- a/src/Syntax.v
+++ b/src/Syntax.v
@@ -883,7 +883,7 @@ Section syntax.
   Proof.
     intros H. unfold well_formed in *. apply andb_prop in H. destruct H as [Hwfp Hwfc].
     simpl in *. rewrite Hwfp. clear Hwfp. simpl.
-    unfold well_formed_closed in *. simpl. Search well_formed_closed_aux.
+    unfold well_formed_closed in *. simpl.
     eapply well_formed_closed_aux_ind. 3: apply Hwfc. all: lia.
   Qed.
 
@@ -4280,6 +4280,9 @@ End BoundVarSugar.
 
 #[export]
  Hint Resolve well_formed_impl_well_formed_ex : core.
+
+#[export]
+ Hint Resolve well_formed_free_evar_subst : core.
 
 (* Tactics for resolving goals involving sets *)
 

--- a/src/Syntax.v
+++ b/src/Syntax.v
@@ -4069,16 +4069,25 @@ Section syntax.
 
   Lemma well_formed_free_evar_subst' x p q n1 n2:
     well_formed q ->
-    well_formed_positive p && well_formed_closed_aux p n1 n2->
-    well_formed_positive (free_evar_subst p q x) && well_formed_closed_aux (free_evar_subst p q x) n1 n2.
+    well_formed_positive p && well_formed_closed_aux p n1 n2 ->
+    no_negative_occurrence_db_b n2 (free_evar_subst p q x) && no_positive_occurrence_db_b n2 (free_evar_subst p q x) &&
+    well_formed_positive (free_evar_subst p q x) && well_formed_closed_aux (free_evar_subst p q x) n1 n2 = true.
   Proof.
     intros wfq wfp.
     move: n1 n2 wfp.
     induction p; intros n1 n2 wfp; simpl; auto.
     - destruct (evar_eqdec x x0); simpl; auto.
       unfold well_formed in wfq. apply andb_prop in wfq. destruct wfq as [wfpq wfcq].
-      rewrite wfpq. simpl.
-      eapply well_formed_closed_aux_ind. 3: apply wfcq. all: lia.
+      rewrite wfpq. simpl in *.
+      pose proof (H1 := @well_formed_closed_aux_ind q 0 0 0 n2 ltac:(lia) ltac:(lia) wfcq).
+      pose proof (H2 := wfc_impl_no_neg_pos_occ H1).
+      rewrite H2. simpl.
+      eapply well_formed_closed_aux_ind.
+      3: apply wfcq. all: lia.
+    - simpl in *. rewrite wfp.
+      rewrite !andbT.
+      apply negb_true_iff. apply PeanoNat.Nat.eqb_neq.
+      apply Nat.ltb_lt in wfp. lia.
     - unfold well_formed, well_formed_closed in *. simpl in *.
       apply andb_prop in wfp. destruct wfp as [wfpp wfcp].
       apply andb_prop in wfpp. destruct wfpp as [wfpp1 wfpp2].
@@ -4089,8 +4098,14 @@ Section syntax.
       simpl in *.
       specialize (IHp1 ltac:(auto)).
       specialize (IHp2 ltac:(auto)).
-      apply andb_prop in IHp1. destruct IHp1 as [IHp1 IHc1]. rewrite IHp1 IHc1.
-      apply andb_prop in IHp2. destruct IHp2 as [IHp2 IHc2]. rewrite IHp2 IHc2.
+      apply andb_prop in IHp1. destruct IHp1 as [IHp1 IHc1].
+      apply andb_prop in IHp1. destruct IHp1 as [IHn1 IHp1].
+      rewrite IHp1 IHc1. apply andb_prop in IHn1. destruct IHn1 as [IHn11 IHn12].
+      rewrite IHn11 IHn12. simpl.
+      apply andb_prop in IHp2. destruct IHp2 as [IHp2 IHc2].
+      apply andb_prop in IHp2. destruct IHp2 as [IHn2 IHp2].
+      rewrite IHp2 IHc2. apply andb_prop in IHn2. destruct IHn2 as [IHn21 IHn22].
+      rewrite IHn21 IHn22.
       reflexivity.
     - unfold well_formed, well_formed_closed in *. simpl in *.
       apply andb_prop in wfp. destruct wfp as [wfpp wfcp].
@@ -4102,16 +4117,28 @@ Section syntax.
       simpl in *.
       specialize (IHp1 ltac:(auto)).
       specialize (IHp2 ltac:(auto)).
-      apply andb_prop in IHp1. destruct IHp1 as [IHp1 IHc1]. rewrite IHp1 IHc1.
-      apply andb_prop in IHp2. destruct IHp2 as [IHp2 IHc2]. rewrite IHp2 IHc2.
+      apply andb_prop in IHp1. destruct IHp1 as [IHp1 IHc1].
+      apply andb_prop in IHp1. destruct IHp1 as [IHn1 IHp1].
+      rewrite IHp1 IHc1. apply andb_prop in IHn1. destruct IHn1 as [IHn11 IHn12].
+      rewrite IHn11 IHn12. simpl.
+      apply andb_prop in IHp2. destruct IHp2 as [IHp2 IHc2].
+      apply andb_prop in IHp2. destruct IHp2 as [IHn2 IHp2].
+      rewrite IHp2 IHc2. apply andb_prop in IHn2. destruct IHn2 as [IHn21 IHn22].
+      rewrite IHn21 IHn22.
       reflexivity.
-    - unfold well_formed, well_formed_closed in *. simpl in *.
+    - simpl in wfp.
+      unfold well_formed, well_formed_closed in *. simpl in *.
       apply andb_prop in wfp. destruct wfp as [wfpp wfcp].
+      pose proof (IHp' := IHp).
       specialize (IHp n1 (S n2)).
       apply andb_prop in wfpp. destruct wfpp as [nnop wfpp].
       rewrite wfpp in IHp. simpl in IHp. rewrite wfcp in IHp.
       specialize (IHp ltac:(auto)).
-      apply andb_prop in IHp. destruct IHp as [IHp IHc]. rewrite IHp IHc.
+      apply andb_prop in IHp. destruct IHp as [IHp IHc].
+      apply andb_prop in IHp. destruct IHp as [IHn1 IHn2].
+      apply andb_prop in IHn1. destruct IHn1 as [IHn11 IHn12].
+      rewrite IHn12 IHn11. simpl. rewrite IHn2.
+      rewrite IHc.
       Check wfc_impl_no_neg_pos_occ.
       pose proof (wfc_impl_no_neg_pos_occ IHc).
       unfold well_formed_positive in IHp


### PR DESCRIPTION
The lemma `prf_equiv_congruence_implicative_ctx` says:
```
    is_implicative_context C ->
    Γ ⊢ (p <---> q) ->
    Γ ⊢ (((emplace C p) <---> (emplace C q))).
```
For example, if we have `|- p <---> q`, then also `|- (a -> b -> p -> c) <---> (a -> b -> q -> c)`.