### PR TITLE
Add script to fix unicode chars

### DIFF
--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -6179,5 +6179,42 @@ Defined.
         mgApply 3.
         mgExactn 4.
   Defined.
-      
+
+  Lemma ex_or_of_equiv_is_equiv_2 {Σ : Signature} Γ p q p' q':
+    well_formed p ->
+    well_formed q ->
+    well_formed p' ->
+    well_formed q' ->
+    Γ ⊢ (p <---> p') ->
+    Γ ⊢ (q <---> q') ->
+    Γ ⊢ ((p or q) <---> (p' or q')).
+  Proof.
+    intros wfp wfq wfp' wfq' pep' qeq'.
+
+    pose proof (pip' := pep'). apply pf_conj_elim_l_meta in pip'; auto.
+    pose proof (p'ip := pep'). apply pf_conj_elim_r_meta in p'ip; auto.
+    pose proof (qiq' := qeq'). apply pf_conj_elim_l_meta in qiq'; auto.
+    pose proof (q'iq := qeq'). apply pf_conj_elim_r_meta in q'iq; auto.
+
+    toMyGoal.
+    { wf_auto2. }
+    unfold patt_iff.
+    mgSplitAnd.
+    - mgIntro.
+      mgDestructOr 0.
+      mgLeft.
+      + mgApplyMeta pip'.
+        mgExactn 0.
+      + mgRight.
+        mgApplyMeta qiq'.
+        mgExactn 0.
+    - mgIntro.
+      mgDestructOr 0.
+      mgLeft.
+      + mgApplyMeta p'ip.
+        mgExactn 0.
+      + mgRight.
+        mgApplyMeta q'iq.
+        mgExactn 0. 
+  Defined.
 

--- a/scripts/convert_to_unicode.py
+++ b/scripts/convert_to_unicode.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import re
+
+def to_unicode(s: str):
+	return bytes(s,'ascii').decode("unicode-escape")
+
+def find_unicodes(f: Path):
+	try:
+		patt = re.compile(r'\\'+'u[a-f0-9]{4}')
+		return f, set(patt.findall(f.open('r').read()))
+	except UnicodeDecodeError:
+		raise
+if __name__ == '__main__':
+	AML = Path.cwd()
+	while AML.name != 'AML-Formalization':
+		AML = AML.parent
+	root = AML / 'matching-logic' / 'src'
+	replaces = []
+	print('The following unicodes were found in the following .v files:')
+	for f in root.glob('*.v'):
+		res = find_unicodes(f)
+		if len(res[1]) > 0:
+			print(res[0].relative_to(AML))
+			for i in res[1]:
+				replaces.append((i,to_unicode(i)))
+				print(f'\t{replaces[-1]}')
+	print(f"{len(replaces)} codes were replaced in the .v files")
+	replaces = set(replaces)
+	for f in root.glob('*.v'):
+		data = f.open('r').read()
+		for esc, uni in replaces:
+			data = data.replace(esc,uni)
+		f.open("w",encoding='utf8').write(data)


### PR DESCRIPTION
Saving a file in CoqIDE with nix replaces unicode characters with their code.
[https://github.com/coq/coq/issues/11526](https://github.com/coq/coq/issues/11526)
The python script reverts these changes : `python3 scripts/convert_to_unicode.py`
A small lemma is added.