### PR TITLE
Preparation for Deduction theorem

### DIFF
--- a/matching-logic/src/DerivedOperators.v
+++ b/matching-logic/src/DerivedOperators.v
@@ -442,7 +442,9 @@ Module Semantics.
           assert (Heqmm' : m = m').
           { 
             simpl in Hbound.
-            rewrite -> evar_open_bound_evar, -> Nat.eqb_refl, -> pattern_interpretation_free_evar_simpl in Hbound.
+            rewrite -> evar_open_bound_evar in Hbound.
+            case_match; try lia.
+            rewrite -> pattern_interpretation_free_evar_simpl in Hbound.
             apply elem_of_singleton in Hbound. subst m.
             rewrite update_evar_val_same. reflexivity.
           }
@@ -459,7 +461,9 @@ Module Semantics.
           exists m.
           rewrite -> pattern_interpretation_and_simpl. constructor.
           +
-            rewrite -> evar_open_bound_evar, -> Nat.eqb_refl, -> pattern_interpretation_free_evar_simpl.
+            rewrite -> evar_open_bound_evar.
+            case_match; try lia.
+            rewrite -> pattern_interpretation_free_evar_simpl.
             rewrite -> update_evar_val_same. constructor.
           + rewrite -> elem_of_PropSet in H.
             rewrite -> set_eq_subseteq in H. destruct H as [H1 H2].

--- a/matching-logic/src/Helpers/FOL_helpers.v
+++ b/matching-logic/src/Helpers/FOL_helpers.v
@@ -2966,6 +2966,8 @@ Section FOL_helpers.
 
 End FOL_helpers.
 
+(* TODO this should have a different name, and we should give the name [mgSplit] to a tactic
+  that works with our goals *)
 Ltac mgSplit := apply conj_intro_meta; auto.
 
 Section FOL_helpers.

--- a/matching-logic/src/Helpers/FOL_helpers.v
+++ b/matching-logic/src/Helpers/FOL_helpers.v
@@ -2367,11 +2367,12 @@ Section FOL_helpers.
   Lemma prf_equiv_congruence_implicative_ctx Γ p q C:
     well_formed p ->
     well_formed q ->
+    PC_wf C ->
     is_implicative_context C ->
     Γ ⊢ (p <---> q) ->
     Γ ⊢ (((emplace C p) <---> (emplace C q))).
   Proof.
-    intros wfp wfq impC Hiff.
+    intros wfp wfq wfC impC Hiff.
     destruct C.
     induction pcPattern; simpl; unfold is_implicative_context in impC; simpl in impC; inversion impC;
       unfold emplace; simpl.
@@ -2381,7 +2382,8 @@ Section FOL_helpers.
       + apply prf_conclusion; auto. unfold patt_iff. auto. apply pf_iff_equiv_refl. auto.*)
     - apply pf_iff_equiv_refl. auto.  (*apply prf_conclusion; auto unfold patt_iff. auto. apply pf_iff_equiv_refl. auto.*)
     - unfold emplace in *. simpl in *.
-      pose proof (pwf := pcPattern_wf).
+      pose proof (pwf := wfC).
+      unfold PC_wf in pwf.
       unfold well_formed,well_formed_closed in pwf. simpl in pwf.
       apply andb_prop in pwf. destruct pwf as [pwf1 pwf2].
       apply andb_prop in pwf1. destruct pwf1 as [pwfp1 pwfp2].
@@ -2399,7 +2401,7 @@ Section FOL_helpers.
         remember (free_evar_subst pcPattern2 q pcEvar) as q2.
         assert (pcOneOcc1 : count_evar_occurrences pcEvar pcPattern1 = 1).
         { lia. }
-        specialize (IHpcPattern1 ltac:(auto) ltac:(lia)).
+        specialize (IHpcPattern1 ltac:(auto) ltac:(auto)).
         unfold is_implicative_context in IHpcPattern1.
         simpl in IHpcPattern1.
         simpl in impC. rewrite andbT in impC.
@@ -2434,7 +2436,7 @@ Section FOL_helpers.
         remember (free_evar_subst pcPattern2 q pcEvar) as q2.
         assert (pcOneOcc1 : count_evar_occurrences pcEvar pcPattern2 = 1).
         { lia. }
-        specialize (IHpcPattern2 ltac:(auto) ltac:(lia)).
+        specialize (IHpcPattern2 ltac:(auto) ltac:(auto)).
         unfold is_implicative_context in IHpcPattern1.
         simpl in IHpcPattern1.
         simpl in impC. (*rewrite andbT in impC.*)

--- a/matching-logic/src/Helpers/FOL_helpers.v
+++ b/matching-logic/src/Helpers/FOL_helpers.v
@@ -3355,6 +3355,26 @@ Section FOL_helpers.
     Unshelve. all: unfold patt_and, patt_or, patt_not; auto 20.
   Defined.
 
+
+  Lemma universal_generalization Γ ϕ x:
+    well_formed ϕ ->
+    Γ ⊢ ϕ ->
+    Γ ⊢ patt_forall (evar_quantify x 0 ϕ).
+  Proof.
+    intros wfϕ Hϕ.
+    unfold patt_forall.
+    unfold patt_not at 1.
+    replace (! evar_quantify x 0 ϕ)
+      with (evar_quantify x 0 (! ϕ))
+      by reflexivity.
+    apply Ex_gen; auto.
+    2: { simpl. set_solver. }
+    toMyGoal. mgIntro. mgAdd Hϕ; auto.
+    mgApply' 1 10. mgExactn 0; auto.
+  Qed.
+  
+  
+  
 End FOL_helpers.
 
 (* Hints *)

--- a/matching-logic/src/Helpers/monotonic.v
+++ b/matching-logic/src/Helpers/monotonic.v
@@ -203,7 +203,7 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
       induction phi; try auto.
       - (* EVar bound *)
         intros. simpl. rewrite evar_open_bound_evar.
-        destruct (n =? n0).
+        case_match.
         * unfold respects_blacklist. intros.
           split; intros; constructor.
         * assumption.  

--- a/matching-logic/src/Semantics.v
+++ b/matching-logic/src/Semantics.v
@@ -64,11 +64,11 @@ Section semantics.
 
   Definition update_evar_val {m : Model} 
              (v : evar) (x : Domain m) (evar_val : @EVarVal m) : EVarVal :=
-    fun v' : evar => if decide (v = v') then x else evar_val v'.
+    fun v' : evar => if decide (v = v') is left _ then x else evar_val v'.
 
   Definition update_svar_val {m : Model}
              (v : svar) (X : Power (Domain m)) (svar_val : @SVarVal m)  : SVarVal :=
-    fun v' : svar => if decide (v = v') then X else svar_val v'.
+    fun v' : svar => if decide (v = v') is left _ then X else svar_val v'.
 
   Lemma update_svar_val_comm M :
     forall (X1 X2 : svar) (S1 S2 : Power (Domain M)) (svar_val : @SVarVal M),
@@ -1005,8 +1005,7 @@ Section semantics.
           destruct (decide (X = x)),(decide (Y = x)); simpl; try contradiction.
           reflexivity.
         + rewrite 2!pattern_interpretation_bound_evar_simpl. reflexivity.
-        + unfold svar_open. simpl. case (compare_nat n dbi); intro H.
-          * now rewrite 2!pattern_interpretation_bound_svar_simpl.
+        + unfold svar_open. simpl. case_match.
           * rewrite 2!pattern_interpretation_free_svar_simpl.
             rewrite 2!update_svar_val_same. reflexivity.
           * rewrite 2!pattern_interpretation_bound_svar_simpl.
@@ -1029,8 +1028,7 @@ Section semantics.
           reflexivity.
         + rewrite 2!pattern_interpretation_free_svar_simpl.
           reflexivity.
-        + unfold evar_open. simpl. case (compare_nat n dbi); intro H.
-          * now rewrite 2!pattern_interpretation_bound_evar_simpl.
+        + unfold evar_open. simpl. case_match.
           * rewrite 2!pattern_interpretation_free_evar_simpl.
             rewrite 2!update_evar_val_same. reflexivity.
           * rewrite 2!pattern_interpretation_bound_evar_simpl.
@@ -1312,8 +1310,7 @@ Section semantics.
         rewrite 2!pattern_interpretation_bound_evar_simpl.
         reflexivity.
       + (* bound_svar *)
-        unfold svar_open. simpl. destruct (compare_nat n dbi) eqn:Heq; simpl.
-        * repeat rewrite -> pattern_interpretation_bound_svar_simpl; auto.
+        unfold svar_open. simpl.  case_match; simpl.
         * rewrite pattern_interpretation_free_svar_simpl. unfold update_svar_val.
           destruct (decide (X = X)). auto. contradiction.
         * repeat rewrite -> pattern_interpretation_bound_svar_simpl; auto.
@@ -1344,8 +1341,7 @@ Section semantics.
       + (* bound_evar *)
         rewrite !pattern_interpretation_bound_evar_simpl. reflexivity.
       + (* bound_svar *)
-        unfold svar_open. simpl. destruct (compare_nat n dbi).
-        * repeat rewrite -> pattern_interpretation_bound_svar_simpl; auto.
+        unfold svar_open. simpl. case_match.
         * rewrite pattern_interpretation_free_svar_simpl. unfold update_svar_val.
           destruct (decide (X = X)). simpl. auto. contradiction.
         * repeat rewrite -> pattern_interpretation_bound_svar_simpl; auto.
@@ -1660,14 +1656,10 @@ Section semantics.
         auto.
       + (* bound_evar *)
         rewrite evar_open_bound_evar.
