### PR TITLE
Refactor Model

### DIFF
--- a/matching-logic/src/FixpointReasoning.v
+++ b/matching-logic/src/FixpointReasoning.v
@@ -888,6 +888,7 @@ Section with_signature.
       Qed.
       
       Section injective.
+        Hypothesis (Domain_eq_dec : EqDecision (Domain M)).
         Hypothesis (Hstep_total_function : @is_total_function _ M step witnessed_elements witnessed_elements ρₑ ρₛ).
         Hypothesis (Hstep_injective : @total_function_is_injective _ M step witnessed_elements ρₑ ρₛ).
 
@@ -910,7 +911,7 @@ Section with_signature.
           assert (Hmwit: m ∈ witnessed_elements).
           { exists l₁. apply Hw₁. }
 
-          assert (Hlcom:  ( @common_length _ (@Domain_eq_dec _ M) l₁ l₂ = length l₂)).
+          assert (Hlcom:  (common_length l₁ l₂ = length l₂)).
           {
             destruct Hw₁ as [[lst₁ [Hlst₁ Hbase₁]] [Hhd₁ Hfa₁]].
             destruct l₁ as [|m₁ l₁].

--- a/matching-logic/src/Semantics.v
+++ b/matching-logic/src/Semantics.v
@@ -26,14 +26,11 @@ Section semantics.
 
   Record Model := {
     Domain : Type;
-    (* TODO: think about whether or not to make it an existential formula. Because that would affect the equality,
-       due to proof irrelevance. We can also replace it by stdpp's Inhabited typeclass *)
-    nonempty_witness : Domain;
+    Domain_inhabited : Inhabited Domain;
     app_interp : Domain -> Domain -> Power Domain;
     sym_interp (sigma : symbols) : Power Domain;
   }.
 
-  
   Definition Empty {M : Model} : Power (Domain M) := @empty (Power (Domain M)) _.
   Definition Full {M : Model} : Power (Domain M) := @top (Power (Domain M)) _.
 
@@ -43,7 +40,7 @@ Section semantics.
   Proof.
     intros M S H.
     intros HContra. rewrite -> HContra in H.
-    assert (Hw1: (nonempty_witness M) ∈ Full).
+    assert (Hw1: (@inhabitant _ (Domain_inhabited M)) ∈ (@Full M)).
     { unfold Full. apply elem_of_top. exact I. }
     rewrite H in Hw1.
     unfold Empty in Hw1.
@@ -66,7 +63,7 @@ Section semantics.
   Proof.
     intros M S H HContra.
     rewrite -> HContra in H.
-    assert (Hw1: (nonempty_witness M) ∈ Full).
+    assert (Hw1: (@inhabitant _ (Domain_inhabited M)) ∈ Full).
     { unfold Full. apply elem_of_top. exact I. }
     rewrite <- H in Hw1.
     unfold Empty in Hw1.

--- a/matching-logic/src/Semantics.v
+++ b/matching-logic/src/Semantics.v
@@ -29,7 +29,6 @@ Section semantics.
     (* TODO: think about whether or not to make it an existential formula. Because that would affect the equality,
        due to proof irrelevance. We can also replace it by stdpp's Inhabited typeclass *)
     nonempty_witness : Domain;
-    Domain_eq_dec :> EqDecision Domain;
     app_interp : Domain -> Domain -> Power Domain;
     sym_interp (sigma : symbols) : Power Domain;
   }.

--- a/matching-logic/src/Tests/TEST_LocallyNameless.v
+++ b/matching-logic/src/Tests/TEST_LocallyNameless.v
@@ -124,6 +124,8 @@ Module test_2.
     | dom_nat (n:nat)
     | dom_custom (c:CustomElements)
     .    
+
+    Instance domain_inhabited : Inhabited domain := populate (dom_nat 0).
     
     Instance domain_eqdec : EqDecision domain.
     Proof. solve_decision. Defined.
@@ -145,10 +147,7 @@ Module test_2.
     
     Definition M1 : Model :=
       {| Domain := domain;
-         nonempty_witness := dom_nat 0;
-         (* for some reason, just using 'my_sym_interp' here results in a type error *)
-         sym_interp := fun s : symbols => my_sym_interp s;
-         (* But this works. interesting. *)
+         sym_interp := my_sym_interp;
          app_interp := my_app_interp;
       |}.
 


### PR DESCRIPTION
- Use the `Inhabited` type class to say that a model has nonempty domain
- No need for decidable equality on domain elements (in general; we still need it in `FixpointReasoning.v`)