### PR TITLE
Metamath Proof object generation (1)

### DIFF
--- a/matching-logic/src/Helpers/FOL_helpers.v
+++ b/matching-logic/src/Helpers/FOL_helpers.v
@@ -1314,10 +1314,10 @@ Qed. *)
   Notation "[ G ⊢ l ==> g ]" := (mkMyGoal G l g).
 
 
-  Coercion of_MyGoal (MG : MyGoal) : Prop := (mgTheory MG) ⊢ (fold_right patt_imp (mgConclusion MG) (mgHypotheses MG)).
+  Coercion of_MyGoal (MG : MyGoal) : Type := (mgTheory MG) ⊢ (fold_right patt_imp (mgConclusion MG) (mgHypotheses MG)).
 
 
-  Lemma of_MyGoal_from_goal Γ (goal : Pattern) : of_MyGoal (MyGoal_from_goal Γ goal) <-> (Γ ⊢ goal).
+  Lemma of_MyGoal_from_goal Γ (goal : Pattern) : of_MyGoal (MyGoal_from_goal Γ goal) = (Γ ⊢ goal).
   Proof. reflexivity. Qed.
 
   Lemma MyGoal_intro (Γ : Theory) (l : list Pattern) (x g : Pattern):
@@ -1342,7 +1342,7 @@ Qed. *)
     apply nested_const_middle; auto.
   Qed.  
   
-  Ltac toMyGoal := rewrite -of_MyGoal_from_goal; unfold MyGoal_from_goal.
+  Ltac toMyGoal := rewrite <- of_MyGoal_from_goal; unfold MyGoal_from_goal.
   Ltac fromMyGoal := unfold of_MyGoal; simpl.
   Ltac mgIntro := apply MyGoal_intro; simpl.
   Ltac mgExactn n := apply (MyGoal_exact _ _ _ n); auto.
@@ -1633,9 +1633,9 @@ Qed. *)
     mkMyGoal Γ (l ++ [h]) g ->
     mkMyGoal Γ l g.
   Proof.
-    intros.
-    eapply prf_add_lemma_under_implication_meta_meta. 4: apply H2. all: auto.
-  Qed.  
+    intros wfl wfg wfh H1 H2.
+    eapply prf_add_lemma_under_implication_meta_meta. 4: apply H1. all: auto.
+  Qed.
   
   Tactic Notation "mgAssert" "(" ident(n) ":" constr(t) ")" :=
     match goal with
@@ -2238,6 +2238,7 @@ Qed.
     apply pf_conj_elim_r_meta in H1; auto.
   Qed.
 
+  (* TODO fix this *)
   Lemma pf_iff_iff Γ A B:
     well_formed A ->
     well_formed B ->

--- a/matching-logic/src/Helpers/FOL_helpers.v
+++ b/matching-logic/src/Helpers/FOL_helpers.v
@@ -2574,22 +2574,23 @@ Qed.
       auto 10.
   Qed.
 