-        destruct (n =? dbi) eqn:Heq, (compare_nat n dbi).
-        * symmetry in Heq; apply beq_nat_eq in Heq. lia.
+        case_match; subst.
         * do 2 rewrite pattern_interpretation_free_evar_simpl.
           unfold update_evar_val.
-          destruct (decide (x = x)). auto. contradiction.
-        * symmetry in Heq; apply beq_nat_eq in Heq. lia.
-        * auto.
-        * apply beq_nat_false in Heq. lia.
+          case_match; auto. contradiction.
         * auto.
       + (* bound_svar *)
         rewrite 2!pattern_interpretation_bound_svar_simpl; auto.
@@ -1699,13 +1691,9 @@ Section semantics.
         auto.
       + (* bound_evar *)
         rewrite evar_open_bound_evar.
-        destruct (n =? dbi) eqn:Heq, (compare_nat n dbi).
-        * symmetry in Heq; apply beq_nat_eq in Heq. lia.
+        case_match.
         * repeat rewrite pattern_interpretation_free_evar_simpl. unfold update_evar_val.
           destruct (decide (x = x)). auto. contradiction.
-        * symmetry in Heq; apply beq_nat_eq in Heq. lia.
-        * auto.
-        * apply beq_nat_false in Heq. lia.
         * auto.
       + (* bound_svar *)
         rewrite 2!pattern_interpretation_bound_svar_simpl; auto.
@@ -2014,11 +2002,9 @@ Section semantics.
       apply pattern_interpretation_free_evar_independent.
       unfold evar_is_fresh_in in Hfr. apply Hfr.
       rewrite evar_open_bound_evar.
-      destruct (Nat.leb_spec0 dbi n).
-      + destruct (eqb_reflect (S n) dbi); try lia.
-        rewrite 2!pattern_interpretation_bound_evar_simpl. reflexivity.
-      + destruct (eqb_reflect n dbi); try lia.
-        rewrite 2!pattern_interpretation_bound_evar_simpl. reflexivity.
+      repeat case_match; try lia.
+      + rewrite 2!pattern_interpretation_bound_evar_simpl. reflexivity.
+      + rewrite 2!pattern_interpretation_bound_evar_simpl. reflexivity.
     - pose proof (Hnot0 := not_bevar_occur_0_nest_ex ϕ).
       destruct ϕ; simpl; move=> Hsz Hfr; try reflexivity.
       rewrite evar_open_free_evar.
@@ -2026,11 +2012,9 @@ Section semantics.
         apply pattern_interpretation_free_evar_independent.
         unfold evar_is_fresh_in in Hfr. apply Hfr.
       + rewrite evar_open_bound_evar.
-        destruct (Nat.leb_spec0 dbi n).
-        * destruct (eqb_reflect (S n) dbi); try lia.
-          rewrite 2!pattern_interpretation_bound_evar_simpl. reflexivity.
-        * destruct (eqb_reflect n dbi); try lia.
-          rewrite 2!pattern_interpretation_bound_evar_simpl. reflexivity.        
+        repeat case_match; try lia.
+        * rewrite 2!pattern_interpretation_bound_evar_simpl. reflexivity.
+        * rewrite 2!pattern_interpretation_bound_evar_simpl. reflexivity.
       + simpl in Hnot0.
         apply orb_false_iff in Hnot0. destruct Hnot0 as [Hnot1 Hnot2].
         rewrite 2!pattern_interpretation_app_simpl.
@@ -2137,12 +2121,12 @@ Section semantics.
       rewrite svar_open_free_svar.
       apply pattern_interpretation_free_svar_independent.
       unfold evar_is_fresh_in in Hfr. apply Hfr.
-      destruct (Nat.leb_spec0 dbi n).
+      case_match.
       + rewrite svar_open_bound_svar.
-        destruct (eqb_reflect (Datatypes.S n) dbi); try lia. simpl.
+        case_match; try lia. simpl.
         rewrite 2!pattern_interpretation_bound_svar_simpl. reflexivity.
       + rewrite svar_open_bound_svar.
-        destruct (eqb_reflect n dbi); try lia.
+        case_match; try lia.
         rewrite 2!pattern_interpretation_bound_svar_simpl. reflexivity.
     - pose proof (Hnot0 := not_bsvar_occur_0_nest_mu ϕ).
       destruct ϕ; simpl; move=> Hsz Hfr; try reflexivity.
@@ -2150,11 +2134,9 @@ Section semantics.
         apply pattern_interpretation_free_svar_independent.
         unfold evar_is_fresh_in in Hfr. apply Hfr.
       + rewrite svar_open_bound_svar.
-        destruct (Nat.leb_spec0 dbi n).
-        * destruct (eqb_reflect (Datatypes.S n) dbi); try lia.
-          rewrite 2!pattern_interpretation_bound_svar_simpl. reflexivity.
-        * destruct (eqb_reflect n dbi); try lia.
-          rewrite 2!pattern_interpretation_bound_svar_simpl. reflexivity.
+        repeat case_match; try lia.
+        * rewrite 2!pattern_interpretation_bound_svar_simpl. reflexivity.
+        * rewrite 2!pattern_interpretation_bound_svar_simpl. reflexivity.
       + simpl in Hnot0.
         apply orb_false_iff in Hnot0. destruct Hnot0 as [Hnot1 Hnot2].
         rewrite 2!pattern_interpretation_app_simpl.

--- a/matching-logic/src/Syntax.v
+++ b/matching-logic/src/Syntax.v
@@ -4894,6 +4894,108 @@ Proof.
     + simpl. set_solver.
 Qed.
 