-  Lemma MyGoal_applyMeta Γ l r r':
+  Lemma MyGoal_applyMeta Γ r r':
     Γ ⊢ (r' ---> r) ->
+    forall l,
     wf l ->
     well_formed r ->
     well_formed r' ->
     mkMyGoal Γ l r' ->
     mkMyGoal Γ l r.
   Proof.
-    intros Himp wfl wfr wfr' H.
+    intros Himp l wfl wfr wfr' H.
     eapply prf_weaken_conclusion_iter_meta_meta.
     4: { apply Himp; auto. }
     all: auto.
   Qed.
 
   Tactic Notation "mgApplyMeta" uconstr(t) :=
-    eapply (MyGoal_applyMeta _ _ _ _ t).
+    unshelve (eapply (MyGoal_applyMeta _ _ _ t)).
 
   Ltac mgLeft := mgApplyMeta (disj_left_intro _ _ _ _ _).
   Ltac mgRight := mgApplyMeta (disj_right_intro _ _ _ _ _).

--- a/matching-logic/src/Helpers/FOL_helpers.v
+++ b/matching-logic/src/Helpers/FOL_helpers.v
@@ -2238,15 +2238,14 @@ Qed.
     apply pf_conj_elim_r_meta in H1; auto.
   Qed.
 
-  (* TODO fix this *)
   Lemma pf_iff_iff Γ A B:
     well_formed A ->
     well_formed B ->
-    (Γ ⊢ (A <---> B)) <-> ((Γ ⊢ (A ---> B)) /\ (Γ ⊢ (B ---> A))).
+    prod ((Γ ⊢ (A <---> B)) -> (prod (Γ ⊢ (A ---> B)) (Γ ⊢ (B ---> A))))
+    ( (prod (Γ ⊢ (A ---> B))  (Γ ⊢ (B ---> A))) -> (Γ ⊢ (A <---> B))).
   Proof.
     intros. firstorder using pf_iff_proj1,pf_iff_proj2,pf_iff_split.
   Qed.
-  
 
   Lemma pf_iff_equiv_refl Γ A :
     well_formed A ->
@@ -2263,8 +2262,11 @@ Qed.
     Γ ⊢ (B <---> A).
   Proof.
     intros wfA wfB H.
-    apply pf_iff_iff in H; auto. apply pf_iff_iff; auto.
-    exact (conj (proj2 H) (proj1 H)).
+    pose proof (H2 := H).
+    apply pf_iff_proj2 in H2; auto.
+    rename H into H1.
+    apply pf_iff_proj1 in H1; auto.
+    apply pf_iff_split; auto.
   Qed.
 
   Lemma pf_iff_equiv_trans Γ A B C :

--- a/matching-logic/src/ProofSystem.v
+++ b/matching-logic/src/ProofSystem.v
@@ -128,10 +128,10 @@ Qed.
 
   
   (* Proof system for AML ref. snapshot: Section 3 *)
-
+Check Pattern.
   Reserved Notation "theory ⊢ pattern" (at level 1).
   Inductive ML_proof_system (theory : Theory) :
-    Pattern -> Prop :=
+    Pattern -> Set :=
 
   (* Hypothesis *)
   | hypothesis (axiom : Pattern) :
@@ -254,9 +254,9 @@ Proof.
     apply Extensionality_Ensembles.
     constructor. constructor.
     assert (Ensembles.Union (Domain m) (Complement (Domain m) Xphi) Xphi = Full_set (Domain m)).
-    apply Same_set_to_eq. apply Union_Compl_Fullset. unfold Full. rewrite <- H1; clear H1.
+    apply Same_set_to_eq. apply Union_Compl_Fullset. unfold Full. rewrite <- H; clear H.
     unfold Included; intros; apply Union_is_or.
-    inversion H1. left. assumption. right. apply Union_intror. assumption.
+    inversion H. left. assumption. right. apply Union_intror. assumption.
 
   (* FOL reasoning - P2 *)
   * intros Hv evar_val svar_val.
@@ -264,61 +264,80 @@ Proof.
     remember (pattern_interpretation evar_val svar_val phi) as Xphi.
     remember (pattern_interpretation evar_val svar_val psi) as Xpsi.
     remember (pattern_interpretation evar_val svar_val xi) as Xxi.
-    pose proof Compl_Union_Intes_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    pose proof Compl_Union_Intes_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    pose proof Compl_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    pose proof Compl_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    pose proof Compl_Union_Intes_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    pose proof Compl_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    epose proof Union_Transitive (Ensembles.Intersection (Domain m) Xphi (Complement (Domain m) Xpsi))
-          (Complement (Domain m) Xphi) Xxi.
-    apply Same_set_to_eq in H2; rewrite <- H2; clear H2.
-    pose proof Intes_Union_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    pose proof Union_Symmetric (Complement (Domain m) Xpsi) (Complement (Domain m) Xphi).
-    apply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    epose proof Union_Transitive; eapply Same_set_to_eq in H2; rewrite <- H2; clear H2.
-    epose proof Union_Transitive; eapply Same_set_to_eq in H2; rewrite <- H2; clear H2.
-    pose proof Intes_Union_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    epose proof Union_Transitive; eapply Same_set_to_eq in H2; erewrite -> H2; clear H2.
-    epose proof Union_Transitive; eapply Same_set_to_eq in H2; erewrite -> H2; clear H2.
-    pose proof Union_Symmetric (Complement (Domain m) Xpsi) Xxi.
-    apply Same_set_to_eq in H2; erewrite -> H2; clear H2.
-    pose proof Union_Transitive (Complement (Domain m) Xphi) Xxi (Complement (Domain m) Xpsi).
-    apply Same_set_to_eq in H2; rewrite <- H2; clear H2.
-    pose proof Union_Symmetric (Complement (Domain m) Xphi) Xxi.
-    apply Same_set_to_eq in H2; erewrite -> H2; clear H2.
-    pose proof Compl_Compl_Ensembles (Domain m) Xxi.
-    apply Same_set_to_eq in H2; rewrite <- H2 at 2; clear H2.
-    pose proof Intersection_Symmetric Xpsi (Complement (Domain m) Xxi).
-    apply Same_set_to_eq in H2; erewrite -> H2; clear H2.
-    epose proof Union_Transitive; eapply Same_set_to_eq in H2; erewrite <- H2; clear H2.    
-    epose proof Union_Transitive; eapply Same_set_to_eq in H2; erewrite <- H2; clear H2.
-    pose proof Intes_Union_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    pose proof Compl_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
+    pose proof (Htmp := Compl_Union_Intes_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Union_Intes_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Union_Intes_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    epose proof (Htmp := Union_Transitive (Ensembles.Intersection (Domain m) Xphi (Complement (Domain m) Xpsi))
+          (Complement (Domain m) Xphi) Xxi).
+    apply Same_set_to_eq in Htmp; rewrite <- Htmp; clear Htmp.
+    pose proof (Htmp := Intes_Union_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Union_Symmetric (Complement (Domain m) Xpsi) (Complement (Domain m) Xphi)).
+    apply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    epose proof (Htmp := Union_Transitive); eapply Same_set_to_eq in Htmp; rewrite <- Htmp; clear Htmp.
+    epose proof (Htmp := Union_Transitive); eapply Same_set_to_eq in Htmp; rewrite <- Htmp; clear Htmp.
+    pose proof (Htmp := Intes_Union_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    epose proof (Htmp := Union_Transitive);
+      eapply Same_set_to_eq in Htmp; erewrite -> Htmp; clear Htmp.
+    epose proof (Htmp := Union_Transitive);
+      eapply Same_set_to_eq in Htmp; erewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Union_Symmetric (Complement (Domain m) Xpsi) Xxi).
+    apply Same_set_to_eq in Htmp; erewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Union_Transitive (Complement (Domain m) Xphi) Xxi (Complement (Domain m) Xpsi)).
+    apply Same_set_to_eq in Htmp; rewrite <- Htmp; clear Htmp.
+    pose proof (Htmp := Union_Symmetric (Complement (Domain m) Xphi) Xxi).
+    apply Same_set_to_eq in Htmp; erewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Compl_Ensembles (Domain m) Xxi).
+    apply Same_set_to_eq in Htmp; rewrite <- Htmp at 2; clear Htmp.
+    pose proof (Htmp := Intersection_Symmetric Xpsi (Complement (Domain m) Xxi)).
+    apply Same_set_to_eq in Htmp; erewrite -> Htmp; clear Htmp.
+    epose proof (Htmp := Union_Transitive);
+      eapply Same_set_to_eq in Htmp; erewrite <- Htmp; clear Htmp.    
+    epose proof (Htmp := Union_Transitive);
+      eapply Same_set_to_eq in Htmp; erewrite <- Htmp; clear Htmp.
+    pose proof (Htmp := Intes_Union_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
 
     apply Extensionality_Ensembles.
     constructor. constructor.
-    assert (Ensembles.Union (Domain m) (Complement (Domain m) Xpsi) Xpsi = Full_set (Domain m)).
-    apply Same_set_to_eq. apply Union_Compl_Fullset. unfold Full. rewrite <- H2; clear H2.
-    unfold Included; intros; unfold In. inversion H2.
+    assert (Htmp: Ensembles.Union (Domain m) (Complement (Domain m) Xpsi) Xpsi = Full_set (Domain m)).
+    { apply Same_set_to_eq. apply Union_Compl_Fullset. }
+    unfold Full. rewrite <- Htmp; clear Htmp.
+    unfold Included; intros x H2; unfold In. inversion H2.
     apply Union_intror; assumption.
     apply Union_introl; apply Union_introl; apply Union_introl; assumption.
 
   (* FOL reasoning - P3 *)
   * intros Hv evar_val svar_val. 
     repeat rewrite -> pattern_interpretation_imp_simpl; rewrite -> pattern_interpretation_bott_simpl.
-    epose proof Union_Empty_l; eapply Same_set_to_eq in H0; unfold Semantics.Empty; rewrite -> H0; clear H0.
-    epose proof Union_Empty_l; eapply Same_set_to_eq in H0; rewrite -> H0; clear H0.
-    pose proof Compl_Compl_Ensembles; eapply Same_set_to_eq in H0; rewrite -> H0; clear H0.
+    epose proof (Htmp := Union_Empty_l);
+      eapply Same_set_to_eq in Htmp; unfold Semantics.Empty; rewrite -> Htmp; clear Htmp.
+    epose proof (Htmp := Union_Empty_l);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
     apply Extensionality_Ensembles.
     apply Union_Compl_Fullset.
 
   (* Modus ponens *)
   * intros Hv evar_val svar_val.
-    pose (IHHp2 H0 Hv evar_val svar_val) as e.
+    rename i into wfphi1. rename i0 into wfphi1impphi2.
+    pose (IHHp2 wfphi1impphi2 Hv evar_val svar_val) as e.
     rewrite -> pattern_interpretation_iff_subset in e.
     apply Extensionality_Ensembles.
-    constructor. constructor. rewrite <- (IHHp1 H Hv evar_val svar_val). apply e; assumption.
+    constructor. constructor. rewrite <- (IHHp1 wfphi1 Hv evar_val svar_val). apply e; assumption.
 
   (* Existential quantifier *)
   * intros Hv evar_val svar_val.
@@ -341,6 +360,7 @@ Proof.
 
   (* Existential generalization *)
   * intros Hv evar_val svar_val.
+    rename i into H. rename i0 into H0.
     rewrite pattern_interpretation_iff_subset.
     assert (Hwf_imp: well_formed (phi1 ---> phi2)).
     { unfold well_formed. simpl. unfold well_formed in H, H0.
@@ -351,7 +371,7 @@ Proof.
       apply andb_true_iff; split; apply andb_true_iff; split; assumption.
     }
     specialize (IHHp Hwf_imp Hv). clear Hv. clear Hwf_imp.
-    assert (forall evar_val svar_val,
+    assert (H2: forall evar_val svar_val,
                Included (Domain m)
                         (pattern_interpretation evar_val svar_val phi1)
                         (pattern_interpretation evar_val svar_val phi2)
@@ -368,7 +388,7 @@ Proof.
                                  (λ e : Domain m, pattern_interpretation
                                                     (update_evar_val x e evar_val) svar_val phi1))).
        { unfold exists_quantify. rewrite pattern_interpretation_ex_simpl. simpl.
-         apply FA_Union_included. unfold Included, Ensembles.In. intros.
+         apply FA_Union_included. unfold Included, Ensembles.In. intros c x1 H3.
          remember (fresh_evar (evar_quantify x 0 phi1)) as x2.
          erewrite interpretation_fresh_evar_open with (y := x) in H3.
          3: { apply evar_is_fresh_in_evar_quantify. }
@@ -383,28 +403,32 @@ Proof.
        }
        unfold Included, Ensembles.In in Hinc. apply Hinc. apply Hphi1.
 
-    -- destruct H3 as [c Hphi2].
-       rewrite pattern_interpretation_free_evar_independent in Hphi2. apply H1.
-       apply Hphi2.
+    -- 
+       destruct H1 as [c Hphi2].
+       rewrite pattern_interpretation_free_evar_independent in Hphi2.
+       { auto. }
+       { apply Hphi2. }
 
   (* Propagation bottom - left *)
   * intros Hv evar_val svar_val. 
     rewrite -> pattern_interpretation_imp_simpl, pattern_interpretation_app_simpl, pattern_interpretation_bott_simpl.
-    epose proof Union_Empty_l; eapply Same_set_to_eq in H0; unfold Semantics.Empty; rewrite -> H0; clear H0.
+    epose proof (Htmp := Union_Empty_l);
+      eapply Same_set_to_eq in Htmp; unfold Semantics.Empty; rewrite -> Htmp; clear Htmp.
     apply Extensionality_Ensembles.
     constructor. constructor.
     unfold Included; intros.
-    epose proof app_ext_bot_l; unfold Semantics.Empty in H1; rewrite -> H1; clear H1.
+    epose proof (Htmp := app_ext_bot_l); unfold Semantics.Empty in Htmp; rewrite -> Htmp; clear Htmp.
     unfold Ensembles.In; unfold Complement; unfold not; contradiction.
 
   (* Propagation bottom - right *)
   * intros Hv evar_val svar_val. 
     rewrite -> pattern_interpretation_imp_simpl, pattern_interpretation_app_simpl, pattern_interpretation_bott_simpl.
-    epose proof Union_Empty_l; eapply Same_set_to_eq in H0; unfold Semantics.Empty; rewrite -> H0; clear H0.
+    epose proof (Htmp := Union_Empty_l);
+      eapply Same_set_to_eq in Htmp; unfold Semantics.Empty; rewrite -> Htmp; clear Htmp.
     apply Extensionality_Ensembles.
     constructor. constructor.
     unfold Included; intros.
-    epose proof app_ext_bot_r; unfold Semantics.Empty in H1; rewrite -> H1; clear H1.
+    epose proof (Htmp := app_ext_bot_r); unfold Semantics.Empty in Htmp; rewrite -> Htmp; clear Htmp.
     unfold Ensembles.In; unfold Complement; unfold not; contradiction.
 
   (* Propagation disjunction - left *)
@@ -412,23 +436,28 @@ Proof.
     unfold patt_or, patt_not. repeat rewrite -> pattern_interpretation_imp_simpl.
     repeat rewrite -> pattern_interpretation_app_simpl, pattern_interpretation_imp_simpl.
     rewrite -> pattern_interpretation_app_simpl, pattern_interpretation_bott_simpl.
-    epose proof Union_Empty_l; eapply Same_set_to_eq in H2; unfold Semantics.Empty; rewrite -> H2; clear H2.
-    epose proof Union_Empty_l; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    pose proof Compl_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    pose proof Compl_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
+    epose proof (Htmp := Union_Empty_l);
+      eapply Same_set_to_eq in Htmp; unfold Semantics.Empty; rewrite -> Htmp; clear Htmp.
+    epose proof (Htmp := Union_Empty_l);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
     remember (pattern_interpretation evar_val svar_val phi1) as Xphi1.
     remember (pattern_interpretation evar_val svar_val phi2) as Xphi2.
     remember (pattern_interpretation evar_val svar_val psi) as Xpsi.
     remember (app_ext (Ensembles.Union (Domain m) Xphi1 Xphi2) Xpsi) as Xext_union.
     apply Extensionality_Ensembles.
     constructor. constructor.
-    assert (Ensembles.Union (Domain m) (Complement (Domain m) Xext_union) Xext_union =
+    assert (Htmp: Ensembles.Union (Domain m) (Complement (Domain m) Xext_union) Xext_union =
             Full_set (Domain m)).
-    apply Same_set_to_eq; apply Union_Compl_Fullset. unfold Full. rewrite <- H2; clear H2.
-    unfold Included; unfold In; intros. inversion H2.
+    { apply Same_set_to_eq; apply Union_Compl_Fullset. }
+    unfold Full. rewrite <- Htmp; clear Htmp.
+    unfold Included; unfold In; intros x H2. inversion H2.
     - left; assumption.
-    - right; subst Xext_union; unfold In; unfold app_ext.
-      destruct H3 as [le [re [Hunion [Hre Happ]]]].
+    - right; subst; unfold In; unfold app_ext.
+      destruct H as [le [re [Hunion [Hre Happ]]]].
       inversion Hunion.
       left. unfold In; exists le; exists re; repeat split; assumption.
       right. unfold In; exists le; exists re; repeat split; assumption.
@@ -439,36 +468,39 @@ Proof.
     repeat rewrite -> pattern_interpretation_app_simpl, pattern_interpretation_imp_simpl.
     rewrite -> pattern_interpretation_app_simpl, pattern_interpretation_bott_simpl.
     simpl.
-    epose proof Union_Empty_l; eapply Same_set_to_eq in H2; unfold Semantics.Empty; rewrite -> H2; clear H2.
-    epose proof Union_Empty_l; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    pose proof Compl_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
-    pose proof Compl_Compl_Ensembles; eapply Same_set_to_eq in H2; rewrite -> H2; clear H2.
+    epose proof (Htmp := Union_Empty_l);
+      eapply Same_set_to_eq in Htmp; unfold Semantics.Empty; rewrite -> Htmp; clear Htmp.
+    epose proof (Htmp := Union_Empty_l);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
+    pose proof (Htmp := Compl_Compl_Ensembles);
+      eapply Same_set_to_eq in Htmp; rewrite -> Htmp; clear Htmp.
     remember (pattern_interpretation evar_val svar_val phi1) as Xphi1.
     remember (pattern_interpretation evar_val svar_val phi2) as Xphi2.
     remember (pattern_interpretation evar_val svar_val psi) as Xpsi.
     remember (app_ext Xpsi (Ensembles.Union (Domain m) Xphi1 Xphi2)) as Xext_union.
     apply Extensionality_Ensembles.
     constructor. constructor.
-    assert (Ensembles.Union (Domain m) (Complement (Domain m) Xext_union) Xext_union =
+    assert (Htmp: Ensembles.Union (Domain m) (Complement (Domain m) Xext_union) Xext_union =
             Full_set (Domain m)).
-    apply Same_set_to_eq; apply Union_Compl_Fullset. unfold Full. rewrite <- H2; clear H2.
-    unfold Included; unfold In; intros. inversion H2.
+    { apply Same_set_to_eq; apply Union_Compl_Fullset. }
+    unfold Full. rewrite <- Htmp; clear Htmp.
+    unfold Included; unfold In; intros x H2. inversion H2.
     - left; assumption.
-    - right; subst Xext_union; unfold In; unfold app_ext.
-      destruct H3 as [le [re [Hle [Hunion Happ]]]].
+    - right; subst; unfold In; unfold app_ext.
+      destruct H as [le [re [Hle [Hunion Happ]]]].
       inversion Hunion.
       left. unfold In; exists le; exists re; repeat split; assumption.
       right. unfold In; exists le; exists re; repeat split; assumption.
 
   (* Propagation exists - left *)
-  * intros Hv evar_val svar_val. 
-    apply (proof_rule_prop_ex_right_sound theory phi psi (evar_val)
-          (svar_val) Hwf H H0 Hv ).
+      * intros Hv evar_val svar_val.
+        eauto using proof_rule_prop_ex_right_sound.
 
   (* Propagation exists - right *)
-  * intros Hv evar_val svar_val. 
-    apply (proof_rule_prop_ex_left_sound theory phi psi (evar_val)
-          (svar_val) Hwf H H0 Hv).
+      * intros Hv evar_val svar_val.
+        eauto using proof_rule_prop_ex_left_sound.
 
   (* Framing - left *)
   * intros Hv evar_val svar_val. 
@@ -536,11 +568,10 @@ Proof.
     }
 
   (* Set Variable Substitution *)
-  * intros. epose proof (IHHp H Hv ) as IH.
-    unfold well_formed in H.
-    apply andb_true_iff in H. destruct H as [H1 H2].
-    eapply (proof_rule_set_var_subst_sound phi psi H2 H0 ) in IH.
-    exact IH.
+  * intros. epose proof (IHHp ltac:(auto) Hv ) as IH.
+    unfold well_formed in i.
+    apply andb_true_iff in i. destruct i as [H1 H2].
+    eauto using proof_rule_set_var_subst_sound.
 
   (* Pre-Fixpoint *)
   * intros Hv evar_val svar_val.

--- a/matching-logic/src/SignatureHelper.v
+++ b/matching-logic/src/SignatureHelper.v
@@ -9,8 +9,8 @@ Require Import extralibrary.
 
 From stdpp Require Import countable strings.
 
-Inductive evar_name_kind : Type := evar_c {id_ev : string}.
-Inductive svar_name_kind : Type := svar_c {id_sv : string}.
+Inductive evar_name_kind : Set := evar_c {id_ev : string}.
+Inductive svar_name_kind : Set := svar_c {id_sv : string}.
 
 Definition evar_name : Set := (evar_name_kind * Z)%type.
 Definition svar_name : Set := (svar_name_kind * Z)%type.
@@ -312,12 +312,12 @@ Next Obligation.
   intros. simpl in H. inversion H. reflexivity.
 Qed.
 
-Class SymbolsH (SHSymbols : Type) :=
+Class SymbolsH (SHSymbols : Set) :=
   { SHSymbols_eqdec : EqDecision SHSymbols; }.
 
 Section helper.
   Context
-    {SHSymbols : Type}
+    {SHSymbols : Set}
     {SHSymbols_h : SymbolsH SHSymbols}.
 
   Instance SignatureFromSymbols : Signature :=

--- a/matching-logic/src/Syntax.v
+++ b/matching-logic/src/Syntax.v
@@ -15,8 +15,8 @@ From stdpp Require Import pmap gmap mapset fin_sets.
 Require Import stdpp_ext.
 
 Class MLVariables := {
-  evar : Type;
-  svar : Type;
+  evar : Set;
+  svar : Set;
   evar_eqdec : EqDecision evar;
   evar_countable : Countable evar;
   svar_eqdec : EqDecision svar;
@@ -37,7 +37,7 @@ Class MLVariables := {
 
 Class Signature := {
   variables : MLVariables;
-  symbols : Type;
+  symbols : Set;
   sym_eq : EqDecision symbols;
 (*  sym_eq : forall (s1 s2 : symbols), {s1 = s2} + {s1 <> s2};*)
 }.
@@ -54,7 +54,7 @@ Section syntax.
   Context {signature : Signature}.
   Existing Instance variables.
 
-  Inductive Pattern : Type :=
+  Inductive Pattern : Set :=
   | patt_free_evar (x : evar)
   | patt_free_svar (x : svar)
   | patt_bound_evar (n : db_index)

--- a/matching-logic/src/Syntax.v
+++ b/matching-logic/src/Syntax.v
@@ -38,7 +38,8 @@ Class MLVariables := {
 Class Signature := {
   variables : MLVariables;
   symbols : Type;
-  sym_eq : forall (s1 s2 : symbols), {s1 = s2} + {s1 <> s2};
+  sym_eq : EqDecision symbols;
+(*  sym_eq : forall (s1 s2 : symbols), {s1 = s2} + {s1 <> s2};*)
 }.
 
 (* TODO move to some other file *)

--- a/matching-logic/src/Tests/TEST_LocallyNameless.v
+++ b/matching-logic/src/Tests/TEST_LocallyNameless.v
@@ -27,9 +27,9 @@ Module test_1.
     
   (* Example patterns *)
   
-  Definition a_symbol := sym ctor.
+  Definition a_symbol : Pattern := sym ctor.
   
-  Definition more := svar ("A") or ¬ (svar ("A") ). (* A \/ ~A *)
+  Definition more : Pattern := svar ("A") or ¬ (svar ("A") ). (* A \/ ~A *)
 
   Example e1 X: evar_open 0 X more = more.
   Proof. unfold more. autorewrite with ml_db. reflexivity. Qed.
@@ -84,7 +84,7 @@ Module test_2.
       * decide equality.
       * decide equality.
     Qed.
-    
+
     Instance symbols_H : SymbolsH Symbols := {| SHSymbols_eqdec := Symbols_eqdec; |}.
     Instance signature : Signature := @SignatureFromSymbols Symbols symbols_H.
     (* https://stackoverflow.com/a/44769124/6209703 *)
@@ -145,12 +145,12 @@ Module test_2.
       | _, _ => Empty_set domain
       end.
     
-    Let M1 : @Model signature :=
+    Let M1 : Model :=
       {| Domain := domain;
          nonempty_witness := dom_nat 0;
          Domain_eq_dec := domain_dec;
          (* for some reason, just using 'my_sym_interp' here results in a type error *)
-         sym_interp := fun s : @symbols signature => my_sym_interp s;
+         sym_interp := fun s : symbols => my_sym_interp s;
          (* But this works. interesting. *)
          app_interp := my_app_interp;
       |}.

--- a/prover/_CoqProject
+++ b/prover/_CoqProject
@@ -1,0 +1,11 @@
+-R theories MatchingLogicProver
+-I src
+
+theories/MLTauto.v
+theories/MMProofExtractorLoader.v
+theories/MMProofExtractor.v
+
+src/mmpf_main.ml
+src/mmpf_main.mli
+src/g_mmpf.mlg
+src/mmpf_plugin.mlpack

--- a/prover/mm/matching-logic.mm
+++ b/prover/mm/matching-logic.mm
@@ -444,3 +444,12 @@ ${
     proof-rule-singleton.3 $e #Substitution ph4 ph1 ( \and x ( \not ph2 ) ) yY $.
     proof-rule-singleton $a |- ( \not ( \and ph3 ph4 ) ) $.    
 $}
+
+$(  Our tests   $)
+
+$c symbol-a $.
+$c symbol-b $.
+
+symbol-a-is-pattern $a #Pattern symbol-a $.
+symbol-b-is-pattern $a #Pattern symbol-b $.
+ab-is-patterng $p #Pattern ( \app symbol-a symbol-b ) $= symbol-a-is-pattern symbol-b-is-pattern app-is-pattern $.

--- a/prover/mm/matching-logic.mm
+++ b/prover/mm/matching-logic.mm
@@ -453,3 +453,5 @@ $c symbol-b $.
 symbol-a-is-pattern $a #Pattern symbol-a $.
 symbol-b-is-pattern $a #Pattern symbol-b $.
 ab-is-patterng $p #Pattern ( \app symbol-a symbol-b ) $= symbol-a-is-pattern symbol-b-is-pattern app-is-pattern $.
+
+a-imp-b-imp-a $p |- ( \imp symbol-a ( \imp symbol-b symbol-a ) ) $= symbol-a-is-pattern symbol-b-is-pattern proof-rule-prop-1 $.

--- a/prover/nix/deps.nix
+++ b/prover/nix/deps.nix
@@ -33,4 +33,12 @@ let
       } ) { } ;
 
     metamath = pkgs.metamath;
-in { coq = ncoq; inherit equations; inherit metamath; inherit mllib; }
+    ocaml = coq.ocamlPackages.ocaml;
+    camlp5 = coq.ocamlPackages.camlp5;
+    findlib = ncoq.ocamlPackages.findlib;
+    zarith = ncoq.ocamlPackages.zarith;
+
+in { coq = ncoq; inherit equations; inherit metamath; inherit mllib;
+  inherit ocaml; inherit camlp5;
+  inherit findlib; inherit zarith;
+}

--- a/prover/shell.nix
+++ b/prover/shell.nix
@@ -7,7 +7,9 @@ let
   
   self = mkShell {
     name="matching-logic-interactive-prover";
-    buildInputs = [deps.coq deps.mllib deps.equations];
+    buildInputs = [deps.coq deps.mllib deps.equations deps.findlib deps.zarith
+      deps.ocaml deps.camlp5
+    ];
   };
 
 in

--- a/prover/shell.nix
+++ b/prover/shell.nix
@@ -8,7 +8,7 @@ let
   self = mkShell {
     name="matching-logic-interactive-prover";
     buildInputs = [deps.coq deps.mllib deps.equations deps.findlib deps.zarith
-      deps.ocaml deps.camlp5
+      deps.ocaml deps.camlp5 deps.metamath
     ];
   };
 

--- a/prover/src/g_mmpf.mlg
+++ b/prover/src/g_mmpf.mlg
@@ -1,0 +1,75 @@
+DECLARE PLUGIN "mmpf_plugin"
+
+{
+
+open Pp
+open Ltac_plugin
+
+let tuto_warn = CWarnings.create ~name:"name" ~category:"category"
+                            (fun _ -> strbrk Mmpf_main.message)
+
+}
+
+(*** Printing messages ***)
+
+(*
+ * This defines a command that prints HelloWorld.
+ * Note that Feedback.msg_notice can be used to print messages.
+ *)
+VERNAC COMMAND EXTEND HelloWorld CLASSIFIED AS QUERY
+| [ "HelloWorld" ] -> { Feedback.msg_notice (strbrk Mmpf_main.message) }
+END
+
+(*
+ * This is a tactic version of the same thing.
+ *)
+TACTIC EXTEND hello_world_tactic
+| [ "hello_world" ] ->
+  { let _ = Feedback.msg_notice (str Mmpf_main.message) in
+    Tacticals.New.tclIDTAC }
+END
+
+(*** Printing warnings ***)
+
+(*
+ * This defines a command that prints HelloWorld as a warning.
+ * tuto_warn is defined at the top-level, before the command runs,
+ * which is standard.
+ *)
+VERNAC COMMAND EXTEND HelloWarning CLASSIFIED AS QUERY
+| [ "HelloWarning" ] ->
+   {
+     tuto_warn ()
+   }
+END
+
+(*
+ * This is a tactic version of the same thing.
+ *)
+TACTIC EXTEND hello_warning_tactic
+| [ "hello_warning" ] ->
+   {
+     let _ = tuto_warn () in
+     Tacticals.New.tclIDTAC
+   }
+END
+
+(*** Printing errors ***)
+
+(*
+ * This defines a command that prints HelloWorld inside of an error.
+ * Note that CErrors.user_err can be used to raise errors to the user.
+ *)
+VERNAC COMMAND EXTEND HelloError CLASSIFIED AS QUERY
+| [ "HelloError" ] -> { CErrors.user_err (str Mmpf_main.message) }
+END
+
+(*
+ * This is a tactic version of the same thing.
+ *)
+TACTIC EXTEND hello_error_tactic
+| [ "hello_error" ] ->
+  { let _ = CErrors.user_err (str Mmpf_main.message) in
+    Tacticals.New.tclIDTAC }
+END
+

--- a/prover/src/g_mmpf.mlg
+++ b/prover/src/g_mmpf.mlg
@@ -46,8 +46,12 @@ VERNAC COMMAND EXTEND MmpfWriteProofObject CLASSIFIED AS SIDEFF
 | ["Write" "MetaMath" "Proof" "Object" "File" string(fname) constr(e)] -> {
      let env = Global.env () in
      let sigma = Evd.from_env env in
-     let s = Ppconstr.pr_constr_expr env sigma e in
-    mmpf_writeFile fname (strip_quotes (Pp.string_of_ppcmds s))
+     let (sigma, t) = Constrintern.interp_constr_evars env sigma e in
+     let e1 : Constr.constr = Reduction.whd_all env t in
+(*     let s = Ppconstr.pr_constr_expr env sigma e1 in *)
+(*      let s = Printer.pr_lconstr_env env sigma e1 in *)
+
+    mmpf_writeFile fname "HI" (* (strip_quotes "HI THERE" (* (Pp.string_of_ppcmds s)*))*)
   }
 END
 

--- a/prover/src/g_mmpf.mlg
+++ b/prover/src/g_mmpf.mlg
@@ -10,18 +10,18 @@ let tuto_warn = CWarnings.create ~name:"name" ~category:"category"
                             (fun _ -> strbrk Mmpf_main.message)
 
 let mmpf_write fmt =
-  Format.fprintf fmt "Hello proof objects!\n"
+  Printf.fprintf fmt "Hello proof objects!\n"
 
 let mmpf_writeFile fname =
   let oc = open_out fname in
-  mmpf_write (Format.formatter_of_out_channel oc);
+  mmpf_write oc;
   close_out oc
 
 }
 
 VERNAC COMMAND EXTEND MmpfWriteProofObject CLASSIFIED AS SIDEFF
-| ["Write" "MetaMath" "Proof" "Object" "File" string(str)] -> {
-    mmpf_writeFile str
+| ["Write" "MetaMath" "Proof" "Object" "File" string(fname)] -> {
+    mmpf_writeFile fname
   }
 END
 

--- a/prover/src/g_mmpf.mlg
+++ b/prover/src/g_mmpf.mlg
@@ -9,21 +9,89 @@ open Ltac_plugin
 let tuto_warn = CWarnings.create ~name:"name" ~category:"category"
                             (fun _ -> strbrk Mmpf_main.message)
 
-let mmpf_write fmt =
-  Printf.fprintf fmt "Hello proof objects!\n"
+let mmpf_write fmt s =
+  Printf.fprintf fmt "Hello proof objects: %s!\n" s
 
-let mmpf_writeFile fname =
+let mmpf_writeFile fname s =
   let oc = open_out fname in
-  mmpf_write oc;
+  mmpf_write oc s;
   close_out oc
+
+let print_input (a : 'a) (printer : 'a -> Pp.t) (type_str : string) : unit =
+  let msg = printer a ++ strbrk (Printf.sprintf " is a %s." type_str) in
+  Feedback.msg_notice msg
+
+
+let simple_body_access gref =
+  let open Names.GlobRef in
+  match gref with
+  | VarRef _ ->
+    failwith "variables are not covered in this example"
+  | IndRef _ ->
+    failwith "inductive types are not covered in this example"
+  | ConstructRef _ ->
+    failwith "constructors are not covered in this example"
+  | ConstRef cst ->
+    let cb = Environ.lookup_constant cst (Global.env()) in
+    match Global.body_of_constant_body Library.indirect_accessor cb with
+    | Some(e, _, _) -> EConstr.of_constr e
+    | None -> failwith "This term has no value"
+
+let strip_quotes (s : string) : string =
+  if (String.length s < 2) then s else (String.sub s 1 (String.length s - 2))
 
 }
 
 VERNAC COMMAND EXTEND MmpfWriteProofObject CLASSIFIED AS SIDEFF
-| ["Write" "MetaMath" "Proof" "Object" "File" string(fname)] -> {
-    mmpf_writeFile fname
+| ["Write" "MetaMath" "Proof" "Object" "File" string(fname) constr(e)] -> {
+     let env = Global.env () in
+     let sigma = Evd.from_env env in
+     let s = Ppconstr.pr_constr_expr env sigma e in
+    mmpf_writeFile fname (strip_quotes (Pp.string_of_ppcmds s))
   }
 END
+
+
+VERNAC COMMAND EXTEND WhatIsThis CLASSIFIED AS QUERY
+| [ "What's" constr(e) ] ->
+   {
+     let env = Global.env () in (* we'll explain later *)
+     let sigma = Evd.from_env env in (* we'll explain later *)
+     print_input e (Ppconstr.pr_constr_expr env sigma) "term"
+   }
+| [ "What" "kind" "of" "term" "is" string(s) ] ->
+   { print_input s strbrk "string" }
+| [ "What" "kind" "of" "term" "is" int(i) ] ->
+   { print_input i Pp.int "int" }
+| [ "What" "kind" "of" "term" "is" ident(id) ] ->
+   { print_input id Ppconstr.pr_id "identifier" }
+| [ "What" "kind" "of" "identifier" "is" reference(r) ] ->
+   { print_input r Ppconstr.pr_qualid "reference" }
+END
+
+VERNAC COMMAND EXTEND ExamplePrint2 CLASSIFIED AS QUERY
+| [ "PrintString" constr(e) ] ->
+   {
+     let env = Global.env () in
+     let sigma = Evd.from_env env in
+     let s = Ppconstr.pr_constr_expr env sigma e in
+     Feedback.msg_notice s
+   }
+END
+
+VERNAC COMMAND EXTEND ExamplePrint CLASSIFIED AS QUERY
+| [ "MyPrint" reference(r) ] ->
+   {
+     let env = Global.env () in
+     let sigma = Evd.from_env env in
+     try
+       let t = simple_body_access (Nametab.global r) in
+       Feedback.msg_notice (Printer.pr_econstr_env env sigma t)
+     with Failure s ->
+       CErrors.user_err (str s)
+   }
+END
+
 
 (*** Printing messages ***)
 

--- a/prover/src/g_mmpf.mlg
+++ b/prover/src/g_mmpf.mlg
@@ -10,7 +10,7 @@ let tuto_warn = CWarnings.create ~name:"name" ~category:"category"
                             (fun _ -> strbrk Mmpf_main.message)
 
 let mmpf_write fmt s =
-  Printf.fprintf fmt "Hello proof objects: %s!\n" s
+  Printf.fprintf fmt "Hello proof objects: ###%s###!\n" s
 
 let mmpf_writeFile fname s =
   let oc = open_out fname in
@@ -38,7 +38,7 @@ let simple_body_access gref =
     | None -> failwith "This term has no value"
 
 let strip_quotes (s : string) : string =
-  if (String.length s < 2) then s else (String.sub s 1 (String.length s - 2))
+  if (String.length s < 9) then s else (String.sub s 1 (String.length s - 9))
 
 }
 
@@ -47,11 +47,12 @@ VERNAC COMMAND EXTEND MmpfWriteProofObject CLASSIFIED AS SIDEFF
      let env = Global.env () in
      let sigma = Evd.from_env env in
      let (sigma, t) = Constrintern.interp_constr_evars env sigma e in
-     let e1 : Constr.constr = Reduction.whd_all env t in
+     let e1 : EConstr.constr = Reductionops.nf_all env sigma t in
+(*     let e1 : Constr.constr = Reduction.whd_all env t in *)
 (*     let s = Ppconstr.pr_constr_expr env sigma e1 in *)
-(*      let s = Printer.pr_lconstr_env env sigma e1 in *)
+      let s = Printer.pr_leconstr_env env sigma e1 in
 
-    mmpf_writeFile fname "HI" (* (strip_quotes "HI THERE" (* (Pp.string_of_ppcmds s)*))*)
+    mmpf_writeFile fname  (strip_quotes (Pp.string_of_ppcmds s))
   }
 END
 

--- a/prover/src/g_mmpf.mlg
+++ b/prover/src/g_mmpf.mlg
@@ -3,12 +3,27 @@ DECLARE PLUGIN "mmpf_plugin"
 {
 
 open Pp
+open Stdarg
 open Ltac_plugin
 
 let tuto_warn = CWarnings.create ~name:"name" ~category:"category"
                             (fun _ -> strbrk Mmpf_main.message)
 
+let mmpf_write fmt =
+  Format.fprintf fmt "Hello proof objects!\n"
+
+let mmpf_writeFile fname =
+  let oc = open_out fname in
+  mmpf_write (Format.formatter_of_out_channel oc);
+  close_out oc
+
 }
+
+VERNAC COMMAND EXTEND MmpfWriteProofObject CLASSIFIED AS SIDEFF
+| ["Write" "MetaMath" "Proof" "Object" "File" string(str)] -> {
+    mmpf_writeFile str
+  }
+END
 
 (*** Printing messages ***)
 

--- a/prover/src/g_mmpf.mlg
+++ b/prover/src/g_mmpf.mlg
@@ -2,40 +2,15 @@ DECLARE PLUGIN "mmpf_plugin"
 
 {
 
-open Pp
 open Stdarg
-open Ltac_plugin
-
-let tuto_warn = CWarnings.create ~name:"name" ~category:"category"
-                            (fun _ -> strbrk Mmpf_main.message)
 
 let mmpf_write fmt s =
-  Printf.fprintf fmt "Hello proof objects: ###%s###!\n" s
+  Printf.fprintf fmt "%s" s
 
 let mmpf_writeFile fname s =
   let oc = open_out fname in
   mmpf_write oc s;
   close_out oc
-
-let print_input (a : 'a) (printer : 'a -> Pp.t) (type_str : string) : unit =
-  let msg = printer a ++ strbrk (Printf.sprintf " is a %s." type_str) in
-  Feedback.msg_notice msg
-
-
-let simple_body_access gref =
-  let open Names.GlobRef in
-  match gref with
-  | VarRef _ ->
-    failwith "variables are not covered in this example"
-  | IndRef _ ->
-    failwith "inductive types are not covered in this example"
-  | ConstructRef _ ->
-    failwith "constructors are not covered in this example"
-  | ConstRef cst ->
-    let cb = Environ.lookup_constant cst (Global.env()) in
-    match Global.body_of_constant_body Library.indirect_accessor cb with
-    | Some(e, _, _) -> EConstr.of_constr e
-    | None -> failwith "This term has no value"
 
 let strip_quotes (s : string) : string =
   if (String.length s < 9) then s else (String.sub s 1 (String.length s - 9))
@@ -48,8 +23,6 @@ VERNAC COMMAND EXTEND MmpfWriteProofObject CLASSIFIED AS SIDEFF
      let sigma = Evd.from_env env in
      let (sigma, t) = Constrintern.interp_constr_evars env sigma e in
      let e1 : EConstr.constr = Reductionops.nf_all env sigma t in
-(*     let e1 : Constr.constr = Reduction.whd_all env t in *)
-(*     let s = Ppconstr.pr_constr_expr env sigma e1 in *)
       let s = Printer.pr_leconstr_env env sigma e1 in
 
     mmpf_writeFile fname  (strip_quotes (Pp.string_of_ppcmds s))
@@ -57,107 +30,4 @@ VERNAC COMMAND EXTEND MmpfWriteProofObject CLASSIFIED AS SIDEFF
 END
 
 
-VERNAC COMMAND EXTEND WhatIsThis CLASSIFIED AS QUERY
-| [ "What's" constr(e) ] ->
-   {
-     let env = Global.env () in (* we'll explain later *)
-     let sigma = Evd.from_env env in (* we'll explain later *)
-     print_input e (Ppconstr.pr_constr_expr env sigma) "term"
-   }
-| [ "What" "kind" "of" "term" "is" string(s) ] ->
-   { print_input s strbrk "string" }
-| [ "What" "kind" "of" "term" "is" int(i) ] ->
-   { print_input i Pp.int "int" }
-| [ "What" "kind" "of" "term" "is" ident(id) ] ->
-   { print_input id Ppconstr.pr_id "identifier" }
-| [ "What" "kind" "of" "identifier" "is" reference(r) ] ->
-   { print_input r Ppconstr.pr_qualid "reference" }
-END
-
-VERNAC COMMAND EXTEND ExamplePrint2 CLASSIFIED AS QUERY
-| [ "PrintString" constr(e) ] ->
-   {
-     let env = Global.env () in
-     let sigma = Evd.from_env env in
-     let s = Ppconstr.pr_constr_expr env sigma e in
-     Feedback.msg_notice s
-   }
-END
-
-VERNAC COMMAND EXTEND ExamplePrint CLASSIFIED AS QUERY
-| [ "MyPrint" reference(r) ] ->
-   {
-     let env = Global.env () in
-     let sigma = Evd.from_env env in
-     try
-       let t = simple_body_access (Nametab.global r) in
-       Feedback.msg_notice (Printer.pr_econstr_env env sigma t)
-     with Failure s ->
-       CErrors.user_err (str s)
-   }
-END
-
-
-(*** Printing messages ***)
-
-(*
- * This defines a command that prints HelloWorld.
- * Note that Feedback.msg_notice can be used to print messages.
- *)
-VERNAC COMMAND EXTEND HelloWorld CLASSIFIED AS QUERY
-| [ "HelloWorld" ] -> { Feedback.msg_notice (strbrk Mmpf_main.message) }
-END
-
-(*
- * This is a tactic version of the same thing.
- *)
-TACTIC EXTEND hello_world_tactic
-| [ "hello_world" ] ->
-  { let _ = Feedback.msg_notice (str Mmpf_main.message) in
-    Tacticals.New.tclIDTAC }
-END
-
-(*** Printing warnings ***)
-
-(*
- * This defines a command that prints HelloWorld as a warning.
- * tuto_warn is defined at the top-level, before the command runs,
- * which is standard.
- *)
-VERNAC COMMAND EXTEND HelloWarning CLASSIFIED AS QUERY
-| [ "HelloWarning" ] ->
-   {
-     tuto_warn ()
-   }
-END
-
-(*
- * This is a tactic version of the same thing.
- *)
-TACTIC EXTEND hello_warning_tactic
-| [ "hello_warning" ] ->
-   {
-     let _ = tuto_warn () in
-     Tacticals.New.tclIDTAC
-   }
-END
-
-(*** Printing errors ***)
-
-(*
- * This defines a command that prints HelloWorld inside of an error.
- * Note that CErrors.user_err can be used to raise errors to the user.
- *)
-VERNAC COMMAND EXTEND HelloError CLASSIFIED AS QUERY
-| [ "HelloError" ] -> { CErrors.user_err (str Mmpf_main.message) }
-END
-
-(*
- * This is a tactic version of the same thing.
- *)
-TACTIC EXTEND hello_error_tactic
-| [ "hello_error" ] ->
-  { let _ = CErrors.user_err (str Mmpf_main.message) in
-    Tacticals.New.tclIDTAC }
-END
 

--- a/prover/src/mmpf_main.ml
+++ b/prover/src/mmpf_main.ml
@@ -1,0 +1,1 @@
+let message = "Hello world!"

--- a/prover/src/mmpf_main.mli
+++ b/prover/src/mmpf_main.mli
@@ -1,0 +1,1 @@
+val message : string

--- a/prover/src/mmpf_plugin.mlpack
+++ b/prover/src/mmpf_plugin.mlpack
@@ -1,0 +1,2 @@
+Mmpf_main
+G_mmpf

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -57,36 +57,22 @@ End MetaMath.
 
 Import MetaMath.
 Section gen.
-  Print Signature.
-  Check Finite.
   Context
     {signature : Signature}
     {finiteSymbols : @Finite (@symbols signature) (@sym_eq signature) }
     (symbolPrinter : symbols -> string)
   .
 
-  Check enum.
-  Print enum.
-  Check (enum symbols).
-
-  Print  Signature.
-  Check map.
-  Check axs.
   Definition axiomForSymbol (s : symbols) : MetaMath.OutermostScopeStmt :=
     oss_s (stmt_assert_stmt (as_axiom (axs
-                                         (tc (constant (ms (symbolPrinter s))))
-                                         []
+                                         (tc (constant (ms (symbolPrinter s ++ "-is-pattern"))))
+                                         [(ms "#Pattern"); (ms (symbolPrinter s))]
           ))).
-Definition generateSymbolAxioms : Database :=
-  map () (enum symbols)
-    
-  
+
+  Definition generateSymbolAxioms : Database :=
+    map (axiomForSymbol) (@enum symbols (@sym_eq signature) finiteSymbols).
+ 
 End gen.
-
-
-
-
-
 
 
 Write MetaMath Proof Object File "myfile.mm".

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -77,7 +77,7 @@ End gen.
 What's "hi".
 PrintString "hello".
 
-Definition myMetamathProofObject : string := "Hi " ++ " " ++ "proof".
+Definition myMetamathProofObject : string := "Hi" ++ " " ++ "proof".
 
 Write MetaMath Proof Object File "myfile.mm" myMetamathProofObject.
 

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -332,6 +332,24 @@ Module MMTest.
     | c => "sym-c"
     end.
 
+  Definition ϕ₁ := patt_imp (patt_sym a) (patt_imp (patt_sym b) (patt_sym a)).
+
+  Lemma P1_holds:
+    ML_proof_system (Ensembles.Empty_set _) ϕ₁.
+  Proof.
+    apply P1; auto.
+  Qed.
+
+  Print ML_proof_system.
+  Check P1.
+  Fixpoint ϕ₁_proof_string (pf : ML_proof_system (Ensembles.Empty_set _) ϕ₁) : string :=
+    match pf as _ return string with
+    | P1 _ p q wfp wfq => "P1"%string
+    | _ => ""%string
+    end.
+  
+  
+  
   Definition P := (patt_and
                      (patt_or (patt_sym a) (patt_not (patt_sym a)))
                      (patt_or (patt_sym b) (patt_sym a))).

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -77,7 +77,7 @@ End gen.
 What's "hi".
 PrintString "hello".
 
-Write MetaMath Proof Object File "myfile.mm" "something".
+Write MetaMath Proof Object File "myfile.mm" (Compute ("something" ++ " else")).
 
 HelloWorld.
 

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -77,7 +77,9 @@ End gen.
 What's "hi".
 PrintString "hello".
 
-Write MetaMath Proof Object File "myfile.mm" (Compute ("something" ++ " else")).
+Definition myMetamathProofObject : string := "Hi " ++ " " ++ "proof".
+
+Write MetaMath Proof Object File "myfile.mm" myMetamathProofObject.
 
 HelloWorld.
 

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -74,8 +74,10 @@ Section gen.
  
 End gen.
 
+What's "hi".
+PrintString "hello".
 
-Write MetaMath Proof Object File "myfile.mm".
+Write MetaMath Proof Object File "myfile.mm" "something".
 
 HelloWorld.
 

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -1,4 +1,4 @@
-From Coq Require Import String.
+From Coq Require Import Strings.String.
 From stdpp Require Import base finite.
 From MatchingLogic Require Import Syntax ProofSystem.
 From MatchingLogicProver Require Import MMProofExtractorLoader.
@@ -17,18 +17,20 @@ Module MetaMath.
   Inductive DisjointStmt := ds (lv : list Variabl).
   Inductive TypeCode := tc (c : Constant).
 
-  Inductive FloatingStmt := fs (tc : TypeCode) (var : Variabl).
-  Inductive EssentialStmt := es (tc : TypeCode) (lms : list MathSymbol).
+  
+  Inductive Label := lbl (s : string).
+  
+  Inductive FloatingStmt := fs (l : Label) (tc : TypeCode) (var : Variabl).
+  Inductive EssentialStmt := es (l : Label) (tc : TypeCode) (lms : list MathSymbol).
   
   
   Inductive HypothesisStmt :=
   | hs_floating (fs : FloatingStmt)
-  | hs_esential (es : EssentialStmt)
+  | hs_essential (es : EssentialStmt)
   .
 
-  Inductive AxiomStmt := axs (tc : TypeCode) (lms : list MathSymbol).
+  Inductive AxiomStmt := axs (l : Label) (tc : TypeCode) (lms : list MathSymbol).
 
-  Inductive Label := lbl (s : string).
   Inductive MMProof := pf (ll : list Label).
   
   Inductive ProvableStmt := ps (tc : TypeCode) (lms : list MathSymbol) (pf : MMProof).
@@ -53,6 +55,139 @@ Module MetaMath.
   
   Definition Database := list OutermostScopeStmt.
 
+  (* Concrete syntax printing. *)
+  
+  Definition IncludeStmt_toString (x : IncludeStmt) :=
+    match x with
+    | include_stmt s => append "$[ " (append s " $]")
+    end.
+  
+
+  Definition MathSymbol_toString (x : MathSymbol) :=
+    match x with
+    | ms s => s
+    end.
+  
+  Definition Constant_toString (x : Constant) :=
+    match x with
+    | constant s => MathSymbol_toString s
+    end.
+
+  Definition ConstantStmt_toString (x : ConstantStmt) : string :=
+    match x with
+    | constant_stmt cs => append "$c" (append (foldr append " "%string (map Constant_toString cs)) "$.")
+    end.
+  
+  Definition Variabl_toString (x : Variabl) :=
+    match x with
+    | variable s => s
+    end.
+  
+  Definition VariableStmt_toString (x : VariableStmt) : string :=
+    match x with
+    | vs lv => append "$v" (append (foldr append " "%string (map Variabl_toString lv)) "$.")
+    end.
+  
+
+  Definition DisjointStmt_toString (x : DisjointStmt) : string :=
+    match x with
+    | ds lv => append "$d" (append (foldr append " "%string (map Variabl_toString lv)) "$.")
+    end.
+  
+  Definition TypeCode_toString (x : TypeCode) : string :=
+    match x with
+    | tc c => Constant_toString c
+    end.
+    
+  Definition Label_toString (x : Label) : string :=
+    match x with
+    | lbl s => s
+    end.
+  
+  
+  Definition FloatingStmt_toString (x : FloatingStmt) : string :=
+    match x with
+    | fs l t var => append
+                      (Label_toString l)
+                      (append
+                         "$f"
+                         (append
+                            (append (TypeCode_toString t) (Variabl_toString var))
+                            "$."
+                         )
+                      )
+    end.
+
+    Definition EssentialStmt_toString (x : EssentialStmt) : string :=
+    match x with
+    | es l t lms => append
+                      (Label_toString l)
+                      (append
+                         "$e"
+                         (append
+                            (append
+                               (TypeCode_toString t)
+                               (foldr append " "%string (map MathSymbol_toString lms))
+                            )
+                            "$."
+                         )
+                      )
+    end.
+
+    Definition HypothesisStmt_toString (x : HypothesisStmt) : string :=
+      match x with
+      | hs_floating f => FloatingStmt_toString f
+      | hs_essential e => EssentialStmt_toString e
+      end.
+    
+
+    
+    Definition AxiomStmt_toString (x : AxiomStmt) : string :=
+    match x with
+    | axs l t lms => append
+                      (Label_toString l)
+                      (append
+                         "$a"
+                         (append
+                            (append
+                               (TypeCode_toString t)
+                               (foldr append " "%string (map MathSymbol_toString lms))
+                            )
+                            "$."
+                         )
+                      )
+    end.
+
+    Definition MMProof_toString (x : MMProof) : string :=
+      match x with
+      | pf ll =>  foldr append " "%string (map Label_toString ll)
+      end.
+
+    
+    
+  Inductive ProvableStmt := ps (tc : TypeCode) (lms : list MathSymbol) (pf : MMProof).
+  
+  Inductive AssertStmt :=
+  | as_axiom (axs : AxiomStmt)
+  | as_provable (ps : ProvableStmt)
+  .
+  
+  Inductive Stmt :=
+  | stmt_block (ls : list Stmt)
+  | stmt_variable_stmt (vs : VariableStmt)
+  | stmt_disj_stmt (ds : DisjointStmt)
+  | stmt_hyp_stmt (hs : HypothesisStmt)
+  | stmt_assert_stmt (ass : AssertStmt).
+  
+  Inductive OutermostScopeStmt :=
+  | oss_inc (incs : IncludeStmt)
+  | oss_cs (cs : ConstantStmt)
+  | oss_s (st : Stmt)
+  .
+  
+  Definition Database := list OutermostScopeStmt.
+
+
 End MetaMath.
 
 Import MetaMath.
@@ -63,18 +198,53 @@ Section gen.
     (symbolPrinter : symbols -> string)
   .
 
-  Definition axiomForSymbol (s : symbols) : MetaMath.OutermostScopeStmt :=
+  Definition constantForSymbol (s : symbols) : OutermostScopeStmt :=
+    oss_cs (constant_stmt [constant (ms (symbolPrinter s))]).
+  
+  Definition axiomForSymbol (s : symbols) : OutermostScopeStmt :=
     oss_s (stmt_assert_stmt (as_axiom (axs
                                          (tc (constant (ms (symbolPrinter s ++ "-is-pattern"))))
                                          [(ms "#Pattern"); (ms (symbolPrinter s))]
           ))).
 
+  Definition constantAndAxiomForSymbol (s : symbols) : Database :=
+    [constantForSymbol s; axiomForSymbol s].
+  
   Definition generateSymbolAxioms : Database :=
     map (axiomForSymbol) (@enum symbols (@sym_eq signature) finiteSymbols).
- 
+ '
 End gen.
+
+
+Module MMTest.
+
+  Require Import MatchingLogic.SignatureHelper.
+  Import MetaMath.
+
+  Inductive Symbol := a | b | c .
+
+
+  Instance Symbol_eqdec : EqDecision Symbol.
+  Proof.
+    intros s1 s2. unfold Decision. decide equality.
+  Defined.
+
+  Instance Symbol_h : SymbolsH Symbol := Build_SymbolsH Symbol Symbol_eqdec.
+  
+  Instance signature : Signature := @SignatureFromSymbols Symbol _.
+
+  Definition symbolPrinter (s : Symbol) : string :=
+    match s with
+    | a => "a"
+    | b => "b"
+    | c => "c"
+    end.
+  
+  
+End MMTest.
+
+
 
 Definition myMetamathProofObject : string := "Hi" ++ " " ++ "proof".
 
 Write MetaMath Proof Object File "myfile.mm" myMetamathProofObject.
-

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -1,0 +1,10 @@
+From MatchingLogic Require Import Syntax ProofSystem.
+From MatchingLogicProver Require Import MMProofExtractorLoader.
+
+HelloWorld.
+
+Lemma test : True.
+Proof.
+hello_world.
+Abort.
+HelloWorld.

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -1,5 +1,66 @@
+From Coq Require Import String.
 From MatchingLogic Require Import Syntax ProofSystem.
 From MatchingLogicProver Require Import MMProofExtractorLoader.
+
+
+
+Module MetaMath.
+
+  Inductive IncludeStmt := include_stmt (s : string).
+
+  Inductive MathSymbol := ms (s : string).
+  Inductive Constant := constant (ms : MathSymbol).
+  Inductive ConstantStmt := constant_stmt (cs : list Constant).
+  Inductive Variabl := variable (s : string).
+  Inductive VariableStmt := vs (lv : list Variabl).
+  Inductive DisjointStmt := ds (lv : list Variabl).
+  Inductive TypeCode := tc (c : Constant).
+
+  Inductive FloatingStmt := fs (tc : TypeCode) (var : Variabl).
+  Inductive EssentialStmt := es (tc : TypeCode) (lms : list MathSymbol).
+  
+  
+  Inductive HypothesisStmt :=
+  | hs_floating (fs : FloatingStmt)
+  | hs_esential (es : EssentialStmt)
+  .
+
+  Inductive AxiomStmt := axs (tc : TypeCode) (lms : list MathSymbol).
+
+  Inductive Label := lbl (s : string).
+  Inductive MMProof := pf (ll : list Label).
+  
+  Inductive ProvableStmt := ps (tc : TypeCode) (lms : list MathSymbol) (pf : MMProof).
+  
+  Inductive AssertStmt :=
+  | as_axiom (axs : AxiomStmt)
+  | as_provable (ps : ProvableStmt)
+  .
+  
+  Inductive Stmt :=
+  | stmt_block (ls : list Stmt)
+  | stmt_variable_stmt (vs : VariableStmt)
+  | stmt_disj_stmt (ds : DisjointStmt)
+  | stmt_hyp_stmt (hs : HypothesisStmt)
+  | stmt_assert_stmt (ass : AssertStmt).
+  
+  Inductive OutermostScopeStmt :=
+  | oss_inc (incs : IncludeStmt)
+  | oss_cs (cs : ConstantStmt)
+  | oss_s (st : Stmt)
+  .
+  
+  Definition Database := list OutermostScopeStmt.
+
+End MetaMath.
+
+  
+
+
+
+
+
+
 
 Write MetaMath Proof Object File "myfile.mm".
 

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -33,7 +33,7 @@ Module MetaMath.
 
   Inductive MMProof := pf (ll : list Label).
   
-  Inductive ProvableStmt := ps (tc : TypeCode) (lms : list MathSymbol) (pf : MMProof).
+  Inductive ProvableStmt := ps (l : Label) (tc : TypeCode) (lms : list MathSymbol) (pf : MMProof).
   
   Inductive AssertStmt :=
   | as_axiom (axs : AxiomStmt)
@@ -163,29 +163,52 @@ Module MetaMath.
       | pf ll =>  foldr append " "%string (map Label_toString ll)
       end.
 
-    
-    
-  Inductive ProvableStmt := ps (tc : TypeCode) (lms : list MathSymbol) (pf : MMProof).
-  
-  Inductive AssertStmt :=
-  | as_axiom (axs : AxiomStmt)
-  | as_provable (ps : ProvableStmt)
-  .
-  
-  Inductive Stmt :=
-  | stmt_block (ls : list Stmt)
-  | stmt_variable_stmt (vs : VariableStmt)
-  | stmt_disj_stmt (ds : DisjointStmt)
-  | stmt_hyp_stmt (hs : HypothesisStmt)
-  | stmt_assert_stmt (ass : AssertStmt).
-  
-  Inductive OutermostScopeStmt :=
-  | oss_inc (incs : IncludeStmt)
-  | oss_cs (cs : ConstantStmt)
-  | oss_s (st : Stmt)
-  .
-  
-  Definition Database := list OutermostScopeStmt.
+    Definition ProvableStmt_toString (x : ProvableStmt) : string :=
+      match x with
+      | ps l t lms p
+        => append
+             (Label_toString l)
+             (append
+                "$p"
+                (append
+                   (append
+                      (TypeCode_toString t)
+                      (foldr append " "%string (map MathSymbol_toString lms))
+                   )
+                   (append "$=" (append (MMProof_toString p)  "$."))
+                )
+             )
+      end.
+
+    Definition AssertStmt_toString (x : AssertStmt) : string :=
+      match x with
+      | as_axiom a => AxiomStmt_toString a
+      | as_provable p => ProvableStmt_toString p
+      end.
+
+    Fixpoint Stmt_toString (x : Stmt) : string :=
+      match x with
+      | stmt_block l
+        => append "${"
+                  (append
+                     (foldr append " "%string (map Stmt_toString l))
+                     "$}")
+      | stmt_variable_stmt v => VariableStmt_toString v
+      | stmt_disj_stmt d => DisjointStmt_toString d
+      | stmt_hyp_stmt h => HypothesisStmt_toString h
+      | stmt_assert_stmt a => AssertStmt_toString a
+      end.
+
+    Definition OutermostScopeStmt_toString (x : OutermostScopeStmt) : string :=
+      match x with
+      | oss_inc i => IncludeStmt_toString i
+      | oss_cs c => ConstantStmt_toString c
+      | oss_s s => Stmt_toString s
+      end.
+
+    Definition Database_toString (x : Database) : string :=
+      foldr append "
+"%string (map OutermostScopeStmt_toString x).
 
 
 End MetaMath.

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -75,9 +75,12 @@ Module MetaMath.
     | constant s => MathSymbol_toString s
     end.
 
+  Definition appendWith between x y :=
+    append x (append between y).
+  
   Definition ConstantStmt_toString (x : ConstantStmt) : string :=
     match x with
-    | constant_stmt cs => append "$c " (append (foldr append " "%string (map Constant_toString cs)) " $.")
+    | constant_stmt cs => append "$c " (append (foldr (appendWith " "%string) ""%string (map Constant_toString cs)) " $.")
     end.
   
   Definition Variabl_toString (x : Variabl) :=
@@ -87,13 +90,13 @@ Module MetaMath.
   
   Definition VariableStmt_toString (x : VariableStmt) : string :=
     match x with
-    | vs lv => append "$v " (append (foldr append " "%string (map Variabl_toString lv)) " $.")
+    | vs lv => append "$v " (append (foldr (appendWith " "%string) ""%string (map Variabl_toString lv)) " $.")
     end.
   
 
   Definition DisjointStmt_toString (x : DisjointStmt) : string :=
     match x with
-    | ds lv => append "$d " (append (foldr append " "%string (map Variabl_toString lv)) " $.")
+    | ds lv => append "$d " (append (foldr (appendWith " "%string) ""%string (map Variabl_toString lv)) " $.")
     end.
   
   Definition TypeCode_toString (x : TypeCode) : string :=
@@ -127,9 +130,9 @@ Module MetaMath.
                       (append
                          " $e "
                          (append
-                            (append
+                            (appendWith " "
                                (TypeCode_toString t)
-                               (foldr append " "%string (map MathSymbol_toString lms))
+                               (foldr (appendWith " "%string) ""%string (map MathSymbol_toString lms))
                             )
                             " $."
                          )
@@ -151,9 +154,9 @@ Module MetaMath.
                       (append
                          " $a "
                          (append
-                            (append
+                            (appendWith " "
                                (TypeCode_toString t)
-                               (foldr append " "%string (map MathSymbol_toString lms))
+                               (foldr (appendWith " "%string) ""%string (map MathSymbol_toString lms))
                             )
                             " $."
                          )
@@ -162,7 +165,7 @@ Module MetaMath.
 
     Definition MMProof_toString (x : MMProof) : string :=
       match x with
-      | pf ll =>  foldr append " "%string (map Label_toString ll)
+      | pf ll =>  foldr (appendWith " "%string) ""%string (map Label_toString ll)
       end.
 
     Definition ProvableStmt_toString (x : ProvableStmt) : string :=
@@ -175,7 +178,7 @@ Module MetaMath.
                 (append
                    (append
                       (TypeCode_toString t)
-                      (foldr append " "%string (map MathSymbol_toString lms))
+                      (foldr (appendWith " "%string) ""%string (map MathSymbol_toString lms))
                    )
                    (append " $= " (append (MMProof_toString p)  " $."))
                 )
@@ -193,7 +196,7 @@ Module MetaMath.
       | stmt_block l
         => append "${ "
                   (append
-                     (foldr append " "%string (map Stmt_toString l))
+                     (foldr (appendWith " "%string) ""%string (map Stmt_toString l))
                      " $}")
       | stmt_variable_stmt v => VariableStmt_toString v
       | stmt_disj_stmt d => DisjointStmt_toString d
@@ -209,8 +212,9 @@ Module MetaMath.
       end.
 
     Definition Database_toString (x : Database) : string :=
-      foldr append "
- "%string (map OutermostScopeStmt_toString x).
+      foldr (appendWith "
+"%string) "
+"%string (map OutermostScopeStmt_toString x).
 
 
 End MetaMath.
@@ -226,7 +230,6 @@ Section gen.
   Definition constantForSymbol (s : symbols) : OutermostScopeStmt :=
     oss_cs (constant_stmt [constant (ms (symbolPrinter s))]).
 
-  Print Label.
   Definition axiomForSymbol (s : symbols) : OutermostScopeStmt :=
     oss_s (stmt_assert_stmt (as_axiom (axs
                                          (lbl (symbolPrinter s ++ "-is-pattern"))
@@ -262,15 +265,19 @@ Module MMTest.
 
   Definition symbolPrinter (s : Symbol) : string :=
     match s with
-    | a => "a"
-    | b => "b"
-    | c => "c"
+    | a => "sym-a"
+    | b => "sym-b"
+    | c => "sym-c"
     end.
 
+  (*
+  Compute ( (map OutermostScopeStmt_toString (constantAndAxiomForSymbol symbolPrinter a))).
+  Compute ( (constantAndAxiomForSymbol symbolPrinter a)).*)
   Compute (Database_toString (constantAndAxiomForSymbol symbolPrinter a)).
 
 
   Definition myMetamathProofObject : string := Database_toString (constantAndAxiomForSymbol symbolPrinter a).
+  (*Compute (myMetamathProofObject).*)
 
   Write MetaMath Proof Object File "myfile.mm" myMetamathProofObject.
 

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -1,6 +1,8 @@
 From MatchingLogic Require Import Syntax ProofSystem.
 From MatchingLogicProver Require Import MMProofExtractorLoader.
 
+Write MetaMath Proof Object File "myfile.mm".
+
 HelloWorld.
 
 Lemma test : True.

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -269,8 +269,37 @@ Section gen.
 
   Definition dependenciesForPattern (p : Pattern) : Database :=
     concat (map constantAndAxiomForSymbol (listset_nodup_car (symbols_of p))).
-  
-  
+
+  Print MathSymbol.
+  Fixpoint pattern2mm (p : Pattern) : list MathSymbol :=
+    match p with
+    | patt_sym s => [ms (symbolPrinter s)]
+    | patt_imp p1 p2 =>
+      let ms1 := pattern2mm p1 in
+      let ms2 := pattern2mm p2 in
+      [(ms "("); (ms "\imp")] ++ ms1 ++ ms2 ++ [ (ms ")")]
+    | patt_app p1 p2 =>
+      let ms1 := pattern2mm p1 in
+      let ms2 := pattern2mm p2 in
+      [(ms "("); (ms "\app")] ++ ms1 ++ ms2 ++ [ (ms ")")]
+    | _ => []
+    end.
+
+  Print Label.
+  Fixpoint pattern2proof (p : Pattern) : list Label :=
+    match p with
+    | patt_sym s => [(lbl (symbolPrinter s ++ "-is-pattern"))]
+    | patt_imp p1 p2 =>
+      let ms1 := pattern2proof p1 in
+      let ms2 := pattern2proof p2 in
+      ms1 ++ ms2 ++ [(lbl "imp-is-pattern")]
+    | patt_app p1 p2 =>
+      let ms1 := pattern2proof p1 in
+      let ms2 := pattern2proof p2 in
+      ms1 ++ ms2 ++ [(lbl "app-is-pattern")]
+    | _ => []
+    end.
+
   (*
   Definition generateSymbolAxioms : Database :=
     map (axiomForSymbol) (@enum symbols (@sym_eq signature) finiteSymbols).
@@ -306,6 +335,9 @@ Module MMTest.
   Definition P := (patt_and
                      (patt_or (patt_sym a) (patt_not (patt_sym a)))
                      (patt_or (patt_sym b) (patt_sym a))).
+
+  Compute (pattern2mm symbolPrinter (patt_imp (patt_sym a) (patt_sym b))).
+  Compute (pattern2proof symbolPrinter (patt_imp (patt_sym a) (patt_sym b))).
 
   Compute (dependenciesForPattern symbolPrinter P).
   Write MetaMath Proof Object File "myfile.mm" (Database_toString (dependenciesForPattern symbolPrinter P)).

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -1,4 +1,5 @@
 From Coq Require Import String.
+From stdpp Require Import base finite.
 From MatchingLogic Require Import Syntax ProofSystem.
 From MatchingLogicProver Require Import MMProofExtractorLoader.
 
@@ -54,7 +55,33 @@ Module MetaMath.
 
 End MetaMath.
 
+Import MetaMath.
+Section gen.
+  Print Signature.
+  Check Finite.
+  Context
+    {signature : Signature}
+    {finiteSymbols : @Finite (@symbols signature) (@sym_eq signature) }
+    (symbolPrinter : symbols -> string)
+  .
+
+  Check enum.
+  Print enum.
+  Check (enum symbols).
+
+  Print  Signature.
+  Check map.
+  Check axs.
+  Definition axiomForSymbol (s : symbols) : MetaMath.OutermostScopeStmt :=
+    oss_s (stmt_assert_stmt (as_axiom (axs
+                                         (tc (constant (ms (symbolPrinter s))))
+                                         []
+          ))).
+Definition generateSymbolAxioms : Database :=
+  map () (enum symbols)
+    
   
+End gen.
 
 
 

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -74,17 +74,7 @@ Section gen.
  
 End gen.
 
-What's "hi".
-PrintString "hello".
-
 Definition myMetamathProofObject : string := "Hi" ++ " " ++ "proof".
 
 Write MetaMath Proof Object File "myfile.mm" myMetamathProofObject.
 
-HelloWorld.
-
-Lemma test : True.
-Proof.
-hello_world.
-Abort.
-HelloWorld.

--- a/prover/theories/MMProofExtractorLoader.v
+++ b/prover/theories/MMProofExtractorLoader.v
@@ -1,0 +1,1 @@
+Declare ML Module "mmpf_plugin".


### PR DESCRIPTION
- Proof system is now in Set instead of Prop, so that we can examine its terms.
- Simple OCaml plugin for writing to a file
- Metamath abstract syntax; its pretty-printing
- Initial work on generating Metamath databases from formulas and their proofs.