+Lemma free_evar_subst_subst_ctx_independent {Σ : Signature} AC ϕ Xfr1 Xfr2:
+  Xfr1 ∉ free_evars_ctx AC ->
+  Xfr2 ∉ free_evars_ctx AC ->
+  free_evar_subst (subst_ctx AC (patt_free_evar Xfr1)) ϕ Xfr1 =
+  free_evar_subst (subst_ctx AC (patt_free_evar Xfr2)) ϕ Xfr2.
+Proof.
+  intros HXfr1 HXfr2.
+  induction AC.
+  - simpl.
+    destruct (decide (Xfr1 = Xfr1)), (decide (Xfr2 = Xfr2)); simpl; try contradiction.
+    reflexivity.
+  - simpl in HXfr1. simpl in HXfr2.
+    feed specialize IHAC.
+    { set_solver. }
+    { set_solver. }
+    simpl. rewrite IHAC.
+    rewrite [free_evar_subst p ϕ Xfr1]free_evar_subst_no_occurrence.
+    { apply count_evar_occurrences_0. set_solver. }
+    rewrite [free_evar_subst p ϕ Xfr2]free_evar_subst_no_occurrence.
+    { apply count_evar_occurrences_0. set_solver. }
+    reflexivity.
+  - simpl in HXfr1. simpl in HXfr2.
+    feed specialize IHAC.
+    { set_solver. }
+    { set_solver. }
+    simpl. rewrite IHAC.
+    rewrite [free_evar_subst p ϕ Xfr1]free_evar_subst_no_occurrence.
+    { apply count_evar_occurrences_0. set_solver. }
+    rewrite [free_evar_subst p ϕ Xfr2]free_evar_subst_no_occurrence.
+    { apply count_evar_occurrences_0. set_solver. }
+    reflexivity.
+Qed.
+
+
+Lemma emplace_subst_ctx {Σ : Signature} AC ϕ:
+  emplace (ApplicationContext2PatternCtx AC) ϕ = subst_ctx AC ϕ.
+Proof.
+  induction AC.
+  - unfold ApplicationContext2PatternCtx,ApplicationContext2PatternCtx'.
+    unfold emplace. simpl.
+    destruct (decide (_ = _)); simpl.
+    + reflexivity.
+    + contradiction.
+  - simpl.
+    rewrite -IHAC.
+    unfold ApplicationContext2PatternCtx,ApplicationContext2PatternCtx'.
+    simpl.
+    unfold emplace. simpl.
+    unfold ApplicationContext2Pattern.
+    f_equal.
+    2: {
+      rewrite free_evar_subst_no_occurrence.
+      2: { reflexivity. }
+      apply count_evar_occurrences_0.
+      eapply evar_is_fresh_in_richer'.
+      2: { apply set_evar_fresh_is_fresh'. }
+      clear. set_solver.
+    }
+    remember (evar_fresh (elements (free_evars_ctx AC ∪ free_evars p))) as Xfr1.
+    remember (evar_fresh (elements (free_evars_ctx AC))) as Xfr2.
+    apply free_evar_subst_subst_ctx_independent.
+    { subst.
+      eapply not_elem_of_larger_impl_not_elem_of.
+      2: { apply set_evar_fresh_is_fresh'. }
+      clear. set_solver.
+    }
+    { subst.
+      eapply not_elem_of_larger_impl_not_elem_of.
+      2: { apply set_evar_fresh_is_fresh'. }
+      clear. set_solver.
+    }    
+  - simpl.
+    rewrite -IHAC.
+    unfold ApplicationContext2PatternCtx,ApplicationContext2PatternCtx'.
+    simpl.
+    unfold emplace. simpl.
+    unfold ApplicationContext2Pattern.
+    f_equal.
+    {
+      rewrite free_evar_subst_no_occurrence.
+      2: { reflexivity. }
+      apply count_evar_occurrences_0.
+      eapply evar_is_fresh_in_richer'.
+      2: { apply set_evar_fresh_is_fresh'. }
+      clear. set_solver.
+    }
+    remember (evar_fresh (elements (free_evars_ctx AC ∪ free_evars p))) as Xfr1.
+    remember (evar_fresh (elements (free_evars_ctx AC))) as Xfr2.
+    apply free_evar_subst_subst_ctx_independent.
+    { subst.
+      eapply not_elem_of_larger_impl_not_elem_of.
+      2: { apply set_evar_fresh_is_fresh'. }
+      clear. set_solver.
+    }
+    { subst.
+      eapply not_elem_of_larger_impl_not_elem_of.
+      2: { apply set_evar_fresh_is_fresh'. }
+      clear. set_solver.
+    }
+Qed.
+
+
 Lemma evar_quantify_subst_ctx {Σ : Signature} x n AC ϕ:
   x ∉ AC_free_evars AC ->
   evar_quantify x n (subst_ctx AC ϕ) = subst_ctx AC (evar_quantify x n ϕ).

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -686,8 +686,7 @@ Section definedness.
       solve_free_evars_inclusion 5.
     }
     do 3 rewrite evar_open_bound_evar.
-    repeat rewrite Nat.eqb_refl.
-    rewrite [(if 0 =? 1 then patt_free_evar x else b0)]/=.
+    repeat case_match; try lia.
 
     remember (fresh_evar (patt_in (patt_free_evar x) (evar_open 1 x (nest_ex (nest_ex ϕ₂)) $ b0))) as y.
     rewrite simpl_evar_open.

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -61,6 +61,9 @@ Section definedness.
 
   Definition patt_in (phi1 phi2 : Pattern) : Pattern :=
     patt_defined (patt_and phi1 phi2).
+
+  Definition AC_patt_defined : Application_context :=
+    @ctx_app_r _ (patt_sym (inj definedness)) box ltac:(auto).
   
 End definedness.
 
@@ -787,14 +790,34 @@ Section definedness.
     constructor.
   Qed.
 
-  Section ProofSystemTheorems.
+End definedness.
   
-    Import ProofSystem Helpers.FOL_helpers.
-    Notation "theory ⊢ pattern" := (@ML_proof_system Σ theory pattern) (at level 95, no associativity).
+#[export]
+ Hint Resolve well_formed_defined : core.
+#[export]
+ Hint Resolve well_formed_total : core.
+#[export]
+ Hint Resolve well_formed_equal : core.
+#[export]
+ Hint Resolve well_formed_subseteq : core.
+#[export]
+ Hint Resolve well_formed_in : core.
 
-    Lemma patt_iff_implies_equal :
+
+Section ProofSystemTheorems.
+
+  Context
+    {Σ : Signature}
+    {syntax : Syntax}
+  .
+
+  
+  Import ProofSystem Helpers.FOL_helpers.
+  Notation "theory ⊢ pattern" := (@ML_proof_system Σ theory pattern) (at level 95, no associativity).
+
+  Lemma patt_iff_implies_equal :
     forall (φ1 φ2 : Pattern) Γ, well_formed φ1 -> well_formed φ2 ->
-    Γ ⊢ (φ1 <---> φ2) -> Γ ⊢ φ1 =ml φ2.
+                                Γ ⊢ (φ1 <---> φ2) -> Γ ⊢ φ1 =ml φ2.
   Proof.
     intros φ1 φ2 Γ WF1 WF2 H.
     epose proof (ANNA := A_implies_not_not_A_ctx Γ (φ1 <---> φ2) (ctx_app_r box _)). 
@@ -805,329 +828,399 @@ Section definedness.
 
   Lemma patt_equal_refl :
     forall φ Γ, well_formed φ ->
-    Γ ⊢ φ =ml φ.
+                Γ ⊢ φ =ml φ.
   Proof.
     intros φ Γ WF. pose proof (IFF := pf_iff_equiv_refl Γ φ WF).
     apply patt_iff_implies_equal in IFF; auto.
   Qed.
 
-
-
-  
-  Fixpoint uses_existential_generalization Γ ϕ (pf : Γ ⊢ ϕ) :=
-    match pf with
-    | hypothesis _ _ _ _ => false
-    | P1 _ _ _ _ _ => false
-    | P2 _ _ _ _ _ _ _ => false
-    | P3 _ _ _ => false
-    | Modus_ponens _ _ _ _ _ m0 m1
-      => uses_existential_generalization m0
-         || uses_existential_generalization m1
-    | Ex_quan _ _ _ => false
-    | Ex_gen _ _ _ _ _ _ _ _ => true
-    | Prop_bott_left _ _ _ => false
-    | Prop_bott_right _ _ _ => false
-    | Prop_disj_left _ _ _ _ _ _ _ => false
-    | Prop_disj_right _ _ _ _ _ _ _ => false
-    | Prop_ex_left _ _ _ _ _ => false
-    | Prop_ex_right _ _ _ _ _ => false
-    | Framing_left _ _ _ _ m0 => uses_existential_generalization m0
-    | Framing_right _ _ _ _ m0 => uses_existential_generalization m0
-    | Svar_subst _ _ _ _ _ _ m0 => uses_existential_generalization m0
-    | Pre_fixp _ _ => false
-    | Knaster_tarski _ phi psi m0 => uses_existential_generalization m0
-    | Existence _ => false
-    | Singleton_ctx _ _ _ _ _ => false
-    end.
-
-  Fixpoint uses_svar_subst Γ ϕ (pf : Γ ⊢ ϕ) :=
-    match pf with
-    | hypothesis _ _ _ _ => false
-    | P1 _ _ _ _ _ => false
-    | P2 _ _ _ _ _ _ _ => false
-    | P3 _ _ _ => false
-    | Modus_ponens _ _ _ _ _ m0 m1
-      => uses_svar_subst m0
-         || uses_svar_subst m1
-    | Ex_quan _ _ _ => false
-    | Ex_gen _ _ _ _ _ _ pf' _ => uses_svar_subst pf'
-    | Prop_bott_left _ _ _ => false
-    | Prop_bott_right _ _ _ => false
-    | Prop_disj_left _ _ _ _ _ _ _ => false
-    | Prop_disj_right _ _ _ _ _ _ _ => false
-    | Prop_ex_left _ _ _ _ _ => false
-    | Prop_ex_right _ _ _ _ _ => false
-    | Framing_left _ _ _ _ m0 => uses_svar_subst m0
-    | Framing_right _ _ _ _ m0 => uses_svar_subst m0
-    | Svar_subst _ _ _ _ _ _ m0 => true
-    | Pre_fixp _ _ => false
-    | Knaster_tarski _ phi psi m0 => uses_svar_subst m0
-    | Existence _ => false
-    | Singleton_ctx _ _ _ _ _ => false
-    end.
-
-
-
-  Theorem deduction_theorem_general Γ ϕ ψ (pf : Γ ∪ {[ ψ ]} ⊢ ϕ) :
-      Γ ⊢ ⌊ ψ ⌋ ---> ϕ.
+  Lemma use_defined_axiom Γ:
+    theory ⊆ Γ ->
+    Γ ⊢ patt_defined p_x.
   Proof.
+    intros HΓ.
+    apply hypothesis; auto. unfold theory,theory_of_NamedAxioms in HΓ. simpl in HΓ.
+    eapply elem_of_weaken.
+    2: { apply HΓ. }
+    unfold axiom.
+    apply elem_of_PropSet.
+    exists AxDefinedness.
+    reflexivity.
+  Qed.
+  
+    
+  Lemma in_context_impl_defined Γ AC ϕ:
+    theory ⊆ Γ ->
+    well_formed ϕ ->
+    Γ ⊢ (subst_ctx AC ϕ) ---> ⌈ ϕ ⌉.
+  Proof.
+    intros HΓ Hwfϕ.
+    assert(S1: Γ ⊢ patt_defined p_x) by (auto using use_defined_axiom).
 
+    assert(S2: Γ ⊢ ⌈ p_x ⌉ or ⌈ ϕ ⌉).
+    {
+      toMyGoal. mgLeft; auto.
+    }
+
+    assert(S3: Γ ⊢ ⌈ p_x or ϕ ⌉).
+    {
+      pose proof (Htmp := (prf_prop_or_iff Γ AC_patt_defined) p_x ϕ ltac:(auto) ltac:(auto)).
+      simpl in Htmp.
+      (*Search (?G ⊢ ?L and ?R). (* Why this does not find pf_conj_elim_r_meta ? *) *)
+      apply pf_conj_elim_r_meta in Htmp; auto.
+      eapply Modus_ponens. 4: apply Htmp.
+      all: auto.
+    }
+
+    assert(S4: Γ ⊢ ⌈ (p_x and (! ϕ)) or ϕ  ⌉).
+    {
+      assert(Htmp1: Γ ⊢ (p_x or ϕ) ---> (p_x and ! ϕ or ϕ)).
+      {
+        toMyGoal. mgIntro.
+        (* Search (?G ⊢ ?q). (* Maybe Search does not work because we use a separate notation... *)*)
+        mgAdd (A_or_notA Γ ϕ Hwfϕ); auto.
+        mgDestruct 0; auto.
+        - mgRight; auto. mgExactn 0.
+        - mgLeft; auto. mgIntro.
+          mgDestruct 1; auto.
+          + mgDestruct 2; auto.
+            * mgApply' 2 10. mgExactn 1; auto 10.
+            * mgApply' 2 10. mgExactn 0; auto 10.
+          + mgApply' 0 10.
+            mgExactn 1; auto 10.
+      }
+      
+      
+      assert(Htmp2: Γ ⊢ (⌈ p_x or ϕ ⌉) ---> (⌈ p_x and ! ϕ or ϕ ⌉)).
+      {
+        apply Framing_right. apply Htmp1.
+      }
+      
+      eapply Modus_ponens.
+      4: apply Htmp2.
+      all: auto 10.
+    }
+    
+    
   Abort.
   
-  Theorem deduction_theorem :
-    forall φ ψ Γ, (* psi closed *)
-      Γ ∪ {[ ψ ]} ⊢ φ ->
-      Γ ⊢ ⌊ ψ ⌋ ---> φ.
-  Proof.
-  
-  Admitted.
-
-  Theorem reverse_deduction_theorem :
-    forall φ ψ Γ,
-      Γ ⊢ ⌊ ψ ⌋ ---> φ ->
-      Γ ∪ {[ ψ ]} ⊢ φ.
-  Proof.
-  
-  Admitted.
-
-  Lemma equality_elimination Γ φ1 φ2 C :
-    well_formed φ1 -> well_formed φ2 ->
-    wf_PatCtx C ->
-    Γ ⊢ (φ1 =ml φ2) ---> (* somewhere "and" is here, somewhere meta-implication *)
-       (subst_patctx C φ1) ---> (subst_patctx C φ2).
-  Proof.
-    intros WF1 WF2 WFC. apply deduction_theorem.
-    remember (Γ ∪ {[ (φ1 <---> φ2) ]}) as Γ'.
-    assert (Γ' ⊢ (φ1 <---> φ2)). {
-      apply hypothesis. now apply well_formed_iff.
-      rewrite HeqΓ'. apply elem_of_union_r. constructor.
-    }
-    apply congruence_iff with (C0 := C) in H; auto.
-    apply pf_iff_proj1 in H; auto.
-    1-2: now apply subst_patctx_wf.
-  Qed.
-
-  Lemma equality_elimination_helper Γ φ1 φ2 ψ x :
-    mu_free ψ ->
-    well_formed φ1 -> well_formed φ2 -> well_formed ψ ->
-    Γ ⊢ (φ1 =ml φ2) ---> 
-        (free_evar_subst ψ φ1 x) ---> (free_evar_subst ψ φ2 x).
-  Proof.
-    intros MF WF1 WF2 WFψ. apply deduction_theorem.
-    remember (Γ ∪ {[ (φ1 <---> φ2) ]}) as Γ'.
-    assert (Γ' ⊢ (φ1 <---> φ2)). {
-      apply hypothesis. now apply well_formed_iff.
-      rewrite HeqΓ'. apply elem_of_union_r. constructor.
-    }
-    apply congruence_iff_helper with (ψ0 := ψ) (sz := Syntax.size ψ) (x0 := x) in H; auto.
-    apply pf_iff_proj1 in H; auto.
-  Qed.
-
-  Corollary equality_elimination2 Γ φ1 φ2 ψ:
-    mu_free ψ ->
-    well_formed φ1 -> well_formed φ2 -> wf_body_ex ψ ->
-    Γ ⊢ (φ1 =ml φ2) ---> 
-        (bevar_subst ψ φ1 0) ---> (bevar_subst ψ φ2 0).
-  Proof.
-    intros MF WF1 WF2 WFB. remember (fresh_evar ψ) as x.
-    assert (x ∉ free_evars ψ) by now apply x_eq_fresh_impl_x_notin_free_evars.
-    rewrite (@bound_to_free_variable_subst _ ψ x 1 0 0 φ1).
-    4: rewrite (@bound_to_free_variable_subst _ ψ x 1 0 0 φ2).
-    1, 4: lia. all: auto.
-    1, 2: apply wf_body_ex_to_wf in WFB; apply andb_true_iff in WFB as [E1 E2]; auto.
-    apply equality_elimination_helper; auto.
-    now apply mu_free_evar_open.
-  Qed.
-
-  Lemma patt_eq_sym_meta Γ φ1 φ2 :
-     well_formed φ1 -> well_formed φ2 ->
-     Γ ⊢ φ1 =ml φ2 -> Γ ⊢ φ2 =ml φ1.
-  Proof.
-    intros WF1 WF2 H.
-    epose proof (P2 := @equality_elimination Γ φ1 φ2 pctx_box WF1 WF2 ltac:(constructor)). simpl in P2.
-    eapply Modus_ponens in P2; auto.
-    epose proof (P1 := @equality_elimination Γ φ1 φ2 (pctx_imp_l pctx_box φ1) WF1 WF2 _).
-    simpl in P1.
-    apply Modus_ponens in P1; auto.
-    apply Modus_ponens in P1. 2-3: auto. 2: apply A_impl_A; auto.
-    apply pf_iff_split in P2; auto.
-    apply patt_iff_implies_equal in P2; auto.
-    Unshelve.
-      simpl. now rewrite WF1.
-  Qed.
-
-  Lemma patt_eq_sym Γ φ1 φ2:
-     well_formed φ1 -> well_formed φ2 ->
-     Γ ⊢ φ1 =ml φ2 ---> φ2 =ml φ1.
-  Proof.
-    intros WF1 WF2.
-    apply deduction_theorem.
-    remember (Γ ∪ {[ (φ1 <---> φ2) ]}) as Γ'.
-    assert (Γ' ⊢ (φ1 <---> φ2)). {
-      apply hypothesis. apply well_formed_iff; auto.
-      rewrite HeqΓ'. apply elem_of_union_r. constructor.
-    }
-    apply pf_iff_equiv_sym in H; auto.
-    apply patt_iff_implies_equal; auto.
-  Qed.
-
-  Lemma evar_quantify_equal_simpl : forall φ1 φ2 x n,
-      evar_quantify x n (φ1 =ml φ2) = (evar_quantify x n φ1) =ml (evar_quantify x n φ2).
-  Proof. auto. Qed.
-
-  Lemma exists_functional_subst φ φ' Γ :
-    mu_free φ -> well_formed φ' -> wf_body_ex φ ->
-    Γ ⊢ ((instantiate (patt_exists φ) φ') and (patt_exists (patt_equal φ' (patt_bound_evar 0)))) ---> (patt_exists φ).
-  Proof.
-    intros MF WF WFB.
-    remember (fresh_evar (φ $ φ')) as Zvar.
-    remember (patt_free_evar Zvar) as Z.
-    assert (well_formed Z) as WFZ. { rewrite HeqZ. auto. }
-    assert (Γ ⊢ (patt_equal φ' Z <---> patt_equal Z φ')). {
-      pose proof (SYM1 := @patt_eq_sym Γ φ' Z ltac:(auto) WFZ).
-      pose proof (SYM2 := @patt_eq_sym Γ Z φ' WFZ ltac:(auto)).
-      apply pf_iff_split; auto. 
-    }
-    assert (well_formed (instantiate (ex , φ) φ')) as WF1. {
-      unfold instantiate.
-      unfold well_formed, well_formed_closed.
-      apply andb_true_iff in WF as [E1 E2]. simpl in E1, E2.
-      apply wf_body_ex_to_wf in WFB.
-      apply andb_true_iff in WFB as [E3 E4]. simpl in E3, E4.
-      erewrite bevar_subst_closed, bevar_subst_positive; auto.
-    }
-    assert (well_formed (instantiate (ex , φ) Z)) as WF2. {
-      unfold instantiate.
-      unfold well_formed, well_formed_closed.
-      apply andb_true_iff in WF as [E1 E2]. simpl in E1, E2.
-      apply wf_body_ex_to_wf in WFB.
-      apply andb_true_iff in WFB as [E3 E4]. simpl in E3, E4.
-      erewrite bevar_subst_closed, bevar_subst_positive; auto.
-      all: rewrite HeqZ; auto.
-    }
-    pose proof (@equality_elimination2 Γ φ' Z φ MF WF WFZ WFB).
-    apply pf_iff_iff in H. destruct H.
-    pose proof (EQ := Ex_quan Γ φ Zvar).
-    epose proof (PC := prf_conclusion Γ (patt_equal φ' Z) (instantiate (ex , φ) (patt_free_evar Zvar) ---> ex , φ) ltac:(apply well_formed_equal;auto) _ EQ).
-    2-3: apply well_formed_equal;auto.
-    assert (Γ
-     ⊢ patt_equal φ' Z ---> instantiate (ex , φ) φ' ---> ex , φ) as HSUB. {
-       pose proof (EE := @equality_elimination2 Γ φ' Z φ 
-                     ltac:(auto) ltac:(auto) ltac:(auto) WFB).
-       unfold instantiate in EE.
-       epose proof (PSP := prf_strenghten_premise Γ ((patt_equal φ' Z) and (instantiate (ex , φ) Z))
-                                             ((patt_equal φ' Z) and (instantiate (ex , φ) φ'))
-                                             (ex , φ) _ _ _).
-       eapply Modus_ponens. 4: apply and_impl.
-       all: auto. 1, 2, 4: shelve.
-       eapply Modus_ponens. 4: eapply Modus_ponens.
-       7: exact PSP. 1, 2, 4, 5: shelve.
-       * epose proof (AI := and_impl' Γ (patt_equal φ' Z) (bevar_subst φ Z 0) (ex , φ) _ _ _).
-         unfold instantiate. eapply Modus_ponens. 1, 2: shelve. 2: exact AI.
-         rewrite <- HeqZ in PC.
-         exact PC.
-       * apply and_drop. 1-3: shelve.
-         epose proof (AI := and_impl' Γ (patt_equal φ' Z) (instantiate (ex , φ) φ') (instantiate (ex , φ) Z) _ _ _).
-         eapply Modus_ponens. 4: exact AI. 1-2: shelve. exact EE.
-      Unshelve.
-      all: unfold patt_equal, patt_iff, patt_total, patt_defined, patt_and, patt_or, patt_not; auto 10.
-      all: repeat try apply well_formed_imp; auto.
-      all: repeat try apply well_formed_app; auto.
-      all: repeat try apply well_formed_imp; auto.
-      rewrite <- HeqZ. auto.
-      all: now apply wf_body_ex_to_wf.
-    }
-    eapply Modus_ponens. 4: apply and_impl'; auto.
-    1,2,4,5: shelve.
-    apply reorder_meta; auto. 1-2: shelve.
-    eapply (Ex_gen Γ _ _ Zvar) in HSUB. unfold exists_quantify in HSUB.
-    rewrite evar_quantify_equal_simpl in HSUB.
-    rewrite -> HeqZ, -> HeqZvar in HSUB. simpl evar_quantify in HSUB.
-    2-4: shelve.
-    destruct (decide ((fresh_evar (φ $ φ')) = (fresh_evar (φ $ φ')))) in HSUB;
-    simpl in HSUB. 2: congruence.
-    rewrite evar_quantify_free_evar_subst in HSUB; auto.
-
-    apply count_evar_occurrences_0.
-    unfold fresh_evar. simpl.
-    epose (NIN := not_elem_of_union (evar_fresh (elements (free_evars φ ∪ free_evars φ'))) (free_evars φ) (free_evars φ')). destruct NIN as [NIN1 NIN2].
-    epose (NIN3 := NIN1 _). destruct NIN3. auto.
-  Unshelve.
-    1-6: unfold patt_equal, patt_iff, patt_total, patt_defined, patt_and, patt_or, patt_not; auto 10.
-    1-4: repeat try apply well_formed_imp; auto.
-    1-9: unfold well_formed, well_formed_closed in *; simpl.
-    all: apply wf_body_ex_to_wf in WFB; auto; apply eq_sym, andb_true_eq in WFB; unfold well_formed_closed in WFB; simpl in WFB; destruct WFB;
-      try rewrite <- WFB, <- H4; auto.
-    1-5: apply andb_true_iff in WF as [E1 E2];
-      apply wfc_aux_extend with (n' := 1) (m' := 0) in E2.
-    all: try lia. 1-5: rewrite -> E1, -> E2; simpl; auto.
-    unfold instantiate. simpl. eapply stdpp_ext.not_elem_of_larger_impl_not_elem_of.
-    eapply union_mono_r. apply free_evars_bevar_subst.
-    rewrite HeqZvar. unfold fresh_evar. simpl.
-    rewrite (union_comm_L (free_evars φ) (free_evars φ')).
-    rewrite <- (union_assoc_L (free_evars φ') (free_evars φ) (free_evars φ)).
-    rewrite (union_idemp_L (free_evars φ)).
-    rewrite (union_comm_L (free_evars φ') (free_evars φ)).
-    replace (@union (@EVarSet Σ)
-        (@gmap.gset_union _ _ _) (@free_evars Σ φ)
-        (@free_evars Σ φ')) with (free_evars (φ $ φ')) by reflexivity.
-    now apply x_eq_fresh_impl_x_notin_free_evars.
-    apply set_evar_fresh_is_fresh'.
-  Qed.
-
-  Corollary forall_functional_subst φ φ' Γ : 
-    mu_free φ -> well_formed φ' -> wf_body_ex φ -> 
-      Γ ⊢ ((patt_forall φ) and (patt_exists (patt_equal φ' (patt_bound_evar 0)))) ---> (bevar_subst φ φ' 0).
-  Proof.
-    intros MF WF WFB. unfold patt_forall.
-    assert (well_formed (bevar_subst φ φ' 0)) as BWF. {
-      unfold well_formed, well_formed_closed.
-      rewrite -> well_formed_positive_bevar_subst, -> wfc_aux_bevar_subst; auto.
-      2, 4: apply andb_true_iff in WF as [E1 E2]; auto.
-      all: apply wf_body_ex_to_wf, andb_true_iff in WFB as [E1 E2]; 
-        unfold well_formed_closed in E2; simpl in E1, E2; auto.
-    }
-    assert (well_formed (ex , patt_equal φ' b0)) as SWF. {
-      unfold well_formed, well_formed_closed.
-      apply andb_true_iff in WF as [E1 E2]. unfold well_formed_closed in E2.
-      simpl. rewrite E1. apply wfc_aux_extend with (n' := 1) (m' := 0) in E2.
-      rewrite E2. auto. all: lia.
-    }
-    assert (well_formed (ex , (φ ---> ⊥))) as NWF. {
-      apply wf_body_ex_to_wf in WFB. unfold well_formed, well_formed_closed in *.
-      clear BWF SWF.
-      apply andb_true_iff in WFB as [E1 E2]. simpl in *.
-      now rewrite -> E1, -> E2.
-    }
-    epose proof (H := @exists_functional_subst (! φ) φ' Γ _ WF _).
-    simpl in H.
-    epose proof (H0 := and_impl _ _ _ _ _ _ _).
-    eapply Modus_ponens in H0. 4: exact H. 2-3: shelve.
-    apply reorder_meta in H0. 2-4: shelve.
     
-    epose proof (H1 := and_impl' _ _ _ _ _ _ _). eapply Modus_ponens in H1. exact H1.
-    1-2: shelve.
-    apply reorder_meta. 1-3: shelve.
-    epose proof (H2 := P4 Γ (bevar_subst φ φ' 0) (! ex , ! φ) _ _).
-    clear H H1.
-    epose proof (H := prf_weaken_conclusion Γ (ex , patt_equal φ' b0) ((bevar_subst φ φ' 0 ---> ⊥) ---> ex , (! φ)) ((bevar_subst φ φ' 0 ---> ⊥) ---> ! ! ex , (! φ)) _ _ _).
-    eapply Modus_ponens in H. eapply Modus_ponens in H; auto.
-    2-4: shelve.
-    2: {
-      epose proof (H1 := prf_weaken_conclusion Γ (bevar_subst φ φ' 0 ---> ⊥) (ex , (! φ)) (! ! ex , (! φ)) _ _ _). eapply Modus_ponens. 4: exact H1. 1-2: shelve.
-      apply not_not_intro. shelve.
-    }
-    eapply syllogism_intro in H2. exact H2. all: auto.
-    Unshelve.
-    all: unfold patt_not; auto.
-    simpl. now rewrite MF.
-    apply wf_body_ex_to_wf in WFB; apply wf_ex_to_wf_body; auto.
-    all: repeat apply well_formed_imp; auto.
-  Qed.
+    
+    
 
-  End ProofSystemTheorems.
+    
+    Fixpoint uses_existential_generalization Γ ϕ (pf : Γ ⊢ ϕ) :=
+      match pf with
+      | hypothesis _ _ _ _ => false
+      | P1 _ _ _ _ _ => false
+      | P2 _ _ _ _ _ _ _ => false
+      | P3 _ _ _ => false
+      | Modus_ponens _ _ _ _ _ m0 m1
+        => uses_existential_generalization m0
+           || uses_existential_generalization m1
+      | Ex_quan _ _ _ => false
+      | Ex_gen _ _ _ _ _ _ _ _ => true
+      | Prop_bott_left _ _ _ => false
+      | Prop_bott_right _ _ _ => false
+      | Prop_disj_left _ _ _ _ _ _ _ => false
+      | Prop_disj_right _ _ _ _ _ _ _ => false
+      | Prop_ex_left _ _ _ _ _ => false
+      | Prop_ex_right _ _ _ _ _ => false
+      | Framing_left _ _ _ _ m0 => uses_existential_generalization m0
+      | Framing_right _ _ _ _ m0 => uses_existential_generalization m0
+      | Svar_subst _ _ _ _ _ _ m0 => uses_existential_generalization m0
+      | Pre_fixp _ _ => false
+      | Knaster_tarski _ phi psi m0 => uses_existential_generalization m0
+      | Existence _ => false
+      | Singleton_ctx _ _ _ _ _ => false
+      end.
 
-End definedness.
+    Fixpoint uses_svar_subst Γ ϕ (pf : Γ ⊢ ϕ) :=
+      match pf with
+      | hypothesis _ _ _ _ => false
+      | P1 _ _ _ _ _ => false
+      | P2 _ _ _ _ _ _ _ => false
+      | P3 _ _ _ => false
+      | Modus_ponens _ _ _ _ _ m0 m1
+        => uses_svar_subst m0
+           || uses_svar_subst m1
+      | Ex_quan _ _ _ => false
+      | Ex_gen _ _ _ _ _ _ pf' _ => uses_svar_subst pf'
+      | Prop_bott_left _ _ _ => false
+      | Prop_bott_right _ _ _ => false
+      | Prop_disj_left _ _ _ _ _ _ _ => false
+      | Prop_disj_right _ _ _ _ _ _ _ => false
+      | Prop_ex_left _ _ _ _ _ => false
+      | Prop_ex_right _ _ _ _ _ => false
+      | Framing_left _ _ _ _ m0 => uses_svar_subst m0
+      | Framing_right _ _ _ _ m0 => uses_svar_subst m0
+      | Svar_subst _ _ _ _ _ _ m0 => true
+      | Pre_fixp _ _ => false
+      | Knaster_tarski _ phi psi m0 => uses_svar_subst m0
+      | Existence _ => false
+      | Singleton_ctx _ _ _ _ _ => false
+      end.
+
+
+
+    Theorem deduction_theorem_general Γ ϕ ψ (pf : Γ ∪ {[ ψ ]} ⊢ ϕ) :
+      Γ ⊢ ⌊ ψ ⌋ ---> ϕ.
+    Proof.
+
+    Abort.
+    
+    Theorem deduction_theorem :
+      forall φ ψ Γ, (* psi closed *)
+        Γ ∪ {[ ψ ]} ⊢ φ ->
+        Γ ⊢ ⌊ ψ ⌋ ---> φ.
+    Proof.
+      
+    Admitted.
+
+    Theorem reverse_deduction_theorem :
+      forall φ ψ Γ,
+        Γ ⊢ ⌊ ψ ⌋ ---> φ ->
+        Γ ∪ {[ ψ ]} ⊢ φ.
+    Proof.
+      
+    Admitted.
+
+    Lemma equality_elimination Γ φ1 φ2 C :
+      well_formed φ1 -> well_formed φ2 ->
+      wf_PatCtx C ->
+      Γ ⊢ (φ1 =ml φ2) ---> (* somewhere "and" is here, somewhere meta-implication *)
+        (subst_patctx C φ1) ---> (subst_patctx C φ2).
+    Proof.
+      intros WF1 WF2 WFC. apply deduction_theorem.
+      remember (Γ ∪ {[ (φ1 <---> φ2) ]}) as Γ'.
+      assert (Γ' ⊢ (φ1 <---> φ2)). {
+        apply hypothesis. now apply well_formed_iff.
+        rewrite HeqΓ'. apply elem_of_union_r. constructor.
+      }
+      apply congruence_iff with (C0 := C) in H; auto.
+      apply pf_iff_proj1 in H; auto.
+      1-2: now apply subst_patctx_wf.
+    Qed.
+
+    Lemma equality_elimination_helper Γ φ1 φ2 ψ x :
+      mu_free ψ ->
+      well_formed φ1 -> well_formed φ2 -> well_formed ψ ->
+      Γ ⊢ (φ1 =ml φ2) ---> 
+        (free_evar_subst ψ φ1 x) ---> (free_evar_subst ψ φ2 x).
+    Proof.
+      intros MF WF1 WF2 WFψ. apply deduction_theorem.
+      remember (Γ ∪ {[ (φ1 <---> φ2) ]}) as Γ'.
+      assert (Γ' ⊢ (φ1 <---> φ2)). {
+        apply hypothesis. now apply well_formed_iff.
+        rewrite HeqΓ'. apply elem_of_union_r. constructor.
+      }
+      apply congruence_iff_helper with (ψ0 := ψ) (sz := Syntax.size ψ) (x0 := x) in H; auto.
+      apply pf_iff_proj1 in H; auto.
+    Qed.
+
+    Corollary equality_elimination2 Γ φ1 φ2 ψ:
+      mu_free ψ ->
+      well_formed φ1 -> well_formed φ2 -> wf_body_ex ψ ->
+      Γ ⊢ (φ1 =ml φ2) ---> 
+        (bevar_subst ψ φ1 0) ---> (bevar_subst ψ φ2 0).
+    Proof.
+      intros MF WF1 WF2 WFB. remember (fresh_evar ψ) as x.
+      assert (x ∉ free_evars ψ) by now apply x_eq_fresh_impl_x_notin_free_evars.
+      rewrite (@bound_to_free_variable_subst _ ψ x 1 0 0 φ1).
+      4: rewrite (@bound_to_free_variable_subst _ ψ x 1 0 0 φ2).
+      1, 4: lia. all: auto.
+      1, 2: apply wf_body_ex_to_wf in WFB; apply andb_true_iff in WFB as [E1 E2]; auto.
+      apply equality_elimination_helper; auto.
+      now apply mu_free_evar_open.
+    Qed.
+
+    Lemma patt_eq_sym_meta Γ φ1 φ2 :
+      well_formed φ1 -> well_formed φ2 ->
+      Γ ⊢ φ1 =ml φ2 -> Γ ⊢ φ2 =ml φ1.
+    Proof.
+      intros WF1 WF2 H.
+      epose proof (P2 := @equality_elimination Γ φ1 φ2 pctx_box WF1 WF2 ltac:(constructor)). simpl in P2.
+      eapply Modus_ponens in P2; auto.
+      epose proof (P1 := @equality_elimination Γ φ1 φ2 (pctx_imp_l pctx_box φ1) WF1 WF2 _).
+      simpl in P1.
+      apply Modus_ponens in P1; auto.
+      apply Modus_ponens in P1. 2-3: auto. 2: apply A_impl_A; auto.
+      apply pf_iff_split in P2; auto.
+      apply patt_iff_implies_equal in P2; auto.
+      Unshelve.
+      simpl. now rewrite WF1.
+    Qed.
+
+    Lemma patt_eq_sym Γ φ1 φ2:
+      well_formed φ1 -> well_formed φ2 ->
+      Γ ⊢ φ1 =ml φ2 ---> φ2 =ml φ1.
+    Proof.
+      intros WF1 WF2.
+      apply deduction_theorem.
+      remember (Γ ∪ {[ (φ1 <---> φ2) ]}) as Γ'.
+      assert (Γ' ⊢ (φ1 <---> φ2)). {
+        apply hypothesis. apply well_formed_iff; auto.
+        rewrite HeqΓ'. apply elem_of_union_r. constructor.
+      }
+      apply pf_iff_equiv_sym in H; auto.
+      apply patt_iff_implies_equal; auto.
+    Qed.
+
+    Lemma evar_quantify_equal_simpl : forall φ1 φ2 x n,
+        evar_quantify x n (φ1 =ml φ2) = (evar_quantify x n φ1) =ml (evar_quantify x n φ2).
+    Proof. auto. Qed.
+
+    Lemma exists_functional_subst φ φ' Γ :
+      mu_free φ -> well_formed φ' -> wf_body_ex φ ->
+      Γ ⊢ ((instantiate (patt_exists φ) φ') and (patt_exists (patt_equal φ' (patt_bound_evar 0)))) ---> (patt_exists φ).
+    Proof.
+      intros MF WF WFB.
+      remember (fresh_evar (φ $ φ')) as Zvar.
+      remember (patt_free_evar Zvar) as Z.
+      assert (well_formed Z) as WFZ. { rewrite HeqZ. auto. }
+                                     assert (Γ ⊢ (patt_equal φ' Z <---> patt_equal Z φ')). {
+        pose proof (SYM1 := @patt_eq_sym Γ φ' Z ltac:(auto) WFZ).
+        pose proof (SYM2 := @patt_eq_sym Γ Z φ' WFZ ltac:(auto)).
+        apply pf_iff_split; auto. 
+      }
+      assert (well_formed (instantiate (ex , φ) φ')) as WF1. {
+        unfold instantiate.
+        unfold well_formed, well_formed_closed.
+        apply andb_true_iff in WF as [E1 E2]. simpl in E1, E2.
+        apply wf_body_ex_to_wf in WFB.
+        apply andb_true_iff in WFB as [E3 E4]. simpl in E3, E4.
+        erewrite bevar_subst_closed, bevar_subst_positive; auto.
+      }
+      assert (well_formed (instantiate (ex , φ) Z)) as WF2. {
+        unfold instantiate.
+        unfold well_formed, well_formed_closed.
+        apply andb_true_iff in WF as [E1 E2]. simpl in E1, E2.
+        apply wf_body_ex_to_wf in WFB.
+        apply andb_true_iff in WFB as [E3 E4]. simpl in E3, E4.
+        erewrite bevar_subst_closed, bevar_subst_positive; auto.
+        all: rewrite HeqZ; auto.
+      }
+      pose proof (@equality_elimination2 Γ φ' Z φ MF WF WFZ WFB).
+      apply pf_iff_iff in H. destruct H.
+      pose proof (EQ := Ex_quan Γ φ Zvar).
+      epose proof (PC := prf_conclusion Γ (patt_equal φ' Z) (instantiate (ex , φ) (patt_free_evar Zvar) ---> ex , φ) ltac:(apply well_formed_equal;auto) _ EQ).
+      2-3: apply well_formed_equal;auto.
+      assert (Γ
+                ⊢ patt_equal φ' Z ---> instantiate (ex , φ) φ' ---> ex , φ) as HSUB. {
+        pose proof (EE := @equality_elimination2 Γ φ' Z φ 
+                                                 ltac:(auto) ltac:(auto) ltac:(auto) WFB).
+        unfold instantiate in EE.
+        epose proof (PSP := prf_strenghten_premise Γ ((patt_equal φ' Z) and (instantiate (ex , φ) Z))
+                                                   ((patt_equal φ' Z) and (instantiate (ex , φ) φ'))
+                                                   (ex , φ) _ _ _).
+        eapply Modus_ponens. 4: apply and_impl.
+        all: auto. 1, 2, 4: shelve.
+        eapply Modus_ponens. 4: eapply Modus_ponens.
+        7: exact PSP. 1, 2, 4, 5: shelve.
+        * epose proof (AI := and_impl' Γ (patt_equal φ' Z) (bevar_subst φ Z 0) (ex , φ) _ _ _).
+          unfold instantiate. eapply Modus_ponens. 1, 2: shelve. 2: exact AI.
+          rewrite <- HeqZ in PC.
+          exact PC.
+        * apply and_drop. 1-3: shelve.
+          epose proof (AI := and_impl' Γ (patt_equal φ' Z) (instantiate (ex , φ) φ') (instantiate (ex , φ) Z) _ _ _).
+          eapply Modus_ponens. 4: exact AI. 1-2: shelve. exact EE.
+          Unshelve.
+          all: unfold patt_equal, patt_iff, patt_total, patt_defined, patt_and, patt_or, patt_not; auto 10.
+          all: repeat try apply well_formed_imp; auto.
+          all: repeat try apply well_formed_app; auto.
+          all: repeat try apply well_formed_imp; auto.
+          rewrite <- HeqZ. auto.
+          all: now apply wf_body_ex_to_wf.
+      }
+      eapply Modus_ponens. 4: apply and_impl'; auto.
+      1,2,4,5: shelve.
+      apply reorder_meta; auto. 1-2: shelve.
+      eapply (Ex_gen Γ _ _ Zvar) in HSUB. unfold exists_quantify in HSUB.
+      rewrite evar_quantify_equal_simpl in HSUB.
+      rewrite -> HeqZ, -> HeqZvar in HSUB. simpl evar_quantify in HSUB.
+      2-4: shelve.
+      destruct (decide ((fresh_evar (φ $ φ')) = (fresh_evar (φ $ φ')))) in HSUB;
+        simpl in HSUB. 2: congruence.
+      rewrite evar_quantify_free_evar_subst in HSUB; auto.
+
+      apply count_evar_occurrences_0.
+      unfold fresh_evar. simpl.
+      epose (NIN := not_elem_of_union (evar_fresh (elements (free_evars φ ∪ free_evars φ'))) (free_evars φ) (free_evars φ')). destruct NIN as [NIN1 NIN2].
+      epose (NIN3 := NIN1 _). destruct NIN3. auto.
+      Unshelve.
+      1-6: unfold patt_equal, patt_iff, patt_total, patt_defined, patt_and, patt_or, patt_not; auto 10.
+      1-4: repeat try apply well_formed_imp; auto.
+      1-9: unfold well_formed, well_formed_closed in *; simpl.
+      all: apply wf_body_ex_to_wf in WFB; auto; apply eq_sym, andb_true_eq in WFB; unfold well_formed_closed in WFB; simpl in WFB; destruct WFB;
+        try rewrite <- WFB, <- H4; auto.
+      1-5: apply andb_true_iff in WF as [E1 E2];
+        apply wfc_aux_extend with (n' := 1) (m' := 0) in E2.
+      all: try lia. 1-5: rewrite -> E1, -> E2; simpl; auto.
+      unfold instantiate. simpl. eapply stdpp_ext.not_elem_of_larger_impl_not_elem_of.
+      eapply union_mono_r. apply free_evars_bevar_subst.
+      rewrite HeqZvar. unfold fresh_evar. simpl.
+      rewrite (union_comm_L (free_evars φ) (free_evars φ')).
+      rewrite <- (union_assoc_L (free_evars φ') (free_evars φ) (free_evars φ)).
+      rewrite (union_idemp_L (free_evars φ)).
+      rewrite (union_comm_L (free_evars φ') (free_evars φ)).
+      replace (@union (@EVarSet Σ)
+                      (@gmap.gset_union _ _ _) (@free_evars Σ φ)
+                      (@free_evars Σ φ')) with (free_evars (φ $ φ')) by reflexivity.
+      now apply x_eq_fresh_impl_x_notin_free_evars.
+      apply set_evar_fresh_is_fresh'.
+    Qed.
+
+    Corollary forall_functional_subst φ φ' Γ : 
+      mu_free φ -> well_formed φ' -> wf_body_ex φ -> 
+      Γ ⊢ ((patt_forall φ) and (patt_exists (patt_equal φ' (patt_bound_evar 0)))) ---> (bevar_subst φ φ' 0).
+    Proof.
+      intros MF WF WFB. unfold patt_forall.
+      assert (well_formed (bevar_subst φ φ' 0)) as BWF. {
+        unfold well_formed, well_formed_closed.
+        rewrite -> well_formed_positive_bevar_subst, -> wfc_aux_bevar_subst; auto.
+        2, 4: apply andb_true_iff in WF as [E1 E2]; auto.
+        all: apply wf_body_ex_to_wf, andb_true_iff in WFB as [E1 E2]; 
+          unfold well_formed_closed in E2; simpl in E1, E2; auto.
+      }
+      assert (well_formed (ex , patt_equal φ' b0)) as SWF. {
+        unfold well_formed, well_formed_closed.
+        apply andb_true_iff in WF as [E1 E2]. unfold well_formed_closed in E2.
+        simpl. rewrite E1. apply wfc_aux_extend with (n' := 1) (m' := 0) in E2.
+        rewrite E2. auto. all: lia.
+      }
+      assert (well_formed (ex , (φ ---> ⊥))) as NWF. {
+        apply wf_body_ex_to_wf in WFB. unfold well_formed, well_formed_closed in *.
+        clear BWF SWF.
+        apply andb_true_iff in WFB as [E1 E2]. simpl in *.
+        now rewrite -> E1, -> E2.
+      }
+      epose proof (H := @exists_functional_subst (! φ) φ' Γ _ WF _).
+      simpl in H.
+      epose proof (H0 := and_impl _ _ _ _ _ _ _).
+      eapply Modus_ponens in H0. 4: exact H. 2-3: shelve.
+      apply reorder_meta in H0. 2-4: shelve.
+      
+      epose proof (H1 := and_impl' _ _ _ _ _ _ _). eapply Modus_ponens in H1. exact H1.
+      1-2: shelve.
+      apply reorder_meta. 1-3: shelve.
+      epose proof (H2 := P4 Γ (bevar_subst φ φ' 0) (! ex , ! φ) _ _).
+      clear H H1.
+      epose proof (H := prf_weaken_conclusion Γ (ex , patt_equal φ' b0) ((bevar_subst φ φ' 0 ---> ⊥) ---> ex , (! φ)) ((bevar_subst φ φ' 0 ---> ⊥) ---> ! ! ex , (! φ)) _ _ _).
+      eapply Modus_ponens in H. eapply Modus_ponens in H; auto.
+      2-4: shelve.
+      2: {
+        epose proof (H1 := prf_weaken_conclusion Γ (bevar_subst φ φ' 0 ---> ⊥) (ex , (! φ)) (! ! ex , (! φ)) _ _ _). eapply Modus_ponens. 4: exact H1. 1-2: shelve.
+        apply not_not_intro. shelve.
+      }
+      eapply syllogism_intro in H2. exact H2. all: auto.
+      Unshelve.
+      all: unfold patt_not; auto.
+      simpl. now rewrite MF.
+      apply wf_body_ex_to_wf in WFB; apply wf_ex_to_wf_body; auto.
+      all: repeat apply well_formed_imp; auto.
+    Qed.
+
+End ProofSystemTheorems.
 
 
 #[export]
@@ -1140,14 +1233,3 @@ End definedness.
  Hint Resolve T_predicate_equals : core.
 #[export]
  Hint Resolve T_predicate_in : core.
-
-#[export]
- Hint Resolve well_formed_defined : core.
-#[export]
- Hint Resolve well_formed_total : core.
-#[export]
- Hint Resolve well_formed_equal : core.
-#[export]
- Hint Resolve well_formed_subseteq : core.
-#[export]
- Hint Resolve well_formed_in : core.

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -811,6 +811,69 @@ Section definedness.
     apply patt_iff_implies_equal in IFF; auto.
   Qed.
 
+
+
+  
+  Fixpoint uses_existential_generalization Γ ϕ (pf : Γ ⊢ ϕ) :=
+    match pf with
+    | hypothesis _ _ _ _ => false
+    | P1 _ _ _ _ _ => false
+    | P2 _ _ _ _ _ _ _ => false
+    | P3 _ _ _ => false
+    | Modus_ponens _ _ _ _ _ m0 m1
+      => uses_existential_generalization m0
+         || uses_existential_generalization m1
+    | Ex_quan _ _ _ => false
+    | Ex_gen _ _ _ _ _ _ _ _ => true
+    | Prop_bott_left _ _ _ => false
+    | Prop_bott_right _ _ _ => false
+    | Prop_disj_left _ _ _ _ _ _ _ => false
+    | Prop_disj_right _ _ _ _ _ _ _ => false
+    | Prop_ex_left _ _ _ _ _ => false
+    | Prop_ex_right _ _ _ _ _ => false
+    | Framing_left _ _ _ _ m0 => uses_existential_generalization m0
+    | Framing_right _ _ _ _ m0 => uses_existential_generalization m0
+    | Svar_subst _ _ _ _ _ _ m0 => uses_existential_generalization m0
+    | Pre_fixp _ _ => false
+    | Knaster_tarski _ phi psi m0 => uses_existential_generalization m0
+    | Existence _ => false
+    | Singleton_ctx _ _ _ _ _ => false
+    end.
+
+  Fixpoint uses_svar_subst Γ ϕ (pf : Γ ⊢ ϕ) :=
+    match pf with
+    | hypothesis _ _ _ _ => false
+    | P1 _ _ _ _ _ => false
+    | P2 _ _ _ _ _ _ _ => false
+    | P3 _ _ _ => false
+    | Modus_ponens _ _ _ _ _ m0 m1
+      => uses_svar_subst m0
+         || uses_svar_subst m1
+    | Ex_quan _ _ _ => false
+    | Ex_gen _ _ _ _ _ _ pf' _ => uses_svar_subst pf'
+    | Prop_bott_left _ _ _ => false
+    | Prop_bott_right _ _ _ => false
+    | Prop_disj_left _ _ _ _ _ _ _ => false
+    | Prop_disj_right _ _ _ _ _ _ _ => false
+    | Prop_ex_left _ _ _ _ _ => false
+    | Prop_ex_right _ _ _ _ _ => false
+    | Framing_left _ _ _ _ m0 => uses_svar_subst m0
+    | Framing_right _ _ _ _ m0 => uses_svar_subst m0
+    | Svar_subst _ _ _ _ _ _ m0 => true
+    | Pre_fixp _ _ => false
+    | Knaster_tarski _ phi psi m0 => uses_svar_subst m0
+    | Existence _ => false
+    | Singleton_ctx _ _ _ _ _ => false
+    end.
+
+
+
+  Theorem deduction_theorem_general Γ ϕ ψ (pf : Γ ∪ {[ ψ ]} ⊢ ϕ) :
+      Γ ⊢ ⌊ ψ ⌋ ---> ϕ.
+  Proof.
+
+  Abort.
+  
   Theorem deduction_theorem :
     forall φ ψ Γ, (* psi closed *)
       Γ ∪ {[ ψ ]} ⊢ φ ->

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -812,8 +812,8 @@ Section ProofSystemTheorems.
   .
 
   
-  Import ProofSystem Helpers.FOL_helpers.
-  Notation "theory ⊢ pattern" := (@ML_proof_system Σ theory pattern) (at level 95, no associativity).
+  Import ProofSystem ProofSystem.Notations Helpers.FOL_helpers.
+  (*Notation "theory ⊢ pattern" := (@ML_proof_system Σ theory pattern) (at level 95, no associativity).*)
 
   Lemma patt_iff_implies_equal :
     forall (φ1 φ2 : Pattern) Γ, well_formed φ1 -> well_formed φ2 ->
@@ -932,9 +932,6 @@ Section ProofSystemTheorems.
       5: apply S7.
       all: auto.
     }
-
-    
-    
     
     
   Abort.

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -932,10 +932,25 @@ Section ProofSystemTheorems.
       5: apply S7.
       all: auto.
     }
-    
-    
   Abort.
-  
+  (*
+    assert (S9: Γ ⊢ all, (subst_ctx AC (patt_bound_evar 0 and ϕ) ---> ⌈ ϕ ⌉)).
+    {
+      Search subst_ctx emplace.
+      Check evar_quantify.
+      replace (subst_ctx AC (patt_bound_evar 0 and ϕ))
+        with (evar_quantify ev_x 0 (subst_ctx AC (p_x and ϕ))).
+      {
+        Search evar_quantify subst_ctx.
+        rewrite evar_quantify_subst_ctx.
+      }
+      
+      apply universal_generalization.
+    }
+    
+  '  
+  Qed.
+  *)
     
     
     

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -872,7 +872,7 @@ Section ProofSystemTheorems.
       all: auto.
     }
 
-    assert(S4: Γ ⊢ ⌈ (p_x and (! ϕ)) or ϕ  ⌉).
+    assert(S4: Γ ⊢ ⌈ (p_x and (! ϕ)) or ϕ ⌉).
     {
       assert(Htmp1: Γ ⊢ (p_x or ϕ) ---> (p_x and ! ϕ or ϕ)).
       {
@@ -900,6 +900,41 @@ Section ProofSystemTheorems.
       4: apply Htmp2.
       all: auto 10.
     }
+
+    assert(S5: Γ ⊢ ⌈ (p_x and (! ϕ)) ⌉ or ⌈ ϕ ⌉).
+    {
+      pose proof (Htmp := (prf_prop_or_iff Γ AC_patt_defined) (p_x and ! ϕ) ϕ ltac:(auto) ltac:(auto)).
+      simpl in Htmp.
+      apply pf_conj_elim_l_meta in Htmp; auto 10.
+      eapply Modus_ponens. 4: apply Htmp.
+      all: auto 10.
+    }
+
+    assert(S6: Γ ⊢ subst_ctx AC (p_x and ϕ) ---> ! ⌈ p_x and ! ϕ ⌉).
+    {
+      pose proof (Htmp := Singleton_ctx Γ AC AC_patt_defined ϕ ev_x).
+      simpl in Htmp.
+      unfold patt_and in Htmp at 1.
+      apply not_not_elim_meta in Htmp; auto 10.
+      replace (patt_sym (inj definedness) $ (patt_free_evar ev_x and ! ϕ))
+        with (patt_defined (p_x and ! ϕ)) in Htmp by reflexivity.
+      
+      toMyGoal. mgIntro. mgAdd Htmp; auto 10.
+      mgApply' 0 10. mgIntro. mgApply' 2 10.
+      mgExactn 1; auto 10.
+    }
+
+    pose proof (S7 := S5). unfold patt_or in S7.
+
+    assert(S8: Γ ⊢ subst_ctx AC (p_x and ϕ) ---> ⌈ ϕ ⌉).
+    {
+      eapply syllogism_intro.
+      5: apply S7.
+      all: auto.
+    }
+
+    
+    
     
     
   Abort.

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -932,8 +932,6 @@ Section ProofSystemTheorems.
       5: apply S7.
       all: auto.
     }
-  Abort.
-  (*
     assert (S9: Γ ⊢ all, (subst_ctx AC (patt_bound_evar 0 and ϕ) ---> ⌈ ϕ ⌉)).
     {
       Search subst_ctx emplace.
@@ -941,8 +939,13 @@ Section ProofSystemTheorems.
       replace (subst_ctx AC (patt_bound_evar 0 and ϕ))
         with (evar_quantify ev_x 0 (subst_ctx AC (p_x and ϕ))).
       {
+        rewrite -emplace_subst_ctx.
+  Abort.
+  (*
+        unfold ApplicationContext2PatternCtx,ApplicationContext2PatternCtx'.
+        Search emplace subst_ctx.
         Search evar_quantify subst_ctx.
-        rewrite evar_quantify_subst_ctx.
+        rewrite evar_quantify_subst_ctx
       }
       
       apply universal_generalization.

--- a/matching-logic/src/Theories/Sorts.v
+++ b/matching-logic/src/Theories/Sorts.v
@@ -520,8 +520,8 @@ Section sorts.
       rewrite 2!free_evars_nest_ex_aux in Hx'fr.
       
       rewrite {2}update_evar_val_comm.
-      do 2 rewrite -> evar_open_bound_evar. rewrite Nat.eqb_refl.
-      rewrite [(if 0 =? 1 then patt_free_evar x' else b0)]/=.
+      do 2 rewrite -> evar_open_bound_evar.
+      repeat case_match; try lia.
       rewrite <- Heqx''. apply Hx''neqx'.
       rewrite update_evar_val_same.
       unfold nest_ex.
@@ -532,8 +532,9 @@ Section sorts.
       rewrite 2!pattern_interpretation_nest_ex_aux.
 
       rewrite pattern_interpretation_free_evar_independent.
-      do 2 rewrite evar_open_bound_evar. rewrite Nat.eqb_refl.
-      rewrite [(if 0 =? 1 then patt_free_evar x' else b0)]/=. unfold nest_ex in Heqx''.
+      do 2 rewrite evar_open_bound_evar.
+      repeat case_match; try lia.
+      unfold nest_ex in Heqx''.
       rewrite <- Heqx''. assumption.
       rewrite pattern_interpretation_free_evar_independent. assumption.
       auto.
@@ -630,7 +631,9 @@ Section sorts.
       rewrite 2!free_evars_nest_ex_aux in Hx'fr.
       
       rewrite {2}update_evar_val_comm.
-      do 2 rewrite evar_open_bound_evar. cbn. rewrite <- Heqx''. apply Hx''neqx'.
+      do 2 rewrite evar_open_bound_evar. cbn.
+      repeat case_match; try lia.
+      rewrite <- Heqx''. apply Hx''neqx'.
       rewrite update_evar_val_same.
       unfold nest_ex.
       rewrite evar_open_nest_ex_aux_comm. simpl.
@@ -641,6 +644,7 @@ Section sorts.
 
       rewrite pattern_interpretation_free_evar_independent.
       do 2 rewrite evar_open_bound_evar. cbn. unfold nest_ex in Heqx''.
+      repeat case_match; try lia.
       rewrite <- Heqx''. assumption.
       rewrite pattern_interpretation_free_evar_independent. assumption.
       auto.

--- a/prover/theories/MLTauto.v
+++ b/prover/theories/MLTauto.v
@@ -357,7 +357,7 @@ Section ml_tauto.
        (*          rewrite ?Hcount_p1' Hcount_p2';*)
        lia|
       ];
-      set (ctx := (@Build_PatternCtx _ star ctx' wfctx' countstar));
+      set (ctx := (@Build_PatternCtx _ star ctx' countstar));
       assert (Himpl: is_implicative_context ctx);
       [ unfold ctx; unfold is_implicative_context;
         rewrite [pcEvar _]/=; rewrite [pcPattern _]/=;

--- a/prover/theories/Named.v
+++ b/prover/theories/Named.v
@@ -135,7 +135,7 @@ Section named.
   named_no_positive_occurrence (X : svar) (ϕ : NamedPattern) : bool :=
     match ϕ with
     | npatt_evar _ | npatt_sym _ | npatt_bott => true
-    | npatt_svar Y => negb (if decide (X = Y) then true else false)
+    | npatt_svar Y => negb (if decide (X = Y) is left _ then true else false)
     | npatt_app ϕ₁ ϕ₂ => named_no_positive_occurrence X ϕ₁ && named_no_positive_occurrence X ϕ₂
     | npatt_imp ϕ₁ ϕ₂ => named_no_negative_occurrence X ϕ₁ && named_no_positive_occurrence X ϕ₂
     | npatt_exists _ ϕ' => named_no_positive_occurrence X ϕ'
@@ -208,12 +208,9 @@ Section named.
       + subst. rewrite Hdbi. simpl. split; [reflexivity|].
         destruct (decide (X = X)); [|contradiction].
         simpl.
-        rewrite Nat.eqb_refl.
         reflexivity.
       + pose proof (Hneq := n0).
         apply Nat.eqb_neq in n0.
-        rewrite n0. simpl.
-        clear n0.
         remember (svm !! n) as svm_n.
         destruct svm_n; split; try reflexivity.
         simpl.


### PR DESCRIPTION
* add Universal Generalization
* do not use boolean versions of functions, but `decide`. This enables more automation (`case_match`)
* PatternCtx now does not carry its well-formedness condition
* do not use `compare_nat` in `bevar_subst` (closes https://github.com/harp-project/AML-Formalization/issues/147)