### PR TITLE
Automation for prop/cast indifference of tactics

### DIFF
--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -4947,9 +4947,12 @@ Proof.
     ).
   }
   {
-    replace (l₁ ++ (x and y) :: l₂) with ((l₁++ [x and y]) ++ l₂).
-    2: { rewrite -app_assoc. reflexivity. }
-    rewrite take_app.
+    eapply cast_proof_mg_hyps.
+    { replace (l₁ ++ (x and y) :: l₂) with ((l₁++ [x and y]) ++ l₂).
+      2: { rewrite -app_assoc. reflexivity. }
+      rewrite take_app.
+      reflexivity.
+    }
     assert (well_formed x).
     {
       abstract (
@@ -4982,9 +4985,13 @@ Proof.
     ).
   }
   {
-    replace (l₁ ++ (x and y) :: l₂) with ((l₁++ [x and y]) ++ l₂).
-    2: { rewrite -app_assoc. reflexivity. }
-    rewrite take_app.
+    eapply cast_proof_mg_hyps.
+    {
+      replace (l₁ ++ (x and y) :: l₂) with ((l₁++ [x and y]) ++ l₂).
+      2: { rewrite -app_assoc. reflexivity. }
+      rewrite take_app.
+      reflexivity.
+    }
     assert (well_formed x).
     {
       abstract (
@@ -5020,7 +5027,12 @@ Program Canonical Structure MyGoal_destructAnd_indifferent_S {Σ : Signature}
         (l₁ l₂ : list Pattern)
         (a b g : Pattern)
   := TacticProperty1 P (@MyGoal_destructAnd Σ Γ g l₁ l₂ a b) _.
-Next Obligation. solve_indif. intros. unfold liftP. solve_indif. intros. unfold liftP. solve_indif. apply H. Qed.
+Next Obligation.
+  solve_indif.
+  intros. unfold liftP. solve_indif.
+  intros. unfold liftP. solve_indif.
+  intros. unfold liftP. apply H.
+Qed.
 
 Tactic Notation "mgDestructAnd" constr(n) :=
   eapply cast_proof_mg_hyps;
@@ -5047,6 +5059,18 @@ Proof.
   mgDestructAnd 1.
   mgDestructAnd 0.
   mgExactn 2.
+Defined.
+
+Local Program Canonical Structure ex_mgDestructAnd_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b p q : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+        (wfp : well_formed p)
+        (wfq : well_formed q)
+  := ProofProperty0 P (@ex_mgDestructAnd Σ Γ a b p q wfa wfb wfp wfq) _.
+Next Obligation.
+  intros. apply liftP_impl_P. solve_indif.
 Qed.
 
 Section FOL_helpers.

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -2491,6 +2491,17 @@ Section FOL_helpers.
     apply prf_weaken_conclusion_iter_under_implication_meta; assumption.
   Defined.
 
+  Program Canonical Structure MyGoal_weakenConclusion_under_first_implication_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+            (l : list Pattern) (ϕ₁ ϕ₂ : Pattern)
+            (wfl : wf l) (wfϕ₁ : well_formed ϕ₁) (wfϕ₂ : well_formed ϕ₂)
+    := TacticProperty1 P (@MyGoal_weakenConclusion_under_first_implication Γ l ϕ₁ ϕ₂) _.
+  Next Obligation.
+    intros. simpl. 
+    unfold MyGoal_weakenConclusion_under_first_implication.
+    case_match. unfold liftP. solve_indif. apply H.
+  Qed.
+
   Lemma prf_weaken_conclusion_iter_under_implication_iter Γ l₁ l₂ g g':
     wf l₁ ->
     wf l₂ ->
@@ -2506,22 +2517,17 @@ Section FOL_helpers.
       eapply prf_weaken_conclusion_meta. all: auto 10.
   Defined.
 
-  Lemma prf_weaken_conclusion_iter_under_implication_iter_indifferent
-        P Γ l₁ l₂ g g'
-        (wfl₁ : wf l₁)
-        (wfl₂ : wf l₂)
-        (wfg : well_formed g)
-        (wfg' : well_formed g') :
-    indifferent_to_prop P ->
-    P _ _ (@prf_weaken_conclusion_iter_under_implication_iter Γ l₁ l₂ g g' wfl₁ wfl₂ wfg wfg') = false.
-  Proof.
-    intros Hp.
-    induction l₁; simpl.
-    - rewrite prf_weaken_conclusion_iter_under_implication_indifferent; auto.
-    - case_match.
-      rewrite prf_weaken_conclusion_meta_indifferent; auto.
+  Program Canonical Structure prf_weaken_conclusion_iter_under_implication_iter_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+            (l₁ l₂ : list Pattern) (ϕ₁ ϕ₂ : Pattern)
+            (wfl₁ : wf l₁) (wfl₂ : wf l₂) (wfϕ₁ : well_formed ϕ₁) (wfϕ₂ : well_formed ϕ₂)
+    := ProofProperty0 P (@prf_weaken_conclusion_iter_under_implication_iter Γ l₁ l₂ ϕ₁ ϕ₂ wfl₁ wfl₂ wfϕ₁ wfϕ₂) _.
+  Next Obligation.
+    intros.
+    induction l₁.
+    - solve_indif.
+    - simpl. case_match. solve_indif. apply IHl₁.
   Qed.
-
 
   Lemma prf_weaken_conclusion_iter_under_implication_iter_meta Γ l₁ l₂ g g':
     wf l₁ ->
@@ -2537,6 +2543,12 @@ Section FOL_helpers.
     all: auto 10.
   Defined.
 
+  Program Canonical Structure prf_weaken_conclusion_iter_under_implication_iter_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+            (l₁ l₂ : list Pattern) (ϕ₁ ϕ₂ : Pattern)
+            (wfl₁ : wf l₁) (wfl₂ : wf l₂) (wfϕ₁ : well_formed ϕ₁) (wfϕ₂ : well_formed ϕ₂)
+    := ProofProperty1 P (@prf_weaken_conclusion_iter_under_implication_iter_meta Γ l₁ l₂ ϕ₁ ϕ₂ wfl₁ wfl₂ wfϕ₁ wfϕ₂) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma MyGoal_weakenConclusion Γ l₁ l₂ g g':
     @mkMyGoal Σ Γ (l₁ ++ (g ---> g') :: l₂) g ->
@@ -2589,21 +2601,11 @@ Section FOL_helpers.
     exact wfl₁gg'l₂.
   Defined.
 
-  Lemma MyGoal_weakenConclusion_indifferent
-        P Γ l₁ l₂ g g' pf :
-    indifferent_to_prop P ->
-    (forall wf3 wf4, P _ _ (pf wf3 wf4) = false) ->
-    (forall wf1 wf2, P _ _ (@MyGoal_weakenConclusion Γ l₁ l₂ g g' pf wf1 wf2) = false).
-  Proof.
-    intros Hp Huse. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    simpl.
-    unfold MyGoal_weakenConclusion.
-    unfold prf_weaken_conclusion_iter_under_implication_iter_meta.
-    intros wf1 wf2.
-    rewrite Hmp. simpl. rewrite Huse. simpl.
-    rewrite prf_weaken_conclusion_iter_under_implication_iter_indifferent; auto.
-  Qed.
-
+  Program Canonical Structure MyGoal_weakenConclusion_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+            (l₁ l₂ : list Pattern) (ϕ₁ ϕ₂ : Pattern)
+    := TacticProperty1 P (@MyGoal_weakenConclusion Γ l₁ l₂ ϕ₁ ϕ₂) _.
+  Next Obligation. intros. unfold MyGoal_weakenConclusion. unfold liftP. solve_indif. apply H. Qed.
 
 End FOL_helpers.
 
@@ -2652,6 +2654,16 @@ Section FOL_helpers.
     mgExactn 4.
   Defined.
 
+  Program Canonical Structure Constructive_dilemma_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+            (p q r s : Pattern)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+            (wfr : well_formed r)
+            (wfs : well_formed s)
+    := ProofProperty0 P (@Constructive_dilemma Γ p q r s wfp wfq wfr wfs) _.
+  Next Obligation. intros. apply liftP_impl_P. solve_indif. Qed.
+
   Lemma prf_add_assumption Γ a b :
     well_formed a ->
     well_formed b ->
@@ -2663,6 +2675,14 @@ Section FOL_helpers.
     4: apply P1. all: auto.
   Defined.
 
+  Program Canonical Structure prf_add_assumption_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (p q : Pattern)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+    := ProofProperty1 P (@prf_add_assumption Γ p q wfp wfq) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
   Lemma prf_impl_distr_meta Γ a b c:
     well_formed a ->
     well_formed b ->
@@ -2673,6 +2693,15 @@ Section FOL_helpers.
     intros wfa wfb wfc H.
     eapply Modus_ponens. 4: apply P2. all: auto.
   Defined.
+
+  Program Canonical Structure prf_impl_distr_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (p q r : Pattern)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+            (wfr : well_formed r)
+    := ProofProperty1 P (@prf_impl_distr_meta Γ p q r wfp wfq wfr) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma prf_add_lemma_under_implication Γ l g h:
     wf l ->
@@ -2697,6 +2726,22 @@ Section FOL_helpers.
       eapply prf_weaken_conclusion_meta_meta.
       4: apply H3. all: auto 10.
   Defined.
+
+
+  Program Canonical Structure prf_add_lemma_under_implication_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l : list Pattern)
+            (p q : Pattern)
+            (wfl : wf l)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+    := ProofProperty0 P (@prf_add_lemma_under_implication Γ l p q wfl wfp wfq) _.
+  Next Obligation.
+    intros.
+    induction l.
+    - solve_indif.
+    - simpl. case_match. solve_indif. apply IHl.
+  Qed.
 
   Lemma prf_add_lemma_under_implication_meta Γ l g h:
     wf l ->

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -3539,14 +3539,17 @@ Tactic Notation "mgClear" constr(n) :=
     [(rewrite -Heql1; rewrite -Heql2; reflexivity)|];
     simpl in Heql1; simpl in Heql2;
     let a := fresh "a" in
-    destruct l2 as [|a l2];[congruence|];
+    let Hd := fresh "Hd" in
+    destruct l2 as [|a l2''] eqn:Hd in *|-;[congruence|];
+    eapply cast_proof_mg_hyps;
+    [(rewrite -> Hd at 1; reflexivity)|];
     let Heqa := fresh "Heqa" in
     let Heql2' := fresh "Heql2'" in
     inversion Heql2 as [[Heqa Heql2']]; clear Heql2;
     apply myGoal_clear_hyp;
     eapply cast_proof_mg_hyps;
     [(try(rewrite -> Heql1 at 1); try(rewrite -> Heql2' at 1); reflexivity)|];
-    clear Heql2' Heqa l2 a Heql1 l1;
+    clear Hd Heql2' Heqa l2 l2'' a Heql1 l1;
     eapply cast_proof_mg_hyps;[rewrite {1}[_ ++ _]/=; reflexivity|]
   end.
 

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -155,19 +155,6 @@ Ltac toMyGoal :=
 
 Ltac fromMyGoal := unfold of_MyGoal; simpl.
 
-
-(*
-Structure myNWFProofProperty
-          {Σ : Signature} (P : proofbpred) (Γ : Theory) (l : list Pattern) (g : Pattern)
-  := MyNWFProofProperty
-       { mnpp_proof : of_MyGoal (mkMyGoal Γ l g) ;
-         mnpp_proof_property :
-         forall wfg wfl,
-           P Γ (foldr patt_imp g l)
-             (mnpp_proof wfg wfl) = false ;
-       }.
-*)
-
 Class IndifCast {Σ : Signature} (P : proofbpred)
   := mkIndifCast { cast_indif : indifferent_to_cast P }.
 
@@ -226,6 +213,20 @@ Structure proofProperty2 {Σ : Signature} (P : proofbpred) (Γ : Theory) (ϕ ψ�
     }.
 
 Arguments ProofProperty2 [Σ] P [Γ ϕ ψ₁ ψ₂] pp2_proof%function_scope _%function_scope.
+
+Structure proofProperty3 {Σ : Signature} (P : proofbpred) (Γ : Theory) (ϕ ψ₁ ψ₂ ψ₃ : Pattern)
+  := ProofProperty3 {
+      pp3_proof : Γ ⊢ ψ₁ -> Γ ⊢ ψ₂ -> Γ ⊢ ψ₃ -> Γ ⊢ ϕ;
+      pp3_proof_property :
+      forall (pf₁ : Γ ⊢ ψ₁) (pf₂ : Γ ⊢ ψ₂) (pf₃ : Γ ⊢ ψ₃),
+        P Γ ψ₁ pf₁ = false ->
+        P Γ ψ₂ pf₂ = false ->
+        P Γ ψ₃ pf₃ = false ->
+        P Γ ϕ (pp3_proof pf₁ pf₂ pf₃) = false;
+    }.
+
+Arguments ProofProperty3 [Σ] P [Γ ϕ ψ₁ ψ₂ ψ₃] pp3_proof%function_scope _%function_scope.
+
 
 Ltac2 mutable solve_indif () := ltac1:(repeat (
                         eapply pp0_proof_property
@@ -4101,11 +4102,6 @@ Section FOL_helpers.
     := ProofProperty2 P (@exd Γ a b p q c wfa wfb wfp wfq wfc) _.
   Next Obligation. solve_indif; assumption. Qed.
 
-  Local Example exd_indifferent Γ (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} a b p q c
-
-    P _ _ (@exd Γ a b p q c wfa wfb wfp wfq wfc
-  
-  
   Lemma conclusion_anyway_meta Γ A B:
     well_formed A ->
     well_formed B ->
@@ -4127,6 +4123,14 @@ Section FOL_helpers.
     auto.
     Unshelve. all: auto.
   Defined.
+
+  Program Canonical Structure conclusion_anyway_meta_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty2 P (@conclusion_anyway_meta Γ a b wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
     
   Lemma pf_or_elim Γ A B C :
     well_formed A ->
@@ -4149,6 +4153,15 @@ Section FOL_helpers.
     { eapply Modus_ponens. 4: apply H2. all: auto. }
     eapply conclusion_anyway_meta. 4: apply H3. all: auto.
   Defined.
+
+  Program Canonical Structure pf_or_elim_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b c : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+        (wfc : well_formed c)
+    := ProofProperty3 P (@pf_or_elim Γ a b c wfa wfb wfc) _.
+  Next Obligation. solve_indif; assumption. Qed.
   
   Lemma pf_iff_split Γ A B:
     well_formed A ->
@@ -4162,25 +4175,13 @@ Section FOL_helpers.
     apply conj_intro_meta; auto.
   Defined.
 
-  Lemma pf_iff_split_indifferent
-        P Γ A B
-        (wfA : well_formed A)
-        (wfB : well_formed B)
-        (AimpB : Γ ⊢ A ---> B)
-        (BimpA : Γ ⊢ B ---> A):
-    indifferent_to_prop P ->
-    P _ _ AimpB = false ->
-    P _ _ BimpA = false ->
-    P _ _ (@pf_iff_split Γ A B wfA wfB AimpB BimpA) = false.
-  Proof.
-    intros [Hp1 [Hp2 [Hp3 Hp4]]] H1 H2.
-    unfold pf_iff_split. unfold conj_intro_meta. rewrite Hp4. rewrite H2. simpl.
-    rewrite Hp4. rewrite H1. simpl.
-    unfold conj_intro.
-    rewrite !(Hp1,Hp2,Hp3,Hp4).
-    reflexivity.
-  Qed.
-
+  Program Canonical Structure pf_iff_split_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty2 P (@pf_iff_split Γ a b wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
   
   Lemma pf_iff_proj1 Γ A B:
     well_formed A ->
@@ -4192,23 +4193,13 @@ Section FOL_helpers.
     apply pf_conj_elim_l_meta in H; auto.
   Defined.
 
-  (* TODO: use indifference proofs for subproofs *)
-  Lemma pf_iff_proj1_indifferent
-        P Γ A B
-        (wfA : well_formed A)
-        (wfB : well_formed B)
-        (AiffB : Γ ⊢ A <---> B):
-    indifferent_to_prop P ->
-    P _ _ AiffB = false ->
-    P _ _ (@pf_iff_proj1 Γ A B wfA wfB AiffB) = false.
-  Proof.
-    intros [Hp1 [Hp2 [Hp3 Hmp]]] H.
-    unfold pf_iff_proj1. unfold pf_conj_elim_l_meta.
-    rewrite Hmp. rewrite H. simpl.
-    unfold pf_conj_elim_l.
-    rewrite !(Hp1,Hp2,Hp3,Hmp).
-    reflexivity.
-  Qed.
+  Program Canonical Structure pf_iff_proj1_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty1 P (@pf_iff_proj1 Γ a b wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma pf_iff_proj2 Γ A B:
     well_formed A ->
@@ -4220,24 +4211,13 @@ Section FOL_helpers.
     apply pf_conj_elim_r_meta in H; auto.
   Defined.
 
-  (* TODO: use indifference proofs for subproofs *)
-  Lemma pf_iff_proj2_indifferent
-        P Γ A B
-        (wfA : well_formed A)
-        (wfB : well_formed B)
-        (AiffB : Γ ⊢ A <---> B):
-    indifferent_to_prop P ->
-    P _ _ AiffB = false ->
-    P _ _ (@pf_iff_proj2 Γ A B wfA wfB AiffB) = false.
-  Proof.
-    intros [Hp1 [Hp2 [Hp3 Hmp]]] H.
-    unfold pf_iff_proj2. unfold pf_conj_elim_r_meta.
-    rewrite Hmp. rewrite H. simpl.
-    unfold pf_conj_elim_r.
-    rewrite !(Hp1,Hp2,Hp3,Hmp).
-    reflexivity.
-  Qed.
-
+  Program Canonical Structure pf_iff_proj2_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty1 P (@pf_iff_proj2 Γ a b wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma pf_iff_iff Γ A B:
     well_formed A ->
@@ -4256,6 +4236,13 @@ Section FOL_helpers.
     apply pf_iff_split; auto.
   Defined.
 
+  Program Canonical Structure pf_iff_equiv_refl_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a : Pattern)
+        (wfa : well_formed a)
+    := ProofProperty0 P (@pf_iff_equiv_refl Γ a wfa) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
   Lemma pf_iff_equiv_sym Γ A B :
     well_formed A ->
     well_formed B ->
@@ -4269,6 +4256,14 @@ Section FOL_helpers.
     apply pf_iff_proj1 in H1; auto.
     apply pf_iff_split; auto.
   Defined.
+
+  Program Canonical Structure pf_iff_equiv_sym_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty1 P (@pf_iff_equiv_sym Γ a b wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma pf_iff_equiv_trans Γ A B C :
     well_formed A ->
@@ -4285,30 +4280,14 @@ Section FOL_helpers.
     split; eauto.
   Defined.
 
-  Lemma pf_iff_equiv_trans_indifferent
-        P Γ A B C
-        (wfA : well_formed A)
-        (wfB : well_formed B)
-        (wfC : well_formed C)
-        (AiffB : Γ ⊢ A <---> B)
-        (BiffC : Γ ⊢ B <---> C):
-    indifferent_to_prop P ->
-    P _ _ AiffB = false ->
-    P _ _ BiffC = false ->
-    P _ _ (@pf_iff_equiv_trans Γ A B C wfA wfB wfC AiffB BiffC) = false.
-  Proof.
-    intros Hp H1 H2. unfold pf_iff_equiv_trans. simpl.
-    pose proof (Hp' := Hp). unfold indifferent_to_prop in Hp'.
-    destruct Hp' as [Hp1 [Hp2 [Hp3 Hp4]]].
-    rewrite pf_iff_split_indifferent; auto;
-      rewrite syllogism_intro_indifferent; auto; try apply A_impl_A_indifferent; auto;
-      rewrite syllogism_intro_indifferent; auto.
-    + apply pf_iff_proj1_indifferent; auto.
-    + apply pf_iff_proj1_indifferent; auto.
-    + apply pf_iff_proj2_indifferent; auto.
-    + apply pf_iff_proj2_indifferent; auto.
-  Qed.
-
+  Program Canonical Structure pf_iff_equiv_trans_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b c : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+        (wfc : well_formed c)
+    := ProofProperty2 P (@pf_iff_equiv_trans Γ a b c wfa wfb wfc) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma prf_conclusion Γ a b:
     well_formed a ->
@@ -4318,6 +4297,14 @@ Section FOL_helpers.
   Proof.
     intros WFa WFb H. eapply Modus_ponens. 4: apply P1. all: auto.
   Defined.
+
+  Program Canonical Structure prf_conclusion_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty1 P (@prf_conclusion Γ a b wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
     
   Lemma prf_prop_bott_iff Γ AC:
     Γ ⊢ ((subst_ctx AC patt_bott) <---> patt_bott).
@@ -4585,8 +4572,6 @@ Section FOL_helpers.
         apply Ex_quan; auto.
   Defined.
   
-
-
   Lemma and_of_negated_iff_not_impl Γ p1 p2:
     well_formed p1 ->
     well_formed p2 ->
@@ -4621,6 +4606,14 @@ Section FOL_helpers.
       mgExactn 4.
   Defined.
 
+  Program Canonical Structure and_of_negated_iff_not_impl_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty0 P (@and_of_negated_iff_not_impl Γ a b wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
   Lemma and_impl_2 Γ p1 p2:
     well_formed p1 ->
     well_formed p2 ->
@@ -4654,6 +4647,14 @@ Section FOL_helpers.
       mgExactn 4.
   Defined.
 
+  Program Canonical Structure and_impl_2_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty0 P (@and_impl_2 Γ a b wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
   Lemma conj_intro_meta_partial (Γ : Theory) (A B : Pattern) :
     well_formed A → well_formed B → Γ ⊢ A → Γ ⊢ B ---> (A and B).
   Proof.
@@ -4664,6 +4665,14 @@ Section FOL_helpers.
     Unshelve. all: auto.
   Defined.
 
+  Program Canonical Structure conj_intro_meta_partial_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty1 P (@conj_intro_meta_partial Γ a b wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
   Lemma and_impl_patt (A B C : Pattern) Γ:
     well_formed A → well_formed B → well_formed C →
     Γ ⊢ A -> Γ ⊢ ((A and B) ---> C) -> Γ ⊢ (B ---> C).
@@ -4673,12 +4682,29 @@ Section FOL_helpers.
     apply conj_intro_meta_partial; auto.
   Defined.
 
+  Program Canonical Structure and_impl_patt_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b c : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+        (wfc : well_formed c)
+    := ProofProperty2 P (@and_impl_patt a b c Γ wfa wfb wfc) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
   Lemma conj_intro2 (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ (A ---> (B ---> (B and A))).
   Proof.
     intros WFA WFB. eapply reorder_meta; auto.
     apply conj_intro; auto.
   Defined.
+
+  Program Canonical Structure conj_intro2_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty0 P (@conj_intro2 Γ a b wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma conj_intro_meta_partial2 (Γ : Theory) (A B : Pattern):
     well_formed A → well_formed B → Γ ⊢ A → Γ ⊢ B ---> (B and A).

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -6484,6 +6484,15 @@ Proof.
   fromMyGoal. intros _ _. apply conj_intro; auto.
 Defined.
 
+Program Canonical Structure lhs_to_and_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b c : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+        (wfc : well_formed c)
+  := ProofProperty1 P (@lhs_to_and Σ Γ a b c wfa wfb wfc) _.
+Next Obligation. solve_indif; assumption. Qed.
+
 Lemma lhs_from_and {Σ : Signature} Γ a b c:
   well_formed a ->
   well_formed b ->
@@ -6509,6 +6518,19 @@ Proof.
   mgExactn 3.
 Defined.
 
+Program Canonical Structure lhs_from_and_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b c : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+        (wfc : well_formed c)
+  := ProofProperty1 P (@lhs_from_and Σ Γ a b c wfa wfb wfc) _.
+Next Obligation.
+  solve_indif. simpl.
+  apply (@liftP_impl_P' Σ P Γ _ c [a and b] _ ltac:(reflexivity)).
+  solve_indif; auto; unfold liftP; solve_indif.
+Qed.
+
 Lemma prf_conj_split {Σ : Signature} Γ a b l:
   well_formed a ->
   well_formed b ->
@@ -6533,6 +6555,21 @@ Proof.
     fromMyGoal. intros _ _. apply IHl.
 Defined.
 
+Program Canonical Structure prf_conj_split_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b : Pattern)
+        (wfl : wf l)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+  := ProofProperty0 P (@prf_conj_split Σ Γ a b l wfa wfb wfl) _.
+Next Obligation.
+  intros.
+  induction l.
+  - solve_indif.
+  - simpl. case_match. solve_indif. apply IHl.
+Qed.
+
 Lemma prf_conj_split_meta {Σ : Signature} Γ a b l:
   well_formed a ->
   well_formed b ->
@@ -6542,6 +6579,16 @@ Lemma prf_conj_split_meta {Σ : Signature} Γ a b l:
 Proof.
   intros. eapply Modus_ponens. 4: apply prf_conj_split. all: auto 10.
 Defined.
+
+Program Canonical Structure prf_conj_split_meta_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b : Pattern)
+        (wfl : wf l)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+  := ProofProperty1 P (@prf_conj_split_meta Σ Γ a b l wfa wfb wfl) _.
+Next Obligation. solve_indif; assumption. Qed.
 
 Lemma prf_conj_split_meta_meta {Σ : Signature} Γ a b l:
   well_formed a ->
@@ -6553,6 +6600,16 @@ Lemma prf_conj_split_meta_meta {Σ : Signature} Γ a b l:
 Proof.
   intros. eapply Modus_ponens. 4: apply prf_conj_split_meta. all: auto 10.
 Defined.
+
+Program Canonical Structure prf_conj_split_meta_meta_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b : Pattern)
+        (wfl : wf l)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+  := ProofProperty2 P (@prf_conj_split_meta_meta Σ Γ a b l wfa wfb wfl) _.
+Next Obligation. solve_indif; assumption. Qed.
 
 Lemma MyGoal_splitAnd {Σ : Signature} Γ a b l:
   @mkMyGoal Σ Γ l a ->
@@ -6573,6 +6630,13 @@ Proof.
   { abstract (wf_auto2). }
 Defined.
 
+Program Canonical Structure MyGoal_splitAnd_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b : Pattern)
+  := TacticProperty2 P (@MyGoal_splitAnd Σ Γ a b l) _.
+Next Obligation. unfold liftP. solve_indif. apply H. apply H0. Qed.
+
 Ltac mgSplitAnd := apply MyGoal_splitAnd.
 
 Local Lemma ex_mgSplitAnd {Σ : Signature} Γ a b c:
@@ -6588,7 +6652,18 @@ Proof.
   mgSplitAnd.
   - mgExactn 0.
   - mgExactn 1.
-Qed.
+Defined.
+
+Local Program Canonical Structure ex_mgSplitAnd_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b c : Pattern)
+        (wfl : wf l)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+        (wfc : well_formed c)
+  := ProofProperty0 P (@ex_mgSplitAnd Σ Γ a b c wfa wfb wfc) _.
+Next Obligation. solve_indif; assumption. Qed.
 
 (* Hints *)
 #[export]
@@ -6630,6 +6705,46 @@ Proof.
       mgApplyMeta IHl in 0. unfold patt_iff at 1. mgDestructAnd 0.
       mgExactn 1.
 Defined.
+
+Program Canonical Structure prf_local_goals_equiv_impl_full_equiv_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b : Pattern)
+        (wfl : wf l)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+  := ProofProperty0 P (@prf_local_goals_equiv_impl_full_equiv Σ Γ a b l wfa wfb wfl) _.
+Next Obligation.
+  intros.
+  induction l.
+  - solve_indif.
+  - simpl. case_match. solve_indif.
+    + apply liftP_impl_P.
+      apply (@tp1_1_tactic_property Σ P Γ _ _ (_) _ _ (@MyGoal_applyMeta_indifferent_S Σ P _ _ Γ _ (((a0 ---> foldr (@patt_imp Σ) (a <---> b) l) --->
+        a0 ---> foldr (@patt_imp Σ) a l ---> foldr (@patt_imp Σ) b l)) ((a0 --->
+        foldr (@patt_imp Σ) (a <---> b) l --->
+        foldr (@patt_imp Σ) a l ---> foldr (@patt_imp Σ) b l)))).
+      { solve_indif. }
+      solve_indif.
+      intros.
+      simpl.
+      apply (@tp1_1_tactic_property Σ P Γ _ _ _ _ _ (@MyGoal_applyMetaIn_indifferent_S Σ P _ _ Γ [] [] _ _ _)).
+      { apply IHl. }
+      solve_indif.
+    + apply liftP_impl_P.
+      apply (@tp1_1_tactic_property Σ P Γ _ _ (_) _ _ (@MyGoal_applyMeta_indifferent_S Σ P _ _ Γ _ (((a0 ---> foldr (@patt_imp Σ) (a <---> b) l) --->
+        a0 ---> foldr (@patt_imp Σ) b l ---> foldr (@patt_imp Σ) a l)) ((a0 --->
+        foldr (@patt_imp Σ) (a <---> b) l --->
+        foldr (@patt_imp Σ) b l ---> foldr (@patt_imp Σ) a l)))).
+      { solve_indif. }
+      solve_indif.
+      intros.
+      simpl.
+      apply (@tp1_1_tactic_property Σ P Γ _ _ _ _ _ (@MyGoal_applyMetaIn_indifferent_S Σ P _ _ Γ [] [] _ _ _)).
+      { apply IHl. }
+      solve_indif.
+Qed.
+
 
 Lemma prf_local_goals_equiv_impl_full_equiv_meta {Σ : Signature} Γ g₁ g₂ l:
   well_formed g₁ ->

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -2973,7 +2973,9 @@ Tactic Notation "mgClear" constr(n) :=
     let l2 := fresh "l2" in
     let Heql1 := fresh "Heql1" in
     let Heql2 := fresh "Heql2" in
-    rewrite -[l](take_drop n);
+    eapply cast_proof_mg_hyps;
+    [(
+      rewrite -[l](take_drop n); reflexivity)|];
     remember (take n l) as l1 eqn:Heql1;
     remember (drop n l) as l2 eqn:Heql2;
     simpl in Heql1; simpl in Heql2;

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -5635,6 +5635,16 @@ Section FOL_helpers.
     all: unfold patt_and, patt_or, patt_not; auto 10.
   Defined.
 
+  Program Canonical Structure impl_and_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+          (a b p q : Pattern)
+          (wfa : well_formed a)
+          (wfb : well_formed b)
+          (wfp : well_formed p)
+          (wfq : well_formed q)
+    := ProofProperty2 P (@impl_and Γ a b p q wfa wfb wfp wfq) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
   Lemma and_drop A B C Γ:
     well_formed A -> well_formed B -> well_formed C ->
     Γ ⊢ ((A and B) ---> C)
@@ -5650,6 +5660,15 @@ Section FOL_helpers.
     eapply Modus_ponens in H3. 4: exact H2. auto.
     Unshelve. all: unfold patt_and, patt_or, patt_not; auto 20.
   Defined.
+
+  Program Canonical Structure and_drop_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+          (a b p : Pattern)
+          (wfa : well_formed a)
+          (wfb : well_formed b)
+          (wfp : well_formed p)
+    := ProofProperty1 P (@and_drop a b p Γ wfa wfb wfp) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
 
   Lemma universal_generalization Γ ϕ x:
@@ -5910,96 +5929,15 @@ Section FOL_helpers.
           mgExactn 2.
   Defined.
 
-  Lemma prf_equiv_of_impl_of_equiv_indifferent
-        P Γ a b a' b'
-        (wfa : well_formed a = true)
-        (wfb : well_formed b = true)
-        (wfa' : well_formed a' = true)
-        (wfb' : well_formed b' = true)
-        (aiffa' : Γ ⊢ a <---> a')
-        (biffb' : Γ ⊢ b <---> b'):
-    indifferent_to_prop P ->
-    indifferent_to_cast P ->
-    P _ _ aiffa' = false ->
-    P _ _ biffb' = false ->
-    P _ _ (@prf_equiv_of_impl_of_equiv Γ a b a' b' wfa wfb wfa' wfb' aiffa' biffb') = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    intros Hc H1 H2.
-    unfold prf_equiv_of_impl_of_equiv.
-    rewrite pf_iff_equiv_trans_indifferent; auto.
-    - rewrite conj_intro_meta_indifferent; auto.
-      + pose proof (Htmp := MyGoal_intro_indifferent). simpl in Htmp.
-        specialize (Htmp P Γ []). simpl in Htmp. rewrite Htmp; clear Htmp; auto.
-        intros wf3 wf4.
-        pose proof (Htmp := MyGoal_intro_indifferent).
-        specialize (Htmp P Γ [a ---> b]). simpl in Htmp. rewrite Htmp; clear Htmp; auto.
-        intros wf5 wf6.
-        rewrite (@MyGoal_add_indifferent Σ P Γ [a ---> b; a]); auto.
-        { rewrite pf_conj_elim_l_meta_indifferent; auto. }
-        intros wf7 wf8.
-        rewrite cast_proof_mg_hyps_indifferent; [assumption|].
-        rewrite MyGoal_weakenConclusion_indifferent;[assumption|idtac|reflexivity].
-        intros wf9 wf10.
-        rewrite cast_proof_mg_hyps_indifferent;[assumption|].        
-        rewrite MyGoal_weakenConclusion_indifferent;[assumption|idtac|reflexivity].
-        intros wf11 wf12.
-        rewrite cast_proof_mg_hyps_indifferent;[assumption|].
-        rewrite MyGoal_exactn_indifferent;[assumption|reflexivity].
-      + pose proof (Htmp := MyGoal_intro_indifferent).
-        specialize (Htmp P Γ []). simpl in Htmp. rewrite Htmp; clear Htmp; auto.
-        intros wf3 wf4.
-        pose proof (Htmp := MyGoal_intro_indifferent).
-        specialize (Htmp P Γ [a ---> b']). simpl in Htmp. rewrite Htmp; clear Htmp; auto.
-        intros wf5 wf6.
-        rewrite (@MyGoal_add_indifferent Σ P Γ [a ---> b'; a]); auto.
-        { rewrite pf_conj_elim_r_meta_indifferent; auto. }
-        intros wf7 wf8.
-        rewrite cast_proof_mg_hyps_indifferent;[assumption|].
-        rewrite MyGoal_weakenConclusion_indifferent;[assumption|idtac|reflexivity].
-        intros wf9 wf10.
-        rewrite cast_proof_mg_hyps_indifferent;[assumption|].
-        rewrite MyGoal_weakenConclusion_indifferent;[assumption|idtac|reflexivity].      
-        intros wf11 wf12.
-        rewrite cast_proof_mg_hyps_indifferent;[assumption|].
-        rewrite MyGoal_exactn_indifferent;[assumption|reflexivity].
-    - rewrite conj_intro_meta_indifferent; auto.
-      + pose proof (Htmp := MyGoal_intro_indifferent).
-        specialize (Htmp P Γ []). simpl in Htmp. rewrite Htmp; clear Htmp; auto.
-        intros wf3 wf4.
-        pose proof (Htmp := MyGoal_intro_indifferent).
-        specialize (Htmp P Γ [a ---> b']). simpl in Htmp. rewrite Htmp; clear Htmp; auto.
-        intros wf5 wf6.
-        rewrite (@MyGoal_add_indifferent Σ P Γ [a ---> b'; a']); auto.
-        { rewrite pf_conj_elim_r_meta_indifferent; auto. }
-        intros wf7 wf8.
-        rewrite cast_proof_mg_hyps_indifferent;[assumption|].
-        rewrite MyGoal_weakenConclusion_indifferent;[assumption|idtac|reflexivity].
-        intros wf9 wf10.
-        rewrite cast_proof_mg_hyps_indifferent;[assumption|].
-        rewrite MyGoal_weakenConclusion_indifferent;[assumption|idtac|reflexivity].
-        intros wf11 wf12.
-        rewrite cast_proof_mg_hyps_indifferent;[assumption|].
-        rewrite MyGoal_exactn_indifferent;[assumption|reflexivity].
-      + pose proof (Htmp := MyGoal_intro_indifferent).
-        specialize (Htmp P Γ []). simpl in Htmp. rewrite Htmp; clear Htmp; auto.
-        intros wf3 wf4.
-        pose proof (Htmp := MyGoal_intro_indifferent).
-        specialize (Htmp P Γ [a' ---> b']). simpl in Htmp. rewrite Htmp; clear Htmp; auto.
-        intros wf5 wf6.
-        rewrite (@MyGoal_add_indifferent Σ P Γ [a' ---> b'; a]); auto.
-        { rewrite pf_conj_elim_l_meta_indifferent; auto. }
-        intros wf7 wf8.
-        rewrite cast_proof_mg_hyps_indifferent;[assumption|].
-        rewrite MyGoal_weakenConclusion_indifferent;[assumption|idtac|reflexivity].
-        intros wf9 wf10.
-        rewrite cast_proof_mg_hyps_indifferent;[assumption|].        
-        rewrite MyGoal_weakenConclusion_indifferent;[assumption|idtac|reflexivity].      
-        intros wf11 wf12.
-        rewrite cast_proof_mg_hyps_indifferent;[assumption|].
-        rewrite MyGoal_exactn_indifferent;[assumption|reflexivity].
-  Qed.
-
+  Program Canonical Structure prf_equiv_of_impl_of_equiv_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+          (a b p q : Pattern)
+          (wfa : well_formed a)
+          (wfb : well_formed b)
+          (wfp : well_formed p)
+          (wfq : well_formed q)
+    := ProofProperty2 P (@prf_equiv_of_impl_of_equiv Γ a b p q wfa wfb wfp wfq) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma pf_evar_open_free_evar_subst_equiv_sides Γ x n ϕ p q E:
     x <> E ->
@@ -6317,18 +6255,10 @@ Section FOL_helpers.
       subst pf₁. subst pf₂.
       specialize (Hind1 Hsub Hpf). specialize (Hind2 Hsub Hpf).
       pose proof (indifferent_to_prop_uses_svar_subst).
-      rewrite pf_iff_equiv_trans_indifferent; auto.
-      + rewrite conj_intro_meta_indifferent; auto.
-        { simpl. rewrite Hind2. reflexivity. }
-        { simpl. rewrite Hind2. reflexivity. }
-      + rewrite conj_intro_meta_indifferent; auto.
-        { simpl. rewrite Hind1. reflexivity. }
-        { simpl. rewrite Hind1. reflexivity. }
+      solve_indif; auto.
     - clear. intros Γ p q wfp wfq EvS SvS' E ϕ₁ ϕ₂ wfψ pf pf₁ pf₂.
       intros Heq1 Hind1 Heq2 Hind2 Hsub Hpf.
-      rewrite prf_equiv_of_impl_of_equiv_indifferent; subst; auto.
-      { apply indifferent_to_prop_uses_svar_subst. }
-      { apply indifferent_to_cast_uses_svar_subst. }
+      solve_indif; subst; auto.
     - clear. intros Γ p q wfp wfq EvS SvS' E ϕ' x frx wfψ pf IH IH' IH1 IH2 IH3 IH4 IH3' IH4'.
       intros.
       inversion Heq; subst; clear Heq.
@@ -6336,68 +6266,20 @@ Section FOL_helpers.
       inversion Heq1; subst; clear Heq1.
 
       specialize (Hind ltac:(assumption) ltac:(assumption)).
-      rewrite pf_iff_split_indifferent.
-      { apply indifferent_to_prop_uses_svar_subst. }
-      + unfold pf_impl_ex_free_evar_subst_twice.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        unfold strip_exists_quantify_l.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        simpl.
-        unfold pf_evar_open_free_evar_subst_equiv_sides.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        rewrite Hind.
-        reflexivity.
-      + unfold pf_impl_ex_free_evar_subst_twice.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        unfold strip_exists_quantify_l.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        simpl.
-        unfold pf_evar_open_free_evar_subst_equiv_sides.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        rewrite Hind.
-        reflexivity.
-      + reflexivity.
+      solve_indif; auto.
     - clear. intros Γ p q wfp wfq EvS SvS' E ϕ' X frX wfψ pf Ih IH' IH1 IH2.
       intros.
       unfold pf_iff_mu_remove_svar_quantify_svar_open.
       rewrite indifferent_to_cast_uses_svar_subst.
       inversion Heq; subst; clear Heq.
       specialize (Hind ltac:(assumption) ltac:(assumption)).
-      rewrite pf_iff_split_indifferent.
-      { apply indifferent_to_prop_uses_svar_subst. }
-      3: { reflexivity. }
-      + unfold mu_monotone.
-        simpl.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        rewrite syllogism_intro_indifferent.
-        { apply indifferent_to_prop_uses_svar_subst. }
-        simpl.
-        { case_match. clear -frX e H. set_solver.
-          unfold pf_iff_free_evar_subst_svar_open_to_bsvar_subst_free_evar_subst.
-          rewrite indifferent_to_cast_uses_svar_subst.
-          rewrite Hind. reflexivity.
-        }
-        2: reflexivity.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        simpl. reflexivity.
-      + unfold mu_monotone.
-        simpl.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        rewrite syllogism_intro_indifferent.
-        { apply indifferent_to_prop_uses_svar_subst. }
-        simpl.
-        { case_match. clear -frX e H. set_solver.
-          unfold pf_iff_free_evar_subst_svar_open_to_bsvar_subst_free_evar_subst.
-          rewrite indifferent_to_cast_uses_svar_subst.
-          rewrite Hind. reflexivity.
-        }
-        2: reflexivity.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        rewrite indifferent_to_cast_uses_svar_subst.
-        simpl. reflexivity.
+      solve_indif; auto.
+      + Unset Printing Implicit. case_match.
+        { clear -frX e H. set_solver. }
+        solve_indif. apply Hind.
+      + case_match.
+        { clear -frX e H. set_solver. }
+        solve_indif. apply Hind.
     - assumption.
     - assumption.
   Qed.

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -268,6 +268,12 @@ Next Obligation.
   rewrite Hmp. apply orb_false_intro. exact H1. exact H2.
 Qed.
 
+Program Canonical Structure cast_proof_indifferent_S
+        {Σ : Signature} (P : proofbpred) {Pic : IndifCast P} (Γ : Theory)
+        (ϕ ψ : Pattern) (e : ψ = ϕ)
+  := ProofProperty1 P (@cast_proof Σ Γ ϕ ψ e) _.
+Next Obligation. intros. destruct Pic as [hic]. rewrite hic. exact H. Qed.
+
 
 Section FOL_helpers.
 
@@ -3087,13 +3093,13 @@ Section FOL_helpers.
   Defined.
 
   Program Canonical Structure prf_disj_elim_indifferent_S
-            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
             (p q r : Pattern)
             (wfp : well_formed p)
             (wfq : well_formed q)
             (wfr : well_formed r)
     := ProofProperty0 P (@prf_disj_elim Γ p q r wfp wfq wfr) _.
-  Next Obligation. intros. unfold prf_disj_elim.  solve_indif.  , Qed.
+  Next Obligation. solve_indif. Qed.
 
 
   Lemma prf_disj_elim_meta Γ p q r:

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -3594,16 +3594,36 @@ Section FOL_helpers.
       unfold wf in wfl. simpl in wfl. apply andb_prop in wfl. destruct wfl as [wfa wfl].
       specialize (IHl wfl).
       simpl. simpl in IHl.
-      rewrite -> tofold. rewrite !consume.
+      eapply cast_proof.
+      { rewrite -> tofold at 1. repeat rewrite -> consume. reflexivity. }
       eapply prf_weaken_conclusion_iter_meta_meta.
       4: { apply IHl. }
       all: auto 10.
-      rewrite consume.
-      replace ((([] ++ [x ---> a ---> foldr patt_imp g l]) ++ [a]) ++ [x])
-        with ([x ---> a ---> foldr patt_imp g l] ++ [a;x] ++ []) by reflexivity.
+      eapply cast_proof.
+      {
+        rewrite consume.
+        replace ((([] ++ [x ---> a ---> foldr patt_imp g l]) ++ [a]) ++ [x])
+          with ([x ---> a ---> foldr patt_imp g l] ++ [a;x] ++ []) by reflexivity.
+        reflexivity.
+      }
       apply prf_reorder_iter_meta; auto 10.
       simpl. auto 10.
   Defined.
+
+  Program Canonical Structure reorder_last_to_head_indifferent_S
+    (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+    (l : list Pattern)
+    (g x : Pattern)
+    (wfl : wf l)
+    (wfg : well_formed g)
+    (wfx : well_formed x)
+    := ProofProperty0 P (@reorder_last_to_head Γ g x l wfl wfg wfx) _.
+  Next Obligation.
+    intros. induction l.
+    - solve_indif.
+    - simpl. case_match. solve_indif. apply IHl.
+  Qed.
+
 
   Lemma reorder_last_to_head_meta Γ g x l:
     wf l ->
@@ -3617,6 +3637,16 @@ Section FOL_helpers.
     4: apply reorder_last_to_head.
     all: auto 10.
   Defined.
+
+  Program Canonical Structure reorder_last_to_head_meta_indifferent_S
+    (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+    (l : list Pattern)
+    (g x : Pattern)
+    (wfl : wf l)
+    (wfg : well_formed g)
+    (wfx : well_formed x)
+    := ProofProperty1 P (@reorder_last_to_head_meta Γ g x l wfl wfg wfx) _.
+  Next Obligation. solve_indif; assumption. Qed.
   
   (* Iterated modus ponens.
      For l = [x₁, ..., xₙ], it says that
@@ -3633,8 +3663,12 @@ Section FOL_helpers.
     - pose proof (wfal := wfl).
       unfold wf in wfl. simpl in wfl. apply andb_prop in wfl. destruct wfl as [wfa wfl].
       specialize (IHl wfl).
-      simpl. rewrite foldr_app. simpl. rewrite consume. simpl.
-      rewrite foldr_app in IHl. simpl in IHl.
+      simpl.
+      eapply cast_proof.
+      { rewrite foldr_app. simpl. rewrite consume. simpl. reflexivity. }
+      eapply cast_proof in IHl.
+      2: { rewrite foldr_app. reflexivity. }
+      simpl in IHl.
       eapply prf_weaken_conclusion_meta_meta.
       4: { apply reorder_last_to_head; auto. }
       all: auto 10.
@@ -3642,6 +3676,19 @@ Section FOL_helpers.
   Defined.
   
 
+  Program Canonical Structure modus_ponens_iter_indifferent_S
+    (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+    (l : list Pattern)
+    (g : Pattern)
+    (wfl : wf l)
+    (wfg : well_formed g)
+    := ProofProperty0 P (@modus_ponens_iter Γ l g wfl wfg) _.
+  Next Obligation.
+    intros.
+    induction l.
+    - solve_indif.
+    - simpl. case_match. solve_indif.
+  Qed.
   
   Lemma and_impl Γ p q r:
     well_formed p ->
@@ -3670,6 +3717,16 @@ Section FOL_helpers.
     mgApply 5. mgExactn 2.
   Defined.
 
+  Program Canonical Structure and_impl_indifferent_S
+    (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+    (p q r : Pattern)
+    (wfp : well_formed p)
+    (wfq : well_formed q)
+    (wfr : well_formed r)
+    := ProofProperty0 P (@and_impl Γ p q r wfp wfq wfr) _.
+  Next Obligation.
+    intros. apply liftP_impl_P. solve_indif.
+  Qed.
   
   Lemma and_impl' Γ p q r:
     well_formed p ->
@@ -3702,6 +3759,16 @@ Section FOL_helpers.
     mgApply 4. mgExactn 3.
   Defined.
   
+  Program Canonical Structure and_impl'_indifferent_S
+    (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+    (p q r : Pattern)
+    (wfp : well_formed p)
+    (wfq : well_formed q)
+    (wfr : well_formed r)
+    := ProofProperty0 P (@and_impl' Γ p q r wfp wfq wfr) _.
+  Next Obligation.
+    intros. apply liftP_impl_P. solve_indif.
+  Qed.
 
   Lemma prf_disj_elim_iter Γ l p q r:
     wf l ->
@@ -3739,6 +3806,21 @@ Section FOL_helpers.
       mgExactn 5.
   Defined.
 
+  Program Canonical Structure prf_disj_elim_iter_indifferent_S
+    (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+    (l : list Pattern)
+    (p q r : Pattern)
+    (wfl : wf l)
+    (wfp : well_formed p)
+    (wfq : well_formed q)
+    (wfr : well_formed r)
+    := ProofProperty0 P (@prf_disj_elim_iter Γ l p q r wfl wfp wfq wfr) _.
+  Next Obligation.
+    intros.
+    induction l.
+    - solve_indif.
+    - apply liftP_impl_P. simpl. case_match. solve_indif. apply IHl.
+  Qed.
   
   Lemma prf_disj_elim_iter_2 Γ l₁ l₂ p q r:
     wf l₁ ->
@@ -3762,48 +3844,101 @@ Section FOL_helpers.
 
       simpl. (* We need to move 'a' to the beginning of l₁; then we can apply IHl₂. *)
       (* Or we can swap p and a (move a to the end of l_1) *)
-      remember (foldr patt_imp r (l₁ ++ p :: a :: l₂)) as A.
-      remember (foldr patt_imp r (l₁ ++ q :: a :: l₂)) as B.
-      remember (foldr patt_imp r (l₁ ++ (p or q) :: a :: l₂)) as C.
-      rewrite -> tofold. rewrite consume. rewrite consume. rewrite [_ ++ [B]]/=.
-      subst.
+      remember (foldr patt_imp r (l₁ ++ p :: a :: l₂)) as A in |-.
+      remember (foldr patt_imp r (l₁ ++ q :: a :: l₂)) as B in |-.
+      remember (foldr patt_imp r (l₁ ++ (p or q) :: a :: l₂)) as C in |-.
+      eapply cast_proof.
+      { rewrite -HeqA. rewrite -HeqB. rewrite -HeqC. reflexivity. }
+      eapply cast_proof.
+      {
+        rewrite -> tofold at 1. rewrite consume. rewrite consume. rewrite [_ ++ [B]]/=.
+        rewrite -> HeqA at 1. rewrite -> HeqB at 1. rewrite -> HeqC at 1.
+        reflexivity.
+      }
       eapply prf_weaken_conclusion_iter_meta_meta.
       4: {
-        replace (l₁ ++ (p or q) :: a :: l₂) with (l₁ ++ [p or q; a] ++ l₂) by reflexivity.
+        eapply cast_proof.
+        {
+          replace (l₁ ++ (p or q) :: a :: l₂) with (l₁ ++ [p or q; a] ++ l₂) by reflexivity.
+          reflexivity.
+        }
         apply prf_reorder_iter; auto.
       }
       all: auto 10.
       simpl.
-      rewrite -> tofold. repeat rewrite consume. rewrite [_ ++ [_]]/=.
-      
 
+      eapply cast_proof.
+      { 
+        rewrite -> tofold at 1. repeat rewrite consume. rewrite [_ ++ [_]]/=.
 
       replace
         ([foldr patt_imp r (l₁ ++ p :: a :: l₂); foldr patt_imp r (l₁ ++ q :: a :: l₂)])
         with
           ([foldr patt_imp r (l₁ ++ p :: a :: l₂)] ++ (foldr patt_imp r (l₁ ++ q :: a :: l₂))::[])
         by reflexivity.
+        reflexivity.
+      }
 
       eapply prf_strenghten_premise_iter_meta_meta with (h := foldr patt_imp r (l₁ ++ a :: q :: l₂)).
       6: { apply prf_reorder_iter; auto. }
       all: auto 10.
 
-      replace
-        ([foldr patt_imp r (l₁ ++ p :: a :: l₂)] ++ [foldr patt_imp r (l₁ ++ a :: q :: l₂)])
-        with
+      eapply cast_proof.
+      {
+        replace
+          ([foldr patt_imp r (l₁ ++ p :: a :: l₂)] ++ [foldr patt_imp r (l₁ ++ a :: q :: l₂)])
+          with
           ([] ++ ((foldr patt_imp r (l₁ ++ p :: a :: l₂))::[foldr patt_imp r (l₁ ++ a :: q :: l₂)]))
-        by reflexivity.
+          by reflexivity.
+        reflexivity.
+     }
 
       eapply prf_strenghten_premise_iter_meta_meta with (h := (foldr patt_imp r (l₁ ++ a :: p :: l₂))).
       6: {  apply prf_reorder_iter; auto. }
       all: auto 10.
 
       simpl.
-      replace (l₁ ++ a :: p :: l₂) with ((l₁ ++ [a]) ++ [p] ++ l₂) by (rewrite <- app_assoc; reflexivity).
-      replace (l₁ ++ a :: q :: l₂) with ((l₁ ++ [a]) ++ [q] ++ l₂) by (rewrite <- app_assoc; reflexivity).
-      replace (l₁ ++ a :: (p or q) :: l₂) with ((l₁ ++ [a]) ++ [p or q] ++ l₂) by (rewrite <- app_assoc; reflexivity).
+      eapply cast_proof.
+      {
+        replace (l₁ ++ a :: p :: l₂) with ((l₁ ++ [a]) ++ [p] ++ l₂) by (rewrite <- app_assoc; reflexivity).
+        replace (l₁ ++ a :: q :: l₂) with ((l₁ ++ [a]) ++ [q] ++ l₂) by (rewrite <- app_assoc; reflexivity).
+        replace (l₁ ++ a :: (p or q) :: l₂) with ((l₁ ++ [a]) ++ [p or q] ++ l₂) by (rewrite <- app_assoc; reflexivity).
+        reflexivity.
+      }
       apply IHl₂; auto.
-Defined.
+  Defined.
+
+  Program Canonical Structure prf_disj_elim_iter_2_indifferent_S
+    (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+    (l₁ l₂ : list Pattern)
+    (p q r : Pattern)
+    (wfl₁ : wf l₁)
+    (wfl₂ : wf l₂)
+    (wfp : well_formed p)
+    (wfq : well_formed q)
+    (wfr : well_formed r)
+    := ProofProperty0 P (@prf_disj_elim_iter_2 Γ l₁ l₂ p q r wfl₁ wfl₂ wfp wfq wfr) _.
+  Next Obligation.
+    intros.
+    move: l₁ wfl₁.
+    induction l₂; intros l₁ wfl₁.
+    - simpl. solve_indif.
+    - apply liftP_impl_P. simpl. case_match. unfold liftP. solve_indif.
+      simpl.
+
+      eapply (@pp2_proof_property Σ P Γ (foldr (@patt_imp Σ) r (l₁ ++ p :: a :: l₂) --->
+                                               foldr (@patt_imp Σ) r (l₁ ++ q :: a :: l₂) --->
+                                               foldr (@patt_imp Σ) r (l₁ ++ a :: (p or q) :: l₂))).
+     { solve_indif. }
+     solve_indif.        
+      simpl.
+      eapply (@pp2_proof_property Σ P Γ (foldr (@patt_imp Σ) r (l₁ ++ p :: a :: l₂) --->
+                                               foldr (@patt_imp Σ) r (l₁ ++ a :: q :: l₂) --->
+                                               foldr (@patt_imp Σ) r (l₁ ++ a :: (p or q) :: l₂))).
+      { solve_indif. }
+      solve_indif.
+      apply IHl₂.
+  Qed.
 
   Lemma prf_disj_elim_iter_2_meta Γ l₁ l₂ p q r:
     wf l₁ ->
@@ -3822,6 +3957,19 @@ Defined.
     4: { apply prf_disj_elim_iter_2; auto. }
     all: auto 10.
   Defined.
+
+
+  Program Canonical Structure prf_disj_elim_iter_2_meta_indifferent_S
+    (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+    (l₁ l₂ : list Pattern)
+    (p q r : Pattern)
+    (wfl₁ : wf l₁)
+    (wfl₂ : wf l₂)
+    (wfp : well_formed p)
+    (wfq : well_formed q)
+    (wfr : well_formed r)
+    := ProofProperty1 P (@prf_disj_elim_iter_2_meta Γ l₁ l₂ p q r wfl₁ wfl₂ wfp wfq wfr) _.
+  Next Obligation. solve_indif; assumption. Qed.
   
   Lemma prf_disj_elim_iter_2_meta_meta Γ l₁ l₂ p q r:
     wf l₁ ->
@@ -3838,6 +3986,19 @@ Defined.
     4: { apply prf_disj_elim_iter_2_meta; auto. }
     all: auto 10.
   Defined.
+
+
+  Program Canonical Structure prf_disj_elim_iter_2_meta_meta_indifferent_S
+    (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+    (l₁ l₂ : list Pattern)
+    (p q r : Pattern)
+    (wfl₁ : wf l₁)
+    (wfl₂ : wf l₂)
+    (wfp : well_formed p)
+    (wfq : well_formed q)
+    (wfr : well_formed r)
+    := ProofProperty2 P (@prf_disj_elim_iter_2_meta_meta Γ l₁ l₂ p q r wfl₁ wfl₂ wfp wfq wfr) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma MyGoal_disj_elim Γ l₁ l₂ p q r:
     @mkMyGoal Σ Γ (l₁ ++ [p] ++ l₂) r ->
@@ -3875,20 +4036,15 @@ Defined.
     }
   Defined.
 
+
+  Program Canonical Structure MyGoal_disj_elim_indifferent_S
+    (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+    (l₁ l₂ : list Pattern)
+    (p q r : Pattern)
+    := TacticProperty2 P (@MyGoal_disj_elim Γ l₁ l₂ p q r) _.
+  Next Obligation. intros. unfold liftP. solve_indif. apply H. apply H0. Qed.
+
 End FOL_helpers.
-
-Check @MyGoal_disj_elim.
-
-Lemma MyGoal_disj_elim_indifferent {Σ : Signature}
-      P Γ l₁ l₂ p q r pf₁ pf₂:
-  indifferent_to_prop P ->
-  (forall wf3 wf4, P _ _ (pf₁ wf3 wf4) = false) ->
-  (forall wf3 wf4, P _ _ (pf₂ wf3 wf4) = false) ->
-  (forall wf1 wf2, P _ _ (@MyGoal_disj_elim Σ Γ l₁ l₂ p q r pf₁ pf₂ wf1 wf2) = false).
-Proof.
-  intros H
-Qed.
-
 
 Tactic Notation "mgDestructOr" constr(n) :=
   match goal with
@@ -3929,7 +4085,25 @@ Section FOL_helpers.
     { wf_auto2. } 
     repeat mgIntro.
     mgDestructOr 1.
-  Abort.
+    - fromMyGoal. intros _ _. apply H.
+    - fromMyGoal. intros _ _. apply H0.
+  Defined.
+
+
+  Local Program Canonical Structure exd_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b p q c : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+        (wfp : well_formed p)
+        (wfq : well_formed q)
+        (wfc : well_formed c)
+    := ProofProperty2 P (@exd Γ a b p q c wfa wfb wfp wfq wfc) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
+  Local Example exd_indifferent Γ (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} a b p q c
+
+    P _ _ (@exd Γ a b p q c wfa wfb wfp wfq wfc
   
   
   Lemma conclusion_anyway_meta Γ A B:

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -6118,7 +6118,9 @@ Ltac2 mgRewrite (hiff : constr) (atn : int) :=
     lazy_match! goal with
     | [ |- of_MyGoal (@mkMyGoal ?sgm ?g ?l ?p)]
       => let hr : HeatResult := heat atn a p in
-         Message.print (Message.of_constr (hr.(ctx_pat)));
+         if ml_debug_rewrite then
+           Message.print (Message.of_constr (hr.(ctx_pat)));
+         else () ;
          let heq := Control.hyp (hr.(equality)) in
          let pc := (hr.(pc)) in
          eapply (@cast_proof_mg_goal _ $g) >

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -6378,59 +6378,24 @@ Section FOL_helpers.
       reflexivity.
     - clear. intros Γ p q wfp wfq EvS SvS E wfψ pf Hmfψ Hpf.
       reflexivity.
-    - clear. intros Γ p q wfp wfq EvS SvS E ϕ₁ ϕ₂ wfψ pf pf₁ pf₂.
-      intros Heq1 Hind1 Heq2 Hind2 Hmfψ Hpf.
-      simpl in Hmfψ. apply andb_prop in Hmfψ. destruct Hmfψ as [Hmfϕ₁ Hmfϕ₂].
-      subst pf₁. subst pf₂.
-      specialize (Hind1 Hmfϕ₂ Hpf). specialize (Hind2 Hmfϕ₁ Hpf).
-      pose proof (indifferent_to_prop_uses_kt).
-      rewrite pf_iff_equiv_trans_indifferent; auto.
-      + rewrite conj_intro_meta_indifferent; auto.
-        { simpl. rewrite Hind2. reflexivity. }
-        { simpl. rewrite Hind2. reflexivity. }
-      + rewrite conj_intro_meta_indifferent; auto.
-        { simpl. rewrite Hind1. reflexivity. }
-        { simpl. rewrite Hind1. reflexivity. }
-    - clear. intros Γ p q wfp wfq EvS SvS E ϕ₁ ϕ₂ wfψ pf pf₁ pf₂.
-      intros Heq1 Hind1 Heq2 Hind2 Hmf Hpf.
-      simpl in Hmf. apply andb_prop in Hmf as [Hmf1 Hmf2].
-      rewrite prf_equiv_of_impl_of_equiv_indifferent; subst; auto.
-      { apply indifferent_to_prop_uses_kt. }
-      { apply indifferent_to_cast_uses_kt. }
-    - clear. intros Γ p q wfp wfq EvS SvS E ϕ' x frx wfψ pf IH IH' IH1 IH2 IH3 IH4 IH3' IH4'.
-      intros.
+    - intros. subst. simpl in * |-. destruct_and!.
+      solve_indif; fold (@uses_kt Σ Γ0); auto.
+    - intros. subst. simpl in * |-. destruct_and!.
+      solve_indif; auto.
+    - intros.
       inversion Heq; subst; clear Heq.
       inversion Heq0; subst; clear Heq0.
       inversion Heq1; subst; clear Heq1.
-      simpl in H.
-
-      feed specialize Hind.
-      { apply mu_free_evar_open. assumption. }
-      { assumption. }
-
-      rewrite pf_iff_split_indifferent.
-      { apply indifferent_to_prop_uses_kt. }
-      + unfold pf_impl_ex_free_evar_subst_twice.
-        rewrite indifferent_to_cast_uses_kt.
-        unfold strip_exists_quantify_l.
-        rewrite indifferent_to_cast_uses_kt.
-        simpl.
-        unfold pf_evar_open_free_evar_subst_equiv_sides.
-        rewrite indifferent_to_cast_uses_kt.
-        rewrite Hind.
-        reflexivity.
-      + unfold pf_impl_ex_free_evar_subst_twice.
-        rewrite indifferent_to_cast_uses_kt.
-        unfold strip_exists_quantify_l.
-        rewrite indifferent_to_cast_uses_kt.
-        simpl.
-        unfold pf_evar_open_free_evar_subst_equiv_sides.
-        rewrite indifferent_to_cast_uses_kt.
-        rewrite Hind.
-        reflexivity.
-      + reflexivity.
-    - clear. intros Γ p q wfp wfq EvS SvS E ϕ' X frX wfψ pf Ih IH' IH1 IH2.
-      intros. simpl in H. congruence.
+      simpl in * |-.
+      solve_indif; fold (@uses_kt Σ Γ0); auto; apply Hind.
+      + apply mu_free_evar_open; assumption.
+      + assumption.
+      + apply mu_free_evar_open; assumption.
+      + assumption.
+    - intros.
+      subst.
+      simpl in * |-.
+      congruence.
     - assumption.
     - assumption.
   Qed.

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -3101,7 +3101,6 @@ Section FOL_helpers.
     := ProofProperty0 P (@prf_disj_elim Γ p q r wfp wfq wfr) _.
   Next Obligation. solve_indif. Qed.
 
-
   Lemma prf_disj_elim_meta Γ p q r:
     well_formed p ->
     well_formed q ->
@@ -3113,6 +3112,15 @@ Section FOL_helpers.
     all: auto 10.
   Defined.
   
+
+  Program Canonical Structure prf_disj_elim_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+            (p q r : Pattern)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+            (wfr : well_formed r)
+    := ProofProperty1 P (@prf_disj_elim_meta Γ p q r wfp wfq wfr) _.
+  Next Obligation. solve_indif; assumption. Qed.
   
   Lemma prf_disj_elim_meta_meta Γ p q r:
     well_formed p ->
@@ -3126,6 +3134,16 @@ Section FOL_helpers.
     all: auto.
   Defined.
 
+  Program Canonical Structure prf_disj_elim_meta_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+            (p q r : Pattern)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+            (wfr : well_formed r)
+    := ProofProperty2 P (@prf_disj_elim_meta_meta Γ p q r wfp wfq wfr) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
+  (* TODO: add an indifference canonical structure for this (ProofProperty3) *)
   Lemma prf_disj_elim_meta_meta_meta Γ p q r:
     well_formed p ->
     well_formed q ->
@@ -3175,18 +3193,17 @@ Section FOL_helpers.
   Defined.
 
   Lemma prf_add_proved_to_assumptions_indifferent
-    P Γ l h g
+    P {Pip : IndifProp P} Γ l h g
     (wfl : wf l)
     (wfg : well_formed g)
     (wfh : well_formed h)
     (pfh : Γ ⊢ h):
-    indifferent_to_prop P ->
     P _ _ pfh = false ->
     P _ _ (@prf_add_proved_to_assumptions Γ l h g wfl wfh wfg pfh) = false.
   Proof.
-    intros Hp H. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
+    intros H. pose proof (Hp' := Pip). destruct Hp' as [[Hp1 [Hp2 [Hp3 Hmp]]]].
     induction l.
-    - simpl. rewrite Hmp. rewrite H. simpl. apply modus_ponens_indifferent; assumption.
+    - solve_indif; assumption.
     - simpl.
       case_match.
       unfold eq_rec_r. unfold eq_rec. unfold eq_rect. unfold eq_sym. unfold tofold. unfold consume.
@@ -3198,18 +3215,28 @@ Section FOL_helpers.
       replace fa with (@erefl Pattern (((h ---> a ---> foldr patt_imp g l) ---> a ---> foldr patt_imp g l))).
       2: { apply UIP_dec. intros x y. apply Pattern_eqdec. }
       simpl.
+      solve_indif.
 
-      pose proof (Htmp := prf_strenghten_premise_iter_meta_meta_indifferent).
-      specialize (Htmp P Γ).
-      specialize (Htmp [] [] (a ---> h ---> foldr patt_imp g l) (h ---> a ---> foldr patt_imp g l)).
-      simpl in Htmp. rewrite Htmp; clear Htmp; auto.
-      { apply reorder_indifferent; assumption. }
-      rewrite prf_strenghten_premise_meta_meta_indifferent; auto.
-      { rewrite reorder_indifferent; auto. }
-      rewrite Hmp. rewrite H. simpl.
-      rewrite modus_ponens_indifferent; auto.
+      epose proof (Htmp :=
+                     pp2_proof_property (
+                         @prf_strenghten_premise_iter_meta_meta_indifferent_S
+                           Σ P Pip Γ [] [] (a ---> h ---> foldr patt_imp g l) (h ---> a ---> foldr patt_imp g l)
+                       _ _ _ _ _ _)
+                  ).
+      apply Htmp; clear Htmp.
+      solve_indif. solve_indif. assumption.
   Qed.
 
+  Program Canonical Structure prf_add_proved_to_assumptions_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l : list Pattern)
+            (p q : Pattern)
+            (wfl : wf l)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+    := ProofProperty1 P (@prf_add_proved_to_assumptions Γ l p q wfl wfp wfq) _.
+  Next Obligation.
+    intros. apply prf_add_proved_to_assumptions_indifferent; assumption. Qed.
 
   Lemma prf_add_proved_to_assumptions_meta Γ l a g:
     wf l ->
@@ -3225,6 +3252,16 @@ Section FOL_helpers.
     3: apply H0.
     all: auto.
   Defined.
+
+  Program Canonical Structure prf_add_proved_to_assumptions_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l : list Pattern)
+            (p q : Pattern)
+            (wfl : wf l)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+    := ProofProperty2 P (@prf_add_proved_to_assumptions_meta Γ l p q wfl wfp wfq) _.
+  Next Obligation. solve_indif; assumption. Qed.
   
   Lemma MyGoal_add Γ l g h:
     Γ ⊢ h ->

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -4716,6 +4716,14 @@ Section FOL_helpers.
     Unshelve. all: auto.
   Defined.
 
+  Program Canonical Structure conj_intro_meta_partial2_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty1 P (@conj_intro_meta_partial2 Γ a b wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
   Lemma and_impl_patt2  (A B C : Pattern) Γ:
     well_formed A → well_formed B → well_formed C →
     Γ ⊢ A -> Γ ⊢ ((B and A) ---> C) -> Γ ⊢ (B ---> C).
@@ -4724,6 +4732,15 @@ Section FOL_helpers.
     eapply syllogism_intro with (B0 := patt_and B A); auto.
     pose conj_intro_meta_partial2; auto.
   Defined.
+
+  Program Canonical Structure and_impl_patt2_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b c : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+        (wfc : well_formed c)
+    := ProofProperty2 P (@and_impl_patt2 a b c Γ wfa wfb wfc) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma patt_and_comm_meta (A B : Pattern) Γ:
     well_formed A → well_formed B
@@ -4735,6 +4752,14 @@ Section FOL_helpers.
     apply pf_conj_elim_l_meta in H as P2. all: auto.
     apply conj_intro_meta; auto.
   Defined.
+
+  Program Canonical Structure patt_and_comm_meta_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+    := ProofProperty1 P (@patt_and_comm_meta a b Γ wfa wfb) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma MyGoal_applyMeta Γ r r':
     Γ ⊢ (r' ---> r) ->
@@ -4751,6 +4776,15 @@ Section FOL_helpers.
     all: try assumption.
     1,2: pose proof (wfrr' := proved_impl_wf _ _ Himp); wf_auto2.
   Defined.
+
+  Program Canonical Structure MyGoal_applyMeta_indifferent_S
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b : Pattern)
+    := TacticProperty1_1 P (fun pf₁ => @MyGoal_applyMeta Γ a b pf₁ l) _.
+  Next Obligation.
+    intros. unfold liftP. solve_indif. assumption. apply H0.
+  Qed.
 
 End FOL_helpers.
 
@@ -4772,6 +4806,13 @@ Proof.
   all: abstract (wf_auto2).
 Defined.
 
+Program Canonical Structure MyGoal_left_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b : Pattern)
+  := TacticProperty1 P (@MyGoal_left Σ Γ l a b) _.
+Next Obligation. intros. unfold liftP. solve_indif. apply H. Qed.
+
 Lemma MyGoal_right {Σ : Signature} Γ l x y:
   @mkMyGoal Σ Γ l y ->
   @mkMyGoal Σ Γ l (patt_or x y).
@@ -4786,6 +4827,12 @@ Proof.
   all: abstract (wf_auto2).
 Defined.
 
+Program Canonical Structure MyGoal_right_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b : Pattern)
+  := TacticProperty1 P (@MyGoal_right Σ Γ l a b) _.
+Next Obligation. intros. unfold liftP. solve_indif. apply H. Qed.
 
 Ltac mgLeft := apply MyGoal_left.
 Ltac mgRight := apply MyGoal_right.
@@ -4838,6 +4885,13 @@ Proof.
  }
 Defined.
 
+Program Canonical Structure MyGoal_applyMetaIn_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l₁ l₂ : list Pattern)
+        (a b g : Pattern)
+  := TacticProperty1_1 P (fun pf => @MyGoal_applyMetaIn Σ Γ a b pf l₁ l₂ g) _.
+Next Obligation. intros. unfold liftP. solve_indif. apply H. apply H0. Qed.
+
 Tactic Notation "mgApplyMeta" uconstr(t) "in" constr(n) :=
   eapply cast_proof_mg_hyps;
   [(let hyps := fresh "hyps" in
@@ -4861,7 +4915,15 @@ Proof.
   mgIntro.
   mgApplyMeta (@disj_left_intro Σ Γ p q ltac:(auto) ltac:(auto)) in 0.
   mgExactn 0.
-Qed.
+Defined.
+
+Local Program Canonical Structure Private_ex_mgApplyMetaIn_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+  := ProofProperty0 P (@Private_ex_mgApplyMetaIn Σ Γ a b wfa wfb) _.
+Next Obligation. solve_indif. Qed.
 
 Lemma MyGoal_destructAnd {Σ : Signature} Γ g l₁ l₂ x y:
     @mkMyGoal Σ Γ (l₁ ++ x::y::l₂ ) g ->
@@ -4952,6 +5014,13 @@ Proof.
  apply myGoal_clear_hyp.  
  exact H.
 Defined.
+
+Program Canonical Structure MyGoal_destructAnd_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l₁ l₂ : list Pattern)
+        (a b g : Pattern)
+  := TacticProperty1 P (@MyGoal_destructAnd Σ Γ g l₁ l₂ a b) _.
+Next Obligation. solve_indif. intros. unfold liftP. solve_indif. intros. unfold liftP. solve_indif. apply H. Qed.
 
 Tactic Notation "mgDestructAnd" constr(n) :=
   eapply cast_proof_mg_hyps;

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -4067,12 +4067,16 @@ Proof.
 Defined.
 
 Tactic Notation "mgApplyMeta" uconstr(t) "in" constr(n) :=
-  let hyps := fresh "hyps" in
-  rewrite -[hyps in @mkMyGoal _ _ hyps _](firstn_skipn n);
-  rewrite [hyps in @mkMyGoal _ _ (hyps ++ _) _]/=;
-  rewrite [hyps in @mkMyGoal _ _ (_ ++ hyps) _]/=;
+  eapply cast_proof_mg_hyps;
+  [(let hyps := fresh "hyps" in
+    rewrite <- (firstn_skipn n);
+    rewrite [hyps in (hyps ++ _)]/=;
+    rewrite [hyps in (_ ++ hyps)]/=;
+    reflexivity
+   )|];
   eapply (@MyGoal_applyMetaIn _ _ _ _ t);
-            rewrite [hyps in @mkMyGoal _ _ hyps _]/app.
+  eapply cast_proof_mg_hyps;
+  [(rewrite /app; reflexivity)|].
 
 Local Example Private_ex_mgApplyMetaIn {Σ : Signature} Γ p q:
   well_formed p ->
@@ -6119,7 +6123,7 @@ Ltac2 mgRewrite (hiff : constr) (atn : int) :=
     | [ |- of_MyGoal (@mkMyGoal ?sgm ?g ?l ?p)]
       => let hr : HeatResult := heat atn a p in
          if ml_debug_rewrite then
-           Message.print (Message.of_constr (hr.(ctx_pat)));
+           Message.print (Message.of_constr (hr.(ctx_pat)))
          else () ;
          let heq := Control.hyp (hr.(equality)) in
          let pc := (hr.(pc)) in

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -6323,90 +6323,23 @@ Section FOL_helpers.
       intros Heq1 Hind1 Heq2 Hind2 Hsub Hpf.
       subst pf₁. subst pf₂.
       specialize (Hind1 Hsub Hpf). specialize (Hind2 Hsub Hpf).
-      pose proof (indifferent_to_prop_uses_ex_gen).
-      rewrite pf_iff_equiv_trans_indifferent; auto.
-      + rewrite conj_intro_meta_indifferent; auto.
-        { simpl. rewrite Hind2. reflexivity. }
-        { simpl. rewrite Hind2. reflexivity. }
-      + rewrite conj_intro_meta_indifferent; auto.
-        { simpl. rewrite Hind1. reflexivity. }
-        { simpl. rewrite Hind1. reflexivity. }
-    - clear. intros Γ p q wfp wfq EvS' SvS E ϕ₁ ϕ₂ wfψ pf pf₁ pf₂.
-      intros Heq1 Hind1 Heq2 Hind2 Hsub Hpf.
-      rewrite prf_equiv_of_impl_of_equiv_indifferent; subst; auto.
-      { apply indifferent_to_prop_uses_ex_gen. }
-      { apply indifferent_to_cast_uses_ex_gen. }
-    - clear. intros Γ p q wfp wfq EvS' SvS E ϕ' x frx wfψ pf IH IH' IH1 IH2 IH3 IH4 IH3' IH4'.
-      intros.
-      inversion Heq; subst; clear Heq.
-      inversion Heq0; subst; clear Heq0.
-      inversion Heq1; subst; clear Heq1.
-
-      specialize (Hind ltac:(assumption) ltac:(assumption)).
-      rewrite pf_iff_split_indifferent.
-      { apply indifferent_to_prop_uses_ex_gen. }
-      + unfold pf_impl_ex_free_evar_subst_twice.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        unfold strip_exists_quantify_l.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        simpl.
-        unfold pf_evar_open_free_evar_subst_equiv_sides.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        rewrite Hind.
-        case_match.
-        { clear -frx e H.  set_solver. }
-        reflexivity.
-      + unfold pf_impl_ex_free_evar_subst_twice.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        unfold strip_exists_quantify_l.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        simpl.
-        unfold pf_evar_open_free_evar_subst_equiv_sides.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        rewrite Hind.
-        case_match.
-        { clear -frx e H. set_solver. }
-        reflexivity.
-      + reflexivity.
+      solve_indif; auto.
     - clear. intros Γ p q wfp wfq EvS' SvS E ϕ' X frX wfψ pf Ih IH' IH1 IH2.
       intros.
       unfold pf_iff_mu_remove_svar_quantify_svar_open.
-      rewrite indifferent_to_cast_uses_ex_gen.
+      solve_indif; auto. rewrite -IH2. auto. rewrite -IH'. auto.
+    - clear. intros.
       inversion Heq; subst; clear Heq.
-      specialize (Hind ltac:(assumption) ltac:(assumption)).
-      rewrite pf_iff_split_indifferent.
-      { apply indifferent_to_prop_uses_ex_gen. }
-      3: { reflexivity. }
-      + unfold mu_monotone.
-        simpl.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        rewrite syllogism_intro_indifferent.
-        { apply indifferent_to_prop_uses_ex_gen. }
-        simpl.
-        { unfold pf_iff_free_evar_subst_svar_open_to_bsvar_subst_free_evar_subst.
-          rewrite indifferent_to_cast_uses_ex_gen.
-          rewrite Hind. reflexivity.
-        }
-        2: reflexivity.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        simpl. reflexivity.
-      + unfold mu_monotone.
-        simpl.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        rewrite syllogism_intro_indifferent.
-        { apply indifferent_to_prop_uses_ex_gen. }
-        simpl.
-        { unfold pf_iff_free_evar_subst_svar_open_to_bsvar_subst_free_evar_subst.
-          rewrite indifferent_to_cast_uses_ex_gen.
-          rewrite Hind. reflexivity.
-        }
-        2: reflexivity.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        rewrite indifferent_to_cast_uses_ex_gen.
-        simpl. reflexivity.
+      inversion Heq0; subst; clear Heq0.
+      inversion Heq1; subst; clear Heq1.
+      solve_indif; auto; simpl; case_match.
+      + exfalso. clear -frx H e. set_solver.
+      + rewrite !orbF.  solve_indif. auto.
+      + exfalso. clear -frx H e. set_solver.
+      + rewrite !orbF.  solve_indif. auto.
+    - clear. intros.
+      inversion Heq; subst; clear Heq.
+      solve_indif; auto.
     - assumption.
     - assumption.
   Qed.

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -5206,6 +5206,18 @@ Section FOL_helpers.
       + mgRight. fromMyGoal. intros _ _. assumption.
   Defined.
 
+  Program Canonical Structure or_of_equiv_is_equiv_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+          (a b p q : Pattern)
+          (wfa : well_formed a)
+          (wfb : well_formed b)
+          (wfp : well_formed p)
+          (wfq : well_formed q)
+    := ProofProperty2 P (@or_of_equiv_is_equiv Γ a b p q wfa wfb wfp wfq) _.
+  Next Obligation.
+    intros. solve_indif; assumption.
+  Qed.
+
 End FOL_helpers.
 
 
@@ -5243,6 +5255,16 @@ Section FOL_helpers.
       mgExactn 1.
   Defined.
 
+  Program Canonical Structure impl_iff_notp_or_q_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+          (p q : Pattern)
+          (wfp : well_formed p)
+          (wfq : well_formed q)
+    := ProofProperty0 P (@impl_iff_notp_or_q Γ p q wfp wfq) _.
+  Next Obligation.
+    intros. solve_indif.
+  Qed.
+
   Lemma p_and_notp_is_bot Γ p:
     well_formed p ->
     Γ ⊢ (⊥ <---> p and ! p).
@@ -5258,6 +5280,13 @@ Section FOL_helpers.
       mgAdd (@A_or_notA Σ Γ (! p) ltac:(auto)).
       mgExactn 0.
   Defined.
+
+  Program Canonical Structure p_and_notp_is_bot_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+          (p : Pattern)
+          (wfp : well_formed p)
+    := ProofProperty0 P (@p_and_notp_is_bot Γ p wfp) _.
+  Next Obligation. solve_indif. Qed.
 
   Lemma weird_lemma Γ A B L R:
     well_formed A ->
@@ -5290,6 +5319,20 @@ Section FOL_helpers.
       mgApply 0. mgExactn 3.
   Defined.
 
+  Program Canonical Structure weird_lemma_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+          (a b p q : Pattern)
+          (wfa : well_formed a)
+          (wfb : well_formed b)
+          (wfp : well_formed p)
+          (wfq : well_formed q)
+    := ProofProperty0 P (@weird_lemma Γ a b p q wfa wfb wfp wfq) _.
+  Next Obligation.
+    intros. unfold weird_lemma. simpl.
+    apply liftP_impl_P.
+    solve_indif. intros. unfold liftP. solve_indif.
+  Qed.
+
   Lemma weird_lemma_meta Γ A B L R:
     well_formed A ->
     well_formed B ->
@@ -5303,6 +5346,16 @@ Section FOL_helpers.
     4: apply weird_lemma.
     all: auto 10.
   Defined.
+
+  Program Canonical Structure weird_lemma_meta_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+          (a b p q : Pattern)
+          (wfa : well_formed a)
+          (wfb : well_formed b)
+          (wfp : well_formed p)
+          (wfq : well_formed q)
+    := ProofProperty1 P (@weird_lemma_meta Γ a b p q wfa wfb wfp wfq) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
 (*
   Theorem congruence_iff :
@@ -5412,6 +5465,16 @@ Section FOL_helpers.
     epose proof (@syllogism_intro Σ Γ _ _ _ _ _ _ H1 H2). auto.
     Unshelve. all: auto.
   Defined.
+
+  Program Canonical Structure imp_trans_mixed_meta_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+          (a b p q : Pattern)
+          (wfa : well_formed a)
+          (wfb : well_formed b)
+          (wfp : well_formed p)
+          (wfq : well_formed q)
+    := ProofProperty2 P (@imp_trans_mixed_meta Γ a b p q wfa wfb wfp wfq) _.
+  Next Obligation. solve_indif; assumption. Qed.
 (*
   Theorem congruence_iff_helper :
     forall sz ψ more, le (Syntax.size ψ) sz ->
@@ -5539,6 +5602,15 @@ Section FOL_helpers.
     Unshelve.
     all: unfold patt_and, patt_or, patt_not; auto 10.
   Defined.
+
+  Program Canonical Structure and_weaken_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+          (a b p : Pattern)
+          (wfa : well_formed a)
+          (wfb : well_formed b)
+          (wfp : well_formed p)
+    := ProofProperty1 P (@and_weaken a b p Γ wfa wfb wfp) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma impl_and Γ A B C D: 
     well_formed A -> well_formed B -> well_formed C -> well_formed D

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -2287,7 +2287,8 @@ Qed.
 
 Ltac simplLocalContext :=
   match goal with
-    | [ |- @of_MyGoal ?Sgm (@mkMyGoal ?Sgm ?Ctx ?l ?g) ] => rewrite {1}[l]/app
+    | [ |- @of_MyGoal ?Sgm (@mkMyGoal ?Sgm ?Ctx ?l ?g) ]
+      => eapply cast_proof_mg_hyps;[(rewrite {1}[l]/app; reflexivity)|]
   end.
 
 #[global]
@@ -6759,6 +6760,16 @@ Proof.
   all: auto.
 Defined.
 
+Program Canonical Structure prf_local_goals_equiv_impl_full_equiv_meta_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b : Pattern)
+        (wfl : wf l)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+  := ProofProperty1 P (@prf_local_goals_equiv_impl_full_equiv_meta Σ Γ a b l wfa wfb wfl) _.
+Next Obligation. solve_indif; assumption. Qed.
+
 Lemma prf_local_goals_equiv_impl_full_equiv_meta_proj1 {Σ : Signature} Γ g₁ g₂ l:
   well_formed g₁ ->
   well_formed g₂ ->
@@ -6775,6 +6786,16 @@ Proof.
   all: auto.
 Defined.
 
+Program Canonical Structure prf_local_goals_equiv_impl_full_equiv_meta_proj1_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b : Pattern)
+        (wfl : wf l)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+  := ProofProperty2 P (@prf_local_goals_equiv_impl_full_equiv_meta_proj1 Σ Γ a b l wfa wfb wfl) _.
+Next Obligation. solve_indif; assumption. Qed.
+
 Lemma prf_local_goals_equiv_impl_full_equiv_meta_proj2 {Σ : Signature} Γ g₁ g₂ l:
   well_formed g₁ ->
   well_formed g₂ ->
@@ -6790,6 +6811,16 @@ Proof.
   9: apply H1.
   all: auto.
 Defined.
+
+Program Canonical Structure prf_local_goals_equiv_impl_full_equiv_meta_proj2_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern)
+        (a b : Pattern)
+        (wfl : wf l)
+        (wfa : well_formed a)
+        (wfb : well_formed b)
+  := ProofProperty2 P (@prf_local_goals_equiv_impl_full_equiv_meta_proj2 Σ Γ a b l wfa wfb wfl) _.
+Next Obligation. solve_indif; assumption. Qed.
 
 Lemma prf_equiv_congruence_iter {Σ : Signature} (Γ : Theory) (p q : Pattern) (C : PatternCtx) l:
   PC_wf C ->
@@ -7059,6 +7090,12 @@ Proof.
   apply pf_iff_equiv_sym; assumption.
 Defined.
 
+Program Canonical Structure pf_iff_equiv_sym_nowf_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a b : Pattern)
+  := ProofProperty1 P (@pf_iff_equiv_sym_nowf Σ Γ a b) _.
+Next Obligation. solve_indif; assumption. Qed.
+
 Tactic Notation "mgRewrite" "->" constr(Hiff) "at" constr(atn) :=
   mgRewrite Hiff at atn.
 
@@ -7089,6 +7126,11 @@ Proof.
   { wf_auto2. }
 Defined.
 
+Program Canonical Structure top_holds_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+  := ProofProperty0 P (@top_holds Σ Γ) _.
+Next Obligation. solve_indif; assumption. Qed.
+
 Lemma phi_iff_phi_top {Σ : Signature} Γ ϕ :
   well_formed ϕ ->
   Γ ⊢ ϕ <---> (ϕ <---> Top).
@@ -7110,6 +7152,18 @@ Proof.
     fromMyGoal. intros _ _.
     apply top_holds.
 Defined.
+
+Program Canonical Structure phi_iff_phi_top_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a : Pattern)
+        (wfa : well_formed a)
+  := ProofProperty0 P (@phi_iff_phi_top Σ Γ a wfa) _.
+Next Obligation.
+  intros. apply liftP_impl_P. solve_indif. simpl.
+  intros. unfold liftP
+  solve_indif. simpl. solve_indif simpl.
+  apply liftP_impl_P. solve_indif.
+solve_indif. assumption. Qed.
 
 Lemma not_phi_iff_phi_bott {Σ : Signature} Γ ϕ :
   well_formed ϕ ->

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -894,6 +894,13 @@ Section FOL_helpers.
     all: auto.
   Defined.
 
+  Program Canonical Structure disj_right_intro_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b
+        (wfa : well_formed a = true)
+        (wfb : well_formed b = true)
+    := ProofProperty1 P (@disj_right_intro_meta Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
   Lemma disj_left_intro_meta (Γ : Theory) (A B : Pattern) :
     well_formed A ->
     well_formed B ->
@@ -908,6 +915,13 @@ Section FOL_helpers.
     all: auto.
   Defined.
 
+  Program Canonical Structure disj_left_intro_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b
+        (wfa : well_formed a = true)
+        (wfb : well_formed b = true)
+    := ProofProperty1 P (@disj_left_intro_meta Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
   Lemma not_not_elim (Γ : Theory) (A : Pattern) :
     well_formed A -> Γ ⊢ (!(!A) ---> A).
   Proof.
@@ -919,14 +933,13 @@ Section FOL_helpers.
   #[local] Hint Resolve not_not_elim : core.
 
   Lemma not_not_elim_indifferent
-        P Γ a (wfa : well_formed a = true):
-    indifferent_to_prop P ->
+        P {Pip : IndifProp P} Γ a (wfa : well_formed a = true):
     P _ _ (@not_not_elim Γ a wfa) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold not_not_elim. rewrite Hp3. reflexivity.
-  Qed.
+  Proof. solve_indif. Qed.
 
+  Canonical Structure not_not_elim_indifferent_S
+        P {Pip : IndifProp P} Γ a (wfa : well_formed a = true)
+    := ProofProperty0 P _ (@not_not_elim_indifferent P _ Γ _ wfa).
 
   Lemma not_not_elim_meta Γ A :
     well_formed A ->
@@ -941,6 +954,11 @@ Section FOL_helpers.
 
   #[local] Hint Resolve not_not_elim_meta : core.
 
+  Program Canonical Structure not_not_elim_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a (wfa : well_formed a = true)
+    := ProofProperty1 P (@not_not_elim_meta Γ a wfa) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
   Lemma double_neg_elim (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ (((!(!A)) ---> (!(!B))) ---> (A ---> B)).
   Proof.
@@ -951,6 +969,11 @@ Section FOL_helpers.
       Unshelve.
       all: auto.
   Defined.
+
+  Program Canonical Structure double_neg_elim_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty0 P (@double_neg_elim Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma double_neg_elim_meta (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> 

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -1499,28 +1499,26 @@ Defined. *)
     eapply Modus_ponens. 4: apply prf_weaken_conclusion_meta. 3: apply H0. all: auto.
   Defined.
 
+  Program Canonical Structure prf_weaken_conclusion_meta_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b c
+        (wfa : well_formed a = true) (wfb : well_formed b = true) (wfc : well_formed c = true)
+    := ProofProperty2 P (@prf_weaken_conclusion_meta_meta Γ a b c wfa wfb wfc) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
   Lemma prf_strenghten_premise Γ A A' B :
     well_formed A ->
     well_formed A' ->
     well_formed B ->
     Γ ⊢ ((A' ---> A) ---> ((A ---> B) ---> (A' ---> B))).
   Proof.
-    intros wfA wfA' wfB. auto.
+    intros wfA wfA' wfB. auto. (* TODO be more explicit here *)
   Defined.
 
-  Lemma prf_strenghten_premise_indifferent
-        P Γ A A' B
-        (wfA : well_formed A)
-        (wfA' : well_formed A')
-        (wfB : well_formed B):
-    indifferent_to_prop P ->
-    P _ _ (@prf_strenghten_premise Γ A A' B wfA wfA' wfB) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold prf_strenghten_premise.
-    rewrite syllogism_indifferent; auto.
-  Qed.
-
+  Program Canonical Structure prf_strenghten_premise_indifferent_S
+        P {Pip : IndifProp P} Γ a b c
+        (wfa : well_formed a = true) (wfb : well_formed b = true) (wfc : well_formed c = true)
+    := ProofProperty0 P (@prf_strenghten_premise Γ a b c wfa wfb wfc) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma prf_strenghten_premise_iter Γ l₁ l₂ h h' g :
     wf l₁ -> wf l₂ ->
@@ -1549,27 +1547,21 @@ Defined. *)
       eapply syllogism_intro. 5: subst; apply prf. all: subst; auto 10.
   Defined.
 
-  Lemma prf_strenghten_premise_iter_indifferent
-        P Γ l₁ l₂ h h' g
-        (wfl₁ : wf l₁)
-        (wfl₂ : wf l₂)
-        (wfh : well_formed h)
-        (wfh' : well_formed h')
-        (wfg : well_formed g):
-    indifferent_to_prop P ->
-    P _ _ (@prf_strenghten_premise_iter Γ l₁ l₂ h h' g wfl₁ wfl₂ wfh wfh' wfg) = false.
-  Proof.
-    intros Hp.
+  Program Canonical Structure prf_strenghten_premise_iter_indifferent_S
+        P {Pip : IndifProp P} Γ l₁ l₂ a b c
+        (wfl₁ : wf l₁) (wfl₂ : wf l₂)
+        (wfa : well_formed a = true) (wfb : well_formed b = true) (wfc : well_formed c = true)
+    := ProofProperty0 P (@prf_strenghten_premise_iter Γ l₁ l₂ a b c wfl₁ wfl₂ wfa wfb wfc) _.
+  Next Obligation.
+    intros.
     induction l₁.
-    - simpl. unfold prf_strenghten_premise. apply syllogism_indifferent; assumption.
+    - solve_indif.
     - simpl.
       case_match. simpl.
       unfold eq_rec_r. unfold eq_rec. unfold eq_rect. unfold eq_sym.
-      rewrite syllogism_intro_indifferent; auto.
-      apply prf_weaken_conclusion_indifferent; auto.
+      solve_indif. apply IHl₁.
   Qed.
 
-  
   Lemma prf_strenghten_premise_meta Γ A A' B :
     well_formed A ->
     well_formed A' ->
@@ -1582,20 +1574,11 @@ Defined. *)
     eapply Modus_ponens. 4: apply H1. all: auto 10.
   Defined.
 
-  Lemma prf_strenghten_premise_meta_indifferent
-        P Γ A A' B
-        (wfA : well_formed A)
-        (wfA' : well_formed A')
-        (wfB : well_formed B)
-        (A'impA : Γ ⊢ A' ---> A):
-    indifferent_to_prop P ->
-    P _ _ A'impA = false ->
-    P _ _ (@prf_strenghten_premise_meta Γ A A' B wfA wfA' wfB A'impA) = false.
-  Proof.
-    intros Hp H1. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold prf_strenghten_premise_meta. rewrite Hmp. rewrite H1. simpl.
-    rewrite syllogism_indifferent; auto.
-  Qed.
+  Program Canonical Structure prf_strenghten_premise_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b c
+        (wfa : well_formed a = true) (wfb : well_formed b = true) (wfc : well_formed c = true)
+    := ProofProperty1 P (@prf_strenghten_premise_meta Γ a b c wfa wfb wfc) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma prf_strenghten_premise_meta_meta Γ A A' B :
     well_formed A ->
@@ -1609,23 +1592,11 @@ Defined. *)
     eapply Modus_ponens. 4: apply prf_strenghten_premise_meta. 3: apply AimpB. all: auto.
   Defined.
 
-  Lemma prf_strenghten_premise_meta_meta_indifferent
-        P Γ A A' B
-        (wfA : well_formed A)
-        (wfA' : well_formed A')
-        (wfB : well_formed B)
-        (A'impA : Γ ⊢ A' ---> A)
-        (AimpB : Γ ⊢ A ---> B):
-    indifferent_to_prop P ->
-    P _ _ A'impA = false ->
-    P _ _ AimpB = false ->
-    P _ _ (@prf_strenghten_premise_meta_meta Γ A A' B wfA wfA' wfB A'impA AimpB) = false.
-  Proof.
-    intros Hp H1 H2. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold prf_strenghten_premise_meta_meta. rewrite Hmp. rewrite H2. simpl.
-    unfold prf_strenghten_premise_meta. rewrite Hmp. rewrite H1. simpl.
-    rewrite syllogism_indifferent; auto.
-  Qed.
+  Program Canonical Structure prf_strenghten_premise_meta_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b c
+        (wfa : well_formed a = true) (wfb : well_formed b = true) (wfc : well_formed c = true)
+    := ProofProperty2 P (@prf_strenghten_premise_meta_meta Γ a b c wfa wfb wfc) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma prf_strenghten_premise_iter_meta Γ l₁ l₂ h h' g :
     wf l₁ -> wf l₂ ->
@@ -1642,6 +1613,13 @@ Defined. *)
     all: auto 10.
   Defined.
 
+  Program Canonical Structure prf_strenghten_premise_iter_meta_indifferent_S
+        P {Pip : IndifProp P} Γ l₁ l₂ a b c
+        (wfl₁ : wf l₁) (wfl₂ : wf l₂)
+        (wfa : well_formed a = true) (wfb : well_formed b = true) (wfc : well_formed c = true)
+    := ProofProperty1 P (@prf_strenghten_premise_iter_meta Γ l₁ l₂ a b c wfl₁ wfl₂ wfa wfb wfc) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
   Lemma prf_strenghten_premise_iter_meta_meta Γ l₁ l₂ h h' g :
     wf l₁ -> wf l₂ ->
     well_formed h ->
@@ -1657,28 +1635,12 @@ Defined. *)
     9: eassumption. all: auto 10.
   Defined.
 
-  Lemma prf_strenghten_premise_iter_meta_meta_indifferent
-        P Γ l₁ l₂ h h' g
-        (wfl₁ : wf l₁)
-        (wfl₂ : wf l₂)
-        (wfh : well_formed h)
-        (wfh' : well_formed h')
-        (wfg : well_formed g)
-        (himph' : Γ ⊢ h' ---> h)
-        (pf': Γ ⊢ foldr patt_imp g (l₁ ++ h::l₂)):
-    indifferent_to_prop P ->
-     P _ _ himph' = false ->
-     P _ _ pf' = false ->
-     P _ _ (@prf_strenghten_premise_iter_meta_meta Γ l₁ l₂ h h' g wfl₁ wfl₂ wfh wfh' wfg himph' pf') = false.
-  Proof.
-    intros Hp H1 H2. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold prf_strenghten_premise_iter_meta_meta.
-    rewrite Hmp. rewrite H2. simpl.
-    unfold prf_strenghten_premise_iter_meta.
-    rewrite Hmp. rewrite H1. simpl.
-    rewrite prf_strenghten_premise_iter_indifferent; auto.
-  Qed.
-
+  Program Canonical Structure prf_strenghten_premise_iter_meta_meta_indifferent_S
+        P {Pip : IndifProp P} Γ l₁ l₂ a b c
+        (wfl₁ : wf l₁) (wfl₂ : wf l₂)
+        (wfa : well_formed a = true) (wfb : well_formed b = true) (wfc : well_formed c = true)
+    := ProofProperty2 P (@prf_strenghten_premise_iter_meta_meta Γ l₁ l₂ a b c wfl₁ wfl₂ wfa wfb wfc) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   (* TODO rename *)
   Lemma rewrite_under_implication Γ g g':
@@ -1696,6 +1658,13 @@ Defined. *)
     { eapply Modus_ponens. 4: apply H2. all: auto 10. }
     eapply Modus_ponens. 4: apply H3. all: auto.
   Defined.
+
+  Program Canonical Structure prf_rewrite_under_implication_indifferent_S
+        P {Pip : IndifProp P} Γ a b
+        (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty1 P (@rewrite_under_implication Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
 
   Local Example example_nested_const Γ a b c:
     well_formed a ->
@@ -1728,19 +1697,16 @@ Defined. *)
       5: apply H1. all: auto.
   Defined.
 
-  Lemma nested_const_indifferent
-        P Γ a l
+  Program Canonical Structure nested_const_indifferent_S
+        P {Pip : IndifProp P} Γ l a
+        (wfl : wf l)
         (wfa : well_formed a = true)
-        (wfl : wf l = true) :
-    indifferent_to_prop P ->
-    P _ _ (@nested_const Γ a l wfa wfl) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    induction l; simpl.
-    - rewrite A_impl_A_indifferent; auto.
-    - case_match. rewrite syllogism_intro_indifferent; auto.
+    := ProofProperty0 P (@nested_const Γ a l wfa wfl) _.
+  Next Obligation.
+    intros. induction l; simpl.
+    - solve_indif.
+    - case_match. solve_indif; apply IHl.
   Qed.
-
 
   Lemma nested_const_middle Γ a l₁ l₂:
     well_formed a ->
@@ -1758,18 +1724,15 @@ Defined. *)
       eapply Modus_ponens. 4: apply P1. all: auto 10.
   Defined.
 
-  Lemma nested_const_middle_indifferent
-        P Γ a l₁ l₂
+  Program Canonical Structure nested_const_middle_indifferent_S
+        P {Pip : IndifProp P} Γ l₁ l₂ a
+        (wfl₁ : wf l₁) (wfl₂ : wf l₂)
         (wfa : well_formed a = true)
-        (wfl₁ : wf l₁ = true)
-        (wfl₂ : wf l₂ = true):
-    indifferent_to_prop P ->
-    P _ _ (@nested_const_middle Γ a l₁ l₂ wfa wfl₁ wfl₂) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    induction l₁; simpl.
-    - apply nested_const_indifferent; assumption.
-    - case_match. rewrite Hmp. rewrite IHl₁. simpl. rewrite Hp1. reflexivity.
+    := ProofProperty0 P (@nested_const_middle Γ a l₁ l₂ wfa wfl₁ wfl₂) _.
+  Next Obligation.
+    intros. induction l₁; simpl.
+    - solve_indif.
+    - case_match. solve_indif; apply IHl₁.
   Qed.
 
   Lemma prf_reorder_iter Γ a b g l₁ l₂:
@@ -1789,6 +1752,17 @@ Defined. *)
       eapply prf_weaken_conclusion_meta; auto 10.
   Defined.
 
+  Program Canonical Structure prf_reorder_iter_indifferent_S
+        P {Pip : IndifProp P} Γ l₁ l₂ a b c
+        (wfl₁ : wf l₁) (wfl₂ : wf l₂)
+        (wfa : well_formed a = true) (wfb : well_formed b = true) (wfc : well_formed c = true)
+    := ProofProperty0 P (@prf_reorder_iter Γ a b c l₁ l₂ wfa wfb wfc wfl₁ wfl₂) _.
+  Next Obligation.
+    intros. induction l₁; simpl.
+    - solve_indif.
+    - case_match. solve_indif; apply IHl₁.
+  Qed.
+
   Lemma prf_reorder_iter_meta Γ a b g l₁ l₂:
     well_formed a ->
     well_formed b ->
@@ -1804,6 +1778,13 @@ Defined. *)
     4: { apply prf_reorder_iter; auto. }
     all: auto 10.
   Defined.
+
+  Program Canonical Structure prf_reorder_iter_meta_indifferent_S
+        P {Pip : IndifProp P} Γ l₁ l₂ a b c
+        (wfl₁ : wf l₁) (wfl₂ : wf l₂)
+        (wfa : well_formed a = true) (wfb : well_formed b = true) (wfc : well_formed c = true)
+    := ProofProperty1 P (@prf_reorder_iter_meta Γ a b c l₁ l₂ wfa wfb wfc wfl₁ wfl₂) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
   
   
   (*
@@ -1827,22 +1808,11 @@ Defined. *)
     all: auto 10.
   Defined.
 
-  Lemma A_impl_not_not_B_meta_indifferent
-        P Γ a b
-        (wfa : well_formed a)
-        (wfb : well_formed b) 
-        (pf : Γ ⊢ a ---> ! ! b)
-    :
-    indifferent_to_prop P ->
-    P _ _ pf = false ->
-    P _ _ (@A_impl_not_not_B_meta Γ a b wfa wfb pf) = false.
-  Proof.
-   intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-   intros Hpf.
-   unfold A_impl_not_not_B_meta.
-   rewrite Hmp. rewrite Hpf. rewrite A_impl_not_not_B_indifferent; auto.
-  Qed.
-
+  Program Canonical Structure A_impl_not_not_B_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b
+        (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty1 P (@A_impl_not_not_B_meta Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma pf_conj_elim_l Γ A B :
     well_formed A ->
@@ -1861,22 +1831,11 @@ Defined. *)
     all: auto.
   Defined.
 
-  Lemma pf_conj_elim_l_indifferent
-        P Γ a b
-        (wfa : well_formed a = true)
-        (wfb : well_formed b = true):
-    indifferent_to_prop P ->
-    P _ _ (@pf_conj_elim_l Γ a b wfa wfb) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold pf_conj_elim_l. rewrite A_impl_not_not_B_meta_indifferent; auto.
-    rewrite reorder_meta_indifferent; auto.
-    rewrite syllogism_intro_indifferent; auto.
-    + rewrite disj_left_intro_indifferent; auto.
-    + rewrite modus_ponens_indifferent; auto.
-  Qed.
-
-
+  Program Canonical Structure pf_conj_elim_l_indifferent_S
+        P {Pip : IndifProp P} Γ a b
+        (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty0 P (@pf_conj_elim_l Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma pf_conj_elim_r Γ A B :
     well_formed A ->
@@ -1895,22 +1854,11 @@ Defined. *)
     all: auto.
   Defined.
 
-  Lemma pf_conj_elim_r_indifferent
-        P Γ a b
-        (wfa : well_formed a = true)
-        (wfb : well_formed b = true):
-    indifferent_to_prop P ->
-    P _ _ (@pf_conj_elim_r Γ a b wfa wfb) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold pf_conj_elim_r.
-    rewrite A_impl_not_not_B_meta_indifferent; auto.
-    rewrite reorder_meta_indifferent; auto.
-    rewrite syllogism_intro_indifferent; auto.
-    + rewrite disj_right_intro_indifferent; auto.
-    + rewrite modus_ponens_indifferent; auto.
-  Qed.
-
+  Program Canonical Structure pf_conj_elim_r_indifferent_S
+        P {Pip : IndifProp P} Γ a b
+        (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty0 P (@pf_conj_elim_r Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma pf_conj_elim_l_meta Γ A B :
     well_formed A ->
@@ -1925,22 +1873,11 @@ Defined. *)
     all: auto.
   Defined.
 
-  Lemma pf_conj_elim_l_meta_indifferent
-        P Γ a b
-        (wfa : well_formed a = true)
-        (wfb : well_formed b = true)
-        (pf : Γ ⊢ a and b)
-    :
-    indifferent_to_prop P ->
-    P _ _ pf = false ->
-    P _ _ (@pf_conj_elim_l_meta Γ a b wfa wfb pf) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    intros Hpf.
-    unfold pf_conj_elim_l_meta. rewrite Hmp. rewrite pf_conj_elim_l_indifferent; auto.
-    rewrite Hpf. reflexivity.
-  Qed.
-
+  Program Canonical Structure pf_conj_elim_l_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b
+        (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty1 P (@pf_conj_elim_l_meta Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
   
   Lemma pf_conj_elim_r_meta Γ A B :
     well_formed A ->
@@ -1955,22 +1892,11 @@ Defined. *)
     all: auto.
   Defined.
 
-  Lemma pf_conj_elim_r_meta_indifferent
-        P Γ a b
-        (wfa : well_formed a = true)
-        (wfb : well_formed b = true)
-        (pf : Γ ⊢ a and b)
-    :
-    indifferent_to_prop P ->
-    P _ _ pf = false ->
-    P _ _ (@pf_conj_elim_r_meta Γ a b wfa wfb pf) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    intros Hpf.
-    unfold pf_conj_elim_r_meta. rewrite Hmp. rewrite pf_conj_elim_r_indifferent; auto.
-    rewrite Hpf. reflexivity.
-  Qed.
-
+  Program Canonical Structure pf_conj_elim_r_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b
+        (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty1 P (@pf_conj_elim_r_meta Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma A_or_notA Γ A :
     well_formed A ->
@@ -1978,8 +1904,14 @@ Defined. *)
   Proof.
     intros wfA.
     unfold patt_or.
-    auto.
+    auto. (* TODO be more explicit here *)
   Defined.
+
+  Program Canonical Structure A_or_notA_indifferent_S
+        P {Pip : IndifProp P} Γ a
+        (wfa : well_formed a = true)
+    := ProofProperty0 P (@A_or_notA Γ a wfa) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma P4m_meta (Γ : Theory) (A B : Pattern) :
     well_formed A ->
@@ -1994,6 +1926,13 @@ Defined. *)
     { eapply Modus_ponens. 4: apply H1. all: auto 10. }
     eapply Modus_ponens. 4: apply H2. all: auto.
   Defined.
+
+  Program Canonical Structure P4m_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b
+        (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty2 P (@P4m_meta Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
 
 End FOL_helpers.
 

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -2366,8 +2366,7 @@ Local Example ex_mgExactn_indif_S {Σ : Signature} P {Pip : IndifProp P} {Pic : 
   (wfc : well_formed c = true):
   P _ _ (@ex_mgExactn Σ Γ a b c wfa wfb wfc) = false.
 Proof.
-  Print tacticProperty0.
-  unfold ex_mgExactn. Set Printing Implicit.
+  unfold ex_mgExactn.
   apply liftP_impl_P.
   solve_indif.
 Qed.
@@ -6278,7 +6277,7 @@ Section FOL_helpers.
       inversion Heq; subst; clear Heq.
       specialize (Hind ltac:(assumption) ltac:(assumption)).
       solve_indif; auto.
-      + Unset Printing Implicit. case_match.
+      + case_match.
         { clear -frX e H. set_solver. }
         solve_indif. apply Hind.
       + case_match.
@@ -7162,11 +7161,10 @@ Program Canonical Structure phi_iff_phi_top_indifferent_S {Σ : Signature}
         (wfa : well_formed a)
   := ProofProperty0 P (@phi_iff_phi_top Σ Γ a wfa) _.
 Next Obligation.
-  intros. apply liftP_impl_P. solve_indif. simpl.
-  intros. unfold liftP
-  solve_indif. simpl. solve_indif simpl.
-  apply liftP_impl_P. solve_indif.
-solve_indif. assumption. Qed.
+  intros. apply liftP_impl_P.
+  unfold phi_iff_phi_top. simpl.
+  solve_indif; simpl; unfold liftP; solve_indif.
+Qed.
 
 Lemma not_phi_iff_phi_bott {Σ : Signature} Γ ϕ :
   well_formed ϕ ->
@@ -7185,6 +7183,16 @@ Proof.
     mgExactn 0.
 Defined.
 
+Program Canonical Structure not_phi_iff_phi_bott_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a : Pattern)
+        (wfa : well_formed a)
+  := ProofProperty0 P (@not_phi_iff_phi_bott Σ Γ a wfa) _.
+Next Obligation.
+  intros. apply liftP_impl_P. unfold not_phi_iff_phi_bott. simpl.
+  solve_indif. unfold liftP. solve_indif.
+Qed.
+
 
 Lemma not_not_iff {Σ : Signature} (Γ : Theory) (A : Pattern) :
   well_formed A ->
@@ -7199,6 +7207,16 @@ Proof.
   - apply not_not_elim.
     { wf_auto2. }
 Defined.    
+
+Program Canonical Structure not_not_iff_indifferent_S {Σ : Signature}
+        (P : proofbpred) {Pip : IndifProp P} {Pic : IndifCast P} (Γ : Theory)
+        (a : Pattern)
+        (wfa : well_formed a)
+  := ProofProperty0 P (@not_not_iff Σ Γ a wfa) _.
+Next Obligation.
+  intros. apply liftP_impl_P. unfold not_phi_iff_phi_bott. simpl.
+  solve_indif. unfold liftP. solve_indif.
+Qed.
 
 (* prenex-exists-and-left *)
 Lemma prenex_exists_and_1 {Σ : Signature} (Γ : Theory) ϕ₁ ϕ₂:

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -2727,7 +2727,6 @@ Section FOL_helpers.
       4: apply H3. all: auto 10.
   Defined.
 
-
   Program Canonical Structure prf_add_lemma_under_implication_indifferent_S
             (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
             (l : list Pattern)
@@ -2753,6 +2752,16 @@ Section FOL_helpers.
     intros WFl WFg WGh H. eapply Modus_ponens. 4: apply prf_add_lemma_under_implication. all: auto 7.
   Defined.
 
+  Program Canonical Structure prf_add_lemma_under_implication_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l : list Pattern)
+            (p q : Pattern)
+            (wfl : wf l)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+    := ProofProperty1 P (@prf_add_lemma_under_implication_meta Γ l p q wfl wfp wfq) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
   Lemma prf_add_lemma_under_implication_meta_meta Γ l g h:
     wf l ->
     well_formed g ->
@@ -2764,6 +2773,16 @@ Section FOL_helpers.
     intros WFl WFg WGh H H0. eapply Modus_ponens. 4: apply prf_add_lemma_under_implication_meta.
     3: apply H0. all: auto 7.
   Defined.
+
+  Program Canonical Structure prf_add_lemma_under_implication_meta_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l : list Pattern)
+            (p q : Pattern)
+            (wfl : wf l)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+    := ProofProperty2 P (@prf_add_lemma_under_implication_meta_meta Γ l p q wfl wfp wfq) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma myGoal_assert Γ l g h:
     well_formed h ->
@@ -2787,6 +2806,19 @@ Section FOL_helpers.
       ).
     }
   Defined.
+
+  Program Canonical Structure myGoal_assert_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l : list Pattern)
+            (p q : Pattern)
+            (wfq : well_formed q)
+    := TacticProperty2 P (@myGoal_assert Γ l p q wfq) _.
+  Next Obligation.
+    intros. unfold myGoal_assert. unfold liftP.
+    solve_indif.
+    - apply H.
+    - apply H0.
+  Qed.
 
   Lemma prf_add_lemma_under_implication_generalized Γ l1 l2 g h:
     wf l1 ->
@@ -2813,6 +2845,22 @@ Section FOL_helpers.
       4: apply H3. all: auto 10.
   Defined.
   
+  Program Canonical Structure prf_add_lemma_under_implication_generalized_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l₁ l₂ : list Pattern)
+            (p q : Pattern)
+            (wfl₁ : wf l₁)
+            (wfl₂ : wf l₂)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+    := ProofProperty0 P (@prf_add_lemma_under_implication_generalized Γ l₁ l₂ p q wfl₁ wfl₂ wfp wfq) _.
+  Next Obligation.
+    intros.
+    induction l₁.
+    - solve_indif.
+    - simpl. case_match. solve_indif. apply IHl₁.
+  Qed.
+
   Lemma prf_add_lemma_under_implication_generalized_meta Γ l1 l2 g h:
     wf l1 ->
     wf l2 ->
@@ -2823,6 +2871,17 @@ Section FOL_helpers.
   Proof.
     intros WFl1 WFl2 WFg WGh H. eapply Modus_ponens. 4: apply prf_add_lemma_under_implication_generalized. all: auto 10.
   Defined.
+
+  Program Canonical Structure prf_add_lemma_under_implication_generalized_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l₁ l₂ : list Pattern)
+            (p q : Pattern)
+            (wfl₁ : wf l₁)
+            (wfl₂ : wf l₂)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+    := ProofProperty1 P (@prf_add_lemma_under_implication_generalized_meta Γ l₁ l₂ p q wfl₁ wfl₂ wfp wfq) _.
+  Next Obligation. solve_indif; assumption. Qed.
   
   Lemma prf_add_lemma_under_implication_generalized_meta_meta Γ l1 l2 g h:
     wf l1 ->
@@ -2836,6 +2895,17 @@ Section FOL_helpers.
     intros WFl1 WFl2 WFg WGh H H0. eapply Modus_ponens. 4: apply prf_add_lemma_under_implication_generalized_meta.
     3: apply H0. all: auto 7.
   Defined.
+
+  Program Canonical Structure prf_add_lemma_under_implication_generalized_meta_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l₁ l₂ : list Pattern)
+            (p q : Pattern)
+            (wfl₁ : wf l₁)
+            (wfl₂ : wf l₂)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+    := ProofProperty2 P (@prf_add_lemma_under_implication_generalized_meta_meta Γ l₁ l₂ p q wfl₁ wfl₂ wfp wfq) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma myGoal_assert_generalized Γ l1 l2 g h:
     well_formed h ->
@@ -2878,6 +2948,14 @@ Section FOL_helpers.
       ).
     }
   Defined.
+
+  Program Canonical Structure myGoal_assert_generalized_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l₁ l₂ : list Pattern)
+            (p q : Pattern)
+            (wfq : well_formed q)
+    := TacticProperty2 P (@myGoal_assert_generalized Γ l₁ l₂ p q wfq) _.
+  Next Obligation. intros. unfold liftP. solve_indif. apply H. apply H0. Qed.
   
 End FOL_helpers.
 
@@ -2973,6 +3051,13 @@ Section FOL_helpers.
 
   #[local] Hint Resolve P4i' : core.
 
+  Program Canonical Structure P4i'_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (q : Pattern)
+            (wfq : well_formed q)
+    := ProofProperty0 P (@P4i' Γ q wfq) _.
+  Next Obligation. solve_indif. Qed.
+
   Lemma tofold p:
     p = fold_right patt_imp p [].
   Proof.
@@ -2996,9 +3081,19 @@ Section FOL_helpers.
     pose proof (H1 := @Constructive_dilemma Σ Γ p r q r wfp wfr wfq wfr).
     assert (Γ ⊢ ((r or r) ---> r)).
     { unfold patt_or. apply P4i'; auto. }
-    rewrite -> tofold in H1. rewrite 3!consume in H1.
+    eapply cast_proof in H1.
+    2: { rewrite -> tofold. do 3 rewrite -> consume. reflexivity. }
     eapply prf_weaken_conclusion_iter_meta_meta in H1. 5: apply H. all: auto 10.
   Defined.
+
+  Program Canonical Structure prf_disj_elim_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (p q r : Pattern)
+            (wfp : well_formed p)
+            (wfq : well_formed q)
+            (wfr : well_formed r)
+    := ProofProperty0 P (@prf_disj_elim Γ p q r wfp wfq wfr) _.
+  Next Obligation. intros. unfold prf_disj_elim.  solve_indif.  , Qed.
 
 
   Lemma prf_disj_elim_meta Γ p q r:

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -987,6 +987,12 @@ Section FOL_helpers.
       all: auto 10.
   Defined.
 
+  Program Canonical Structure double_neg_elim_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty1 P (@double_neg_elim_meta Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
+
   Lemma P4_rev_meta (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ (A ---> B) -> Γ ⊢ ((A ---> B) ---> (!B ---> !A)).
   Proof.
@@ -1004,6 +1010,11 @@ Section FOL_helpers.
         all: auto 10.
   Defined.
 
+  Program Canonical Structure P4_rev_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty1 P (@P4_rev_meta Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
   Lemma P4_rev_meta' (Γ : Theory) (A B : Pattern) :
     well_formed A ->
     well_formed B ->
@@ -1019,6 +1030,12 @@ Section FOL_helpers.
 
   #[local] Hint Resolve P4_rev_meta' : core.
   
+  Program Canonical Structure P4_rev_meta'_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty1 P (@P4_rev_meta' Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
+
   Lemma P4m_neg (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ ((!B ---> !A) ---> (A ---> !B) --->  !A).
   Proof.
@@ -1030,6 +1047,11 @@ Section FOL_helpers.
       Unshelve.
       all: auto.
   Defined.
+
+  Program Canonical Structure P4m_neg_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty0 P (@P4m_neg Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma not_not_impl_intro_meta (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ (A ---> B) -> Γ ⊢ ((! ! A) ---> (! ! B)).
@@ -1045,6 +1067,11 @@ Section FOL_helpers.
     Unshelve.
     all: auto.
   Defined.
+
+  Program Canonical Structure not_not_impl_intro_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty1 P (@not_not_impl_intro_meta Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma not_not_impl_intro (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ ((A ---> B) ---> ((! ! A) ---> (! ! B))).
@@ -1075,6 +1102,10 @@ Section FOL_helpers.
       all: auto 10.
   Defined.
 
+  Program Canonical Structure not_not_impl_intro_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty0 P (@not_not_impl_intro Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma contraposition (Γ : Theory) (A B : Pattern) : 
     well_formed A -> well_formed B -> 
@@ -1091,6 +1122,11 @@ Section FOL_helpers.
       Unshelve.
       all: auto.
   Defined.
+
+  Program Canonical Structure contraposition_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty0 P (@contraposition Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma or_comm_meta (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B ->
@@ -1111,6 +1147,12 @@ Section FOL_helpers.
       all: auto 10.
   Defined.
 
+  Program Canonical Structure or_comm_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty1 P (@or_comm_meta Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
+
   Lemma A_implies_not_not_A_alt (Γ : Theory) (A : Pattern) :
     well_formed A -> Γ ⊢ A -> Γ ⊢ (!( !A )).
   Proof.
@@ -1122,6 +1164,11 @@ Section FOL_helpers.
     Unshelve.
     all: auto.
   Defined.
+
+  Program Canonical Structure A_implies_not_not_A_alt_indifferent_S
+        P {Pip : IndifProp P} Γ a (wfa : well_formed a = true)
+    := ProofProperty1 P (@A_implies_not_not_A_alt Γ a wfa) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma P5i (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ (! A ---> (A ---> B)).
@@ -1138,6 +1185,11 @@ Section FOL_helpers.
     all: auto.
   Defined.
 
+  Program Canonical Structure P5i_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty0 P (@P5i Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
   Lemma false_implies_everything (Γ : Theory) (phi : Pattern) :
     well_formed phi -> Γ ⊢ (Bot ---> phi).
   Proof.
@@ -1152,6 +1204,11 @@ Section FOL_helpers.
       Unshelve.
       all: auto.
   Defined.
+
+  Program Canonical Structure false_implies_everthing_indifferent_S
+        P {Pip : IndifProp P} Γ a (wfa : well_formed a = true)
+    := ProofProperty0 P (@false_implies_everything Γ a wfa) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
 
   (* Goal  forall (A B : Pattern) (Γ : Theory) , well_formed A -> well_formed B ->
@@ -1228,6 +1285,12 @@ Defined. *)
     all: auto.
   Defined.
 
+
+  Program Canonical Structure A_implies_not_not_A_alt_Γ_indifferent_S
+        P {Pip : IndifProp P} Γ a (wfa : well_formed a = true)
+    := ProofProperty1 P (@A_implies_not_not_A_alt_Γ Γ a wfa) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
   (* Lemma equiv_implies_eq (Γ : Theory) (A B : Pattern) :
   well_formed A -> well_formed B -> Γ ⊢ (A <---> B) -> Γ ⊢ ()
    *) (*Need equal*)
@@ -1270,7 +1333,9 @@ Defined. *)
       all: auto.
   Abort.
 
+  (* TODO remove *)
   Definition empty_Γ := Empty_set (@Pattern Σ).
+
   Lemma exclusion (G : Theory) (A : Pattern) :
     well_formed A -> G ⊢ A -> G ⊢ (A ---> Bot) -> G ⊢ Bot.
   Proof.
@@ -1280,6 +1345,11 @@ Defined. *)
     Unshelve.
     all: auto.
   Defined.
+
+  Program Canonical Structure exclusion_indifferent_S
+        P {Pip : IndifProp P} Γ a (wfa : well_formed a = true)
+    := ProofProperty2 P (@exclusion Γ a wfa) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma modus_tollens Γ A B :
     well_formed A ->
@@ -1292,6 +1362,11 @@ Defined. *)
     4: apply contraposition.
     all: auto.
   Defined.
+
+  Program Canonical Structure modus_tollens_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty1 P (@modus_tollens Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
   
   Lemma A_impl_not_not_B Γ A B :
     well_formed A ->
@@ -1305,21 +1380,13 @@ Defined. *)
     eapply Modus_ponens. 4: apply H0. all: auto 10.
   Defined.
 
+  (* TODO remove this hint *)
   #[local] Hint Resolve A_impl_not_not_B : core.
 
-  Lemma A_impl_not_not_B_indifferent
-        P Γ a b
-        (wfa : well_formed a)
-        (wfb : well_formed b) :
-    indifferent_to_prop P ->
-    P _ _ (@A_impl_not_not_B Γ a b wfa wfb) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold A_impl_not_not_B.
-    rewrite Hmp. rewrite not_not_elim_indifferent; [assumption|]. simpl.
-    rewrite reorder_meta_indifferent;[assumption|idtac|reflexivity].
-    rewrite syllogism_indifferent; auto.
-  Qed.
+  Program Canonical Structure A_impl_not_not_B_indifferent_S
+        P {Pip : IndifProp P} Γ a b (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty0 P (@A_impl_not_not_B Γ a b wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma prf_weaken_conclusion Γ A B B' :
     well_formed A ->
@@ -1330,22 +1397,13 @@ Defined. *)
     intros wfA wfB wfB'.
     apply reorder_meta; auto.
   Defined.
+
+  Program Canonical Structure prf_weaken_conclusion_indifferent_S
+        P {Pip : IndifProp P} Γ a b c
+        (wfa : well_formed a = true) (wfb : well_formed b = true) (wfc : well_formed c = true)
+    := ProofProperty0 P (@prf_weaken_conclusion Γ a b c wfa wfb wfc) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
   
-  Lemma prf_weaken_conclusion_indifferent
-        P Γ A B B'
-        (wfA : well_formed A)
-        (wfB : well_formed B)
-        (wfB' : well_formed B'):
-    indifferent_to_prop P ->
-    P _ _ (@prf_weaken_conclusion Γ A B B' wfA wfB wfB') = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold prf_weaken_conclusion.
-    rewrite reorder_meta_indifferent; auto.
-    rewrite syllogism_indifferent; auto.
-  Qed.
-
-
   Lemma prf_weaken_conclusion_meta Γ A B B' :
     well_formed A ->
     well_formed B ->
@@ -1359,23 +1417,11 @@ Defined. *)
     eapply Modus_ponens. 4: apply H1. all: auto 10.
   Defined.
 
-  Lemma prf_weaken_conclusion_meta_indifferent
-        P Γ A B B'
-        (wfA : well_formed A)
-        (wfB : well_formed B)
-        (wfB' : well_formed B')
-        (pf : Γ ⊢ B ---> B')
-        :
-        indifferent_to_prop P ->
-        P _ _ pf = false ->
-        P _ _ (@prf_weaken_conclusion_meta Γ A B B' wfA wfB wfB' pf) = false.
-  Proof.
-    intros Hp Hpf. pose proof (Hp' := Hp). destruct Hp as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold prf_weaken_conclusion_meta. rewrite Hmp. rewrite Hpf. simpl.
-    rewrite reorder_meta_indifferent; auto.
-    rewrite syllogism_indifferent; auto.
-  Qed.
-
+  Program Canonical Structure prf_weaken_conclusion_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b c
+        (wfa : well_formed a = true) (wfb : well_formed b = true) (wfc : well_formed c = true)
+    := ProofProperty1 P (@prf_weaken_conclusion_meta Γ a b c wfa wfb wfc) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
 
   Lemma prf_weaken_conclusion_iter Γ l g g'
           (wfl : wf l) (wfg : well_formed g) (wfg' : well_formed g') :
@@ -1394,25 +1440,16 @@ Defined. *)
       all: apply well_formed_foldr; auto.
   Defined.
 
-  Lemma prf_weaken_conclusion_iter_indifferent
-        P Γ l g g'
-        (wfl : wf l)
-        (wfg : well_formed g)
-        (wfg' : well_formed g')
-    : indifferent_to_prop P ->
-    P _ _ (@prf_weaken_conclusion_iter Γ l g g' wfl wfg wfg') = false.
-  Proof.
-    intros Hp.
-    move: wfl.
-    induction l; intros wfl.
-    - simpl. rewrite A_impl_A_indifferent; auto.
+  Program Canonical Structure prf_weaken_conclusion_iter_indifferent_S
+        P {Pip : IndifProp P} Γ l a b (wfl : wf l = true) (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty0 P (@prf_weaken_conclusion_iter Γ l a b wfl wfa wfb) _.
+  Next Obligation.
+    intros. induction l.
+    - simpl. solve_indif.
     - simpl.
       case_match.
-      rewrite syllogism_intro_indifferent; auto.
-      simpl in *.
-      rewrite prf_weaken_conclusion_indifferent; auto.
+      solve_indif. apply IHl.
   Qed.
-
 
   Lemma prf_weaken_conclusion_iter_meta Γ l g g':
     wf l ->
@@ -1427,6 +1464,11 @@ Defined. *)
     all: auto.
   Defined.
 
+  Program Canonical Structure prf_weaken_conclusion_iter_meta_indifferent_S
+        P {Pip : IndifProp P} Γ l a b (wfl : wf l = true) (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty1 P (@prf_weaken_conclusion_iter_meta Γ l a b wfl wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
+
   Lemma prf_weaken_conclusion_iter_meta_meta Γ l g g':
     wf l ->
     well_formed g ->
@@ -1439,35 +1481,12 @@ Defined. *)
     eapply Modus_ponens. 4: apply prf_weaken_conclusion_iter_meta. 3: apply H.
     all: auto.
   Defined.
+
+  Program Canonical Structure prf_weaken_conclusion_iter_meta_meta_indifferent_S
+        P {Pip : IndifProp P} Γ l a b (wfl : wf l = true) (wfa : well_formed a = true) (wfb : well_formed b = true)
+    := ProofProperty2 P (@prf_weaken_conclusion_iter_meta_meta Γ l a b wfl wfa wfb) _.
+  Next Obligation. intros. solve_indif; assumption. Qed.
     
-  Lemma prf_weaken_conclusion_iter_meta_meta_indifferent
-        P Γ l g g'
-        (wfl : wf l)
-        (wfg : well_formed g)
-        (wfg' : well_formed g')
-        (gimpg' : Γ ⊢ g ---> g')
-        (pf : Γ ⊢ foldr patt_imp g l)
-    :
-    indifferent_to_prop P ->
-    P _ _ gimpg' = false ->
-    P _ _ pf = false ->
-    P _ _ (@prf_weaken_conclusion_iter_meta_meta Γ l g g' wfl wfg wfg' gimpg' pf) = false.
-  Proof.
-    intros Hp H1 H2. pose proof (Hp':= Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold prf_weaken_conclusion_iter_meta_meta. rewrite Hmp.
-    rewrite H2. simpl.
-    unfold prf_weaken_conclusion_iter_meta. rewrite Hmp.
-    rewrite H1. simpl.
-
-    clear H2 pf.
-    induction l.
-    - simpl. apply A_impl_A_indifferent; assumption.
-    - simpl. case_match. rewrite syllogism_intro_indifferent; auto.
-      simpl.
-      rewrite prf_weaken_conclusion_indifferent; auto.
-  Qed.
-
-
   Lemma prf_weaken_conclusion_meta_meta Γ A B B' :
     well_formed A ->
     well_formed B ->

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -424,28 +424,25 @@ Section FOL_helpers.
   Defined.
 
   Lemma reorder_meta_indifferent
-        P Γ A B C
+        P {HP : IndifProp P} Γ A B C
         (wfA : well_formed A)
         (wfB : well_formed B)
         (wfC : well_formed C)
         (AimpBimpC : Γ ⊢ A ---> B ---> C):
-    indifferent_to_prop P ->
     P _ _ AimpBimpC = false ->
     P _ _ (@reorder_meta Γ A B C wfA wfB wfC AimpBimpC) = false.
   Proof.
-    intros Hp H. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold reorder_meta. rewrite !(Hp1,Hp2,Hp3,Hmp). rewrite H.
-    reflexivity.
+    intros H. solve_indif. assumption.
   Qed.
 
-  Print ProofProperty1.
-
   Program Canonical Structure reorder_meta_indifferent_S
-          {Σ : Signature} (P : proofbpred) {Pip : IndifProp P}
-          (Γ : Theory) (ϕ₁ ϕ₂ ϕ₃ : Pattern)
-          (wfϕ₁ : well_formed ϕ₁) (wfϕ₂ : well_formed ϕ₂) (wfϕ₃ : well_formed ϕ₃)
-  := ProofProperty2 P (fun pf1 pf2 => @Modus_ponens Σ Γ ϕ₁ ϕ₂ wfϕ₁ wfϕ₁₂ pf1 pf2) _.
-
+          (P : proofbpred) {Pip : IndifProp P}
+          (Γ : Theory) (A B C : Pattern)
+          (wfA : well_formed A) (wfB : well_formed B) (wfC : well_formed C)
+    := ProofProperty1 P (fun pf1 => @reorder_meta Γ A B C wfA wfB wfC pf1) _.
+  Next Obligation.
+    intros. apply reorder_meta_indifferent; assumption.
+  Qed.
 
   Lemma syllogism (Γ : Theory) (A B C : Pattern) :
     well_formed A -> well_formed B -> well_formed C -> Γ ⊢ ((A ---> B) ---> (B ---> C) ---> (A ---> C)).
@@ -466,18 +463,18 @@ Section FOL_helpers.
   #[local] Hint Resolve syllogism : core.
 
   Lemma syllogism_indifferent
-        P Γ A B C
+        P {Pip : IndifProp P} Γ A B C
         (wfA : well_formed A)
         (wfB : well_formed B)
         (wfC : well_formed C):
-    indifferent_to_prop P ->
     P _ _ (@syllogism Γ A B C wfA wfB wfC) = false.
   Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hp4]]].
-    unfold syllogism.
-    rewrite !(Hp1,Hp2,Hp3,Hp4).
-    reflexivity.
+    unfold syllogism. solve_indif.
   Qed.
+
+  Canonical Structure syllogism_indifferent_S P {HP : IndifProp P} Γ A B C
+            (wfA : well_formed A) (wfB : well_formed B) (wfC : well_formed C)
+    := ProofProperty0 P _ (syllogism_indifferent Γ wfA wfB wfC).
 
   
   Lemma syllogism_intro (Γ : Theory) (A B C : Pattern) :
@@ -493,27 +490,32 @@ Section FOL_helpers.
         all: auto.
   Defined.
 
+  (* TODO: remove these hints *)
   #[local] Hint Resolve syllogism_intro : core.
 
   Lemma syllogism_intro_indifferent
-        P Γ A B C
+        P {Pip : IndifProp P} Γ A B C
         (wfA : well_formed A)
         (wfB : well_formed B)
         (wfC : well_formed C)
         (AimpB : Γ ⊢ A ---> B)
         (BimpC : Γ ⊢ B ---> C):
-    indifferent_to_prop P ->
     P _ _ AimpB = false ->
     P _ _ BimpC = false ->
     P _ _ (@syllogism_intro Γ A B C wfA wfB wfC AimpB BimpC) = false.
   Proof.
-    intros Hp H1 H2. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hp4]]].
-    unfold syllogism_intro.
-    rewrite !(Hp1,Hp2,Hp3,Hp4).
-    rewrite H1. rewrite H2.
-    reflexivity.
+    intros H1 H2. unfold syllogism_intro. solve_indif; assumption.
   Qed.
 
+  Program Canonical Structure syllogism_intro_indifferent_S (P : proofbpred) {Pip : IndifProp P}
+          (Γ : Theory) (A B C : Pattern)
+          (wfA : well_formed A)
+          (wfB : well_formed B)
+          (wfC : well_formed C)
+    := ProofProperty2 P (fun pf1 pf2 => @syllogism_intro Γ A B C wfA wfB wfC pf1 pf2) _.
+  Next Obligation.
+    intros. apply syllogism_intro_indifferent; assumption.
+  Qed.
   
   Lemma modus_ponens (Γ : Theory) ( A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ (A ---> (A ---> B) ---> B).
@@ -531,23 +533,17 @@ Section FOL_helpers.
           all: auto 10.
   Defined.
 
+  (* TODO: remove this hint *)
   #[local] Hint Resolve modus_ponens : core.
   
- Lemma modus_ponens_indifferent
-        P Γ A B
+  Lemma modus_ponens_indifferent
+        P {Pip : IndifProp P} Γ A B
         (wfA : well_formed A)
         (wfB : well_formed B):
-    indifferent_to_prop P ->
     P _ _ (@modus_ponens Γ A B wfA wfB) = false.
   Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold modus_ponens.
-    rewrite 3!Hmp. rewrite Hp1. rewrite Hp2.
-    rewrite reorder_meta_indifferent; simpl; auto.
-    + rewrite syllogism_indifferent; auto.
-    + rewrite A_impl_A_indifferent; auto.
+    unfold modus_ponens. solve_indif.
   Qed.
-
 
   Lemma not_not_intro (Γ : Theory) (A : Pattern) :
     well_formed A -> Γ ⊢ (A ---> !(!A)).
@@ -562,6 +558,7 @@ Section FOL_helpers.
 
   #[local] Hint Resolve not_not_intro : core.
 
+  (* FIXME this has a very wrong name. Do we need it at all? *)
   Lemma deduction (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ A -> Γ ⊢ B -> Γ ⊢ (A ---> B).
   Proof.
@@ -616,15 +613,21 @@ Section FOL_helpers.
   Defined.
 
   Lemma P4_indifferent
-        P Γ a b
+        P {Pip : IndifProp P} Γ a b
         (wfa : well_formed a = true)
         (wfb : well_formed b = true):
-    indifferent_to_prop P ->
     P _ _ (@P4 Γ a b wfa wfb) = false.
   Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold P4. rewrite !(Hp1,Hp2,Hp3,Hmp). reflexivity.
+    solve_indif.
   Qed.
+
+  Program Canonical Structure P4_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P}
+          (Γ : Theory) (A B : Pattern)
+          (wfA : well_formed A) (wfB : well_formed B)
+    := ProofProperty0 P (@P4 Γ A B wfA wfB) _.
+  Next Obligation. intros. apply P4_indifferent; assumption. Qed.
+
 
   Lemma conj_intro (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ (A ---> B ---> (A and B)).
@@ -670,6 +673,13 @@ Section FOL_helpers.
     all: auto 10.
   Defined.
 
+  Program Canonical Structure conj_intro_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P}
+          (Γ : Theory) (A B : Pattern)
+          (wfA : well_formed A) (wfB : well_formed B)
+    := ProofProperty0 P (@conj_intro Γ A B wfA wfB) _.
+  Next Obligation. intros. solve_indif. Qed.
+
 
   Lemma conj_intro_meta (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ A -> Γ ⊢ B -> Γ ⊢ (A and B).
@@ -685,22 +695,23 @@ Section FOL_helpers.
   Defined.
   
   Lemma conj_intro_meta_indifferent
-        P Γ A B
+        P {Pip : IndifProp P} Γ A B
         (wfA : well_formed A)
         (wfB : well_formed B)
         (HA : Γ ⊢ A)
         (HB : Γ ⊢ B):
-    indifferent_to_prop P ->
     P _ _ HA = false ->
     P _ _ HB = false ->
     P _ _ (@conj_intro_meta Γ A B wfA wfB HA HB) = false.
-  Proof.
-    intros Hp H1 H2. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold conj_intro_meta. unfold conj_intro.
-    rewrite !(Hp1,Hp2,Hp3,Hmp). rewrite H1. rewrite H2.
-    reflexivity.
-  Qed.
+  Proof. intros H1 H2. solve_indif; assumption. Qed.
 
+  Canonical Structure conj_intro_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P}
+          (Γ : Theory) (A B : Pattern)
+          (wfA : well_formed A) (wfB : well_formed B)
+    := ProofProperty2 P _ (@conj_intro_meta_indifferent P _ Γ _ _ wfA wfB).
+
+  
   (* Lemma conj_intro_meta_e (Γ : Theory) (A B : Pattern) : *) 
   Definition conj_intro_meta_e := conj_intro_meta.    (*The same as conj_intro_meta*)
 
@@ -754,25 +765,25 @@ Section FOL_helpers.
   Defined.
 
   Lemma syllogism_4_meta_indifferent
-        P Γ a b c d
+        P {Pip : IndifProp P} Γ a b c d
         (wfa : well_formed a = true)
         (wfb : well_formed b = true)
         (wfc : well_formed c = true)
         (wfd : well_formed d = true)
         (pf1 : Γ ⊢ a ---> b ---> c)
         (pf2 : Γ ⊢ c ---> d):
-    indifferent_to_prop P ->
     P _ _ pf1 = false ->
     P _ _ pf2 = false ->
     P _ _ (@syllogism_4_meta Γ a b c d wfa wfb wfc wfd pf1 pf2) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    intros Hpf1 Hpf2.
-    unfold syllogism_4_meta.
-    rewrite !(Hp1,Hp2,Hp3,Hmp).
-    rewrite Hpf1. rewrite Hpf2.
-    reflexivity.
-  Qed.
+  Proof. intros. solve_indif; assumption. Qed.
+
+  Canonical Structure syllogism_4_meta_indifferent_S
+        P {Pip : IndifProp P} Γ a b c d
+        (wfa : well_formed a = true)
+        (wfb : well_formed b = true)
+        (wfc : well_formed c = true)
+        (wfd : well_formed d = true)
+    := ProofProperty2 P _ (@syllogism_4_meta_indifferent P _ Γ _ _ _ _ wfa wfb wfc wfd).
 
 
   Lemma bot_elim (Γ : Theory) (A : Pattern) :
@@ -793,16 +804,14 @@ Section FOL_helpers.
   Defined.
 
   Lemma bot_elim_indifferent
-        P Γ a (wfa : well_formed a = true):
-    indifferent_to_prop P ->
+        P {Pip : IndifProp P} Γ a (wfa : well_formed a = true):
     P _ _ (@bot_elim Γ a wfa) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    { unfold bot_elim. do 4 rewrite Hmp. rewrite Hp1. simpl.
-      rewrite Hp2. simpl. rewrite P4_indifferent; auto. simpl.
-      rewrite Hp1. simpl. rewrite P4_indifferent; auto. }
-  Qed.
+  Proof. solve_indif. Qed.
 
+  Canonical Structure bot_elim_indifferent_S
+        P {Pip : IndifProp P} Γ a
+        (wfa : well_formed a = true)
+    := ProofProperty0 P _ (@bot_elim_indifferent P _ Γ _ wfa).
 
   Lemma modus_ponens' (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ (A ---> (!B ---> !A) ---> B).
@@ -814,6 +823,11 @@ Section FOL_helpers.
     Unshelve.
     all: auto.
   Defined.
+
+  Program Canonical Structure modus_ponens'_indifferent_S
+            P {Pip : IndifProp P} Γ A B (wfA : well_formed A) (wfB : well_formed B)
+    := ProofProperty0 P (@modus_ponens' Γ A B wfA wfB) _.
+  Next Obligation. intros. solve_indif. Qed.
 
   Lemma disj_right_intro (Γ : Theory) (A B : Pattern) :
     well_formed A -> well_formed B -> Γ ⊢ (B ---> (A or B)).
@@ -829,15 +843,17 @@ Section FOL_helpers.
   #[local] Hint Resolve disj_right_intro : core.
 
   Lemma disj_right_intro_indifferent
-        P Γ a b
+        P {Pip : IndifProp P} Γ a b
         (wfa : well_formed a = true)
         (wfb : well_formed b = true) :
-    indifferent_to_prop P ->
     P _ _ (@disj_right_intro Γ a b wfa wfb) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold disj_right_intro. rewrite Hp1. reflexivity.
-  Qed.
+  Proof. solve_indif. Qed.
+
+  Canonical Structure disj_right_intro_indifferent_S
+        P {Pip : IndifProp P} Γ a b
+        (wfa : well_formed a = true)
+        (wfb : well_formed b = true)
+    := ProofProperty0 P _ (@disj_right_intro_indifferent P _ Γ a b wfa wfb).
 
   
   Lemma disj_left_intro (Γ : Theory) (A B : Pattern) :
@@ -852,20 +868,17 @@ Section FOL_helpers.
   #[local] Hint Resolve disj_left_intro : core.
 
   Lemma disj_left_intro_indifferent
-        P Γ a b
+        P {Pip : IndifProp P} Γ a b
         (wfa : well_formed a = true)
         (wfb : well_formed b = true) :
-    indifferent_to_prop P ->
     P _ _ (@disj_left_intro Γ a b wfa wfb) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold disj_left_intro.
-    rewrite syllogism_4_meta_indifferent; auto.
-    { rewrite modus_ponens_indifferent; auto. }
-    rewrite bot_elim_indifferent.
-    assumption. reflexivity.
-  Qed.
+  Proof. solve_indif. Qed.
 
+  Canonical Structure disj_left_intro_indifferent_S
+        P {Pip : IndifProp P} Γ a b
+        (wfa : well_formed a = true)
+        (wfb : well_formed b = true)
+    := ProofProperty0 P _ (@disj_left_intro_indifferent P _ Γ a b wfa wfb).
 
   Lemma disj_right_intro_meta (Γ : Theory) (A B : Pattern) :
     well_formed A ->

--- a/matching-logic/src/ProofMode.v
+++ b/matching-logic/src/ProofMode.v
@@ -2223,6 +2223,16 @@ Next Obligation.
   rewrite cast_indif0. simpl in *. unfold liftP in H. apply H.
 Qed.
 
+Program Canonical Structure cast_proof_mg_goal_indifferent_S
+        {Σ : Signature} (P : proofbpred) {Pic : IndifCast P} (Γ : Theory)
+        (l : list Pattern) (g₁ g₂ : Pattern) (e : g₁ = g₂)
+  := TacticProperty1 P (@cast_proof_mg_goal Σ Γ l g₁ g₂ e) _.
+Next Obligation.
+  intros. unfold liftP. simpl. unfold cast_proof_mg_goal.
+  pose proof (Pic' := Pic). destruct Pic' as [cast_indif0].
+  rewrite cast_indif0. simpl in *. unfold liftP in H. apply H.
+Qed.
+
 Ltac simplLocalContext :=
   match goal with
     | [ |- @of_MyGoal ?Sgm (@mkMyGoal ?Sgm ?Ctx ?l ?g) ] => rewrite {1}[l]/app
@@ -2329,6 +2339,14 @@ Section FOL_helpers.
     5: apply Hg.
     all: assumption.
   Defined.
+
+(*
+  Program Canonical Structure MyGoal_weakenConclusion'_indifferent_S
+          (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+          (l : list Pattern) (g₁ g₂ : Pattern)
+    := TacticProperty1 P (@MyGoal_weakenConclusion Γ l g₁ g₂) _.
+  Next Obligation.
+*)
   
   Lemma prf_contraction Γ a b:
     well_formed a ->
@@ -2342,21 +2360,12 @@ Section FOL_helpers.
   Defined.
 
   #[local] Hint Resolve prf_contraction : core.
-  
-  Lemma prf_contraction_indifferent
-        P Γ a b
-        (wfa : well_formed a)
-        (wfb : well_formed b):
-    indifferent_to_prop P ->
-    P _ _ (@prf_contraction Γ a b wfa wfb) = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold prf_contraction.
-    rewrite Hmp. rewrite modus_ponens_indifferent;[assumption|].
-    rewrite Hp2.
-    reflexivity.
-  Qed.
 
+  Program Canonical Structure prf_contraction_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (ϕ₁ ϕ₂ : Pattern) (wfϕ₁ : well_formed ϕ₁) (wfϕ₂ : well_formed ϕ₂)
+    := ProofProperty0 P (@prf_contraction Γ ϕ₁ ϕ₂ wfϕ₁ wfϕ₂) _.
+  Next Obligation. solve_indif. Qed.
 
   Lemma prf_weaken_conclusion_under_implication Γ a b c:
     well_formed a ->
@@ -2379,6 +2388,13 @@ Section FOL_helpers.
     4: apply H4. all: auto 10.
   Defined.
 
+  Program Canonical Structure prf_weaken_conclusion_under_implication_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (ϕ₁ ϕ₂ ϕ₃ : Pattern)
+            (wfϕ₁ : well_formed ϕ₁) (wfϕ₂ : well_formed ϕ₂) (wfϕ₃ : well_formed ϕ₃)
+    := ProofProperty0 P (@prf_weaken_conclusion_under_implication Γ ϕ₁ ϕ₂ ϕ₃ wfϕ₁ wfϕ₂ wfϕ₃) _.
+  Next Obligation. solve_indif. Qed.
+
   Lemma prf_weaken_conclusion_under_implication_meta Γ a b c:
     well_formed a ->
     well_formed b ->
@@ -2391,6 +2407,14 @@ Section FOL_helpers.
     4: apply prf_weaken_conclusion_under_implication.
     all: auto 10.
   Defined.
+
+  Program Canonical Structure prf_weaken_conclusion_under_implication_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (ϕ₁ ϕ₂ ϕ₃ : Pattern)
+            (wfϕ₁ : well_formed ϕ₁) (wfϕ₂ : well_formed ϕ₂) (wfϕ₃ : well_formed ϕ₃)
+    := ProofProperty1 P (@prf_weaken_conclusion_under_implication_meta Γ ϕ₁ ϕ₂ ϕ₃ wfϕ₁ wfϕ₂ wfϕ₃) _.
+  Next Obligation. solve_indif; assumption. Qed.
+
 
   Lemma prf_weaken_conclusion_under_implication_meta_meta Γ a b c:
     well_formed a ->
@@ -2405,6 +2429,13 @@ Section FOL_helpers.
     4: apply prf_weaken_conclusion_under_implication_meta. 3: apply H2.
     all: auto.
   Defined.
+
+  Program Canonical Structure prf_weaken_conclusion_under_implication_meta_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (ϕ₁ ϕ₂ ϕ₃ : Pattern)
+            (wfϕ₁ : well_formed ϕ₁) (wfϕ₂ : well_formed ϕ₂) (wfϕ₃ : well_formed ϕ₃)
+    := ProofProperty2 P (@prf_weaken_conclusion_under_implication_meta_meta Γ ϕ₁ ϕ₂ ϕ₃ wfϕ₁ wfϕ₂ wfϕ₃) _.
+  Next Obligation. solve_indif; assumption. Qed.
 
   Lemma prf_weaken_conclusion_iter_under_implication Γ l g g':
     wf l ->
@@ -2422,57 +2453,12 @@ Section FOL_helpers.
     eapply Modus_ponens. 4: apply H2. all: subst;auto 10.
   Defined.
 
-  Lemma prf_weaken_conclusion_iter_under_implication_indifferent
-        P Γ l g g'
-        (wfl : wf l)
-        (wfg : well_formed g)
-        (wfg' : well_formed g'):
-    indifferent_to_prop P ->
-    P _ _ (@prf_weaken_conclusion_iter_under_implication Γ l g g' wfl wfg wfg') = false.
-  Proof.
-    intros Hp. pose proof (Hp' := Hp). destruct Hp' as [Hp1 [Hp2 [Hp3 Hmp]]].
-    unfold prf_weaken_conclusion_iter_under_implication.
-    rewrite Hmp.
-
-    (*simpl. rewrite !orbF.*)
-    unfold eq_rec_r. unfold eq_rec. unfold eq_rect.
-    remember (eq_sym (@erefl _ (g ---> g'))) as eqs.
-    clear Heqeqs.
-    move: (well_formed_imp wfg wfg').
-    replace eqs with (@erefl Pattern (g ---> g')).
-    2: { apply UIP_dec. intros. apply Pattern_eqdec. }
-
-    remember (eq_sym (@erefl _ (foldr patt_imp g l))) as eqs2.
-    clear Heqeqs2.
-    replace eqs2 with (@erefl Pattern (foldr patt_imp g l)).
-    2: { apply UIP_dec. intros. apply Pattern_eqdec. }
-
-    remember (eq_sym (@erefl _ (foldr patt_imp g' l))) as eqs3.
-    clear Heqeqs3.
-    replace eqs3 with (@erefl Pattern (foldr patt_imp g' l)).
-    2: { apply UIP_dec. intros. apply Pattern_eqdec. }
-
-    intros wfi.
-    rewrite prf_weaken_conclusion_iter_indifferent; simpl; auto.
-    rewrite reorder_meta_indifferent; auto.
-    unfold prf_weaken_conclusion_under_implication.
-    unfold prf_weaken_conclusion_meta_meta.
-    rewrite Hmp. unfold eq_rec_r. unfold eq_rec. unfold eq_rect. unfold eq_sym.
-    simpl.
-    pose proof (Htmp := prf_weaken_conclusion_iter_meta_meta_indifferent).
-    specialize (Htmp P Γ).
-    specialize (Htmp [(g ---> g') ---> foldr patt_imp g l;
-       foldr patt_imp g l ---> (g ---> g') ---> foldr patt_imp g' l]).
-    simpl in Htmp. rewrite Htmp; simpl; auto.
-    - rewrite prf_contraction_indifferent; [assumption|].
-      reflexivity.
-    - rewrite syllogism_indifferent; [assumption|].
-      reflexivity.
-    - clear Htmp. rewrite prf_weaken_conclusion_meta_indifferent; [assumption|idtac|reflexivity].
-      rewrite prf_strenghten_premise_meta_indifferent; auto.
-      rewrite reorder_indifferent; auto.
-  Qed.
-
+  Program Canonical Structure prf_weaken_conclusion_iter_under_implication_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l : list Pattern) (ϕ₁ ϕ₂ : Pattern)
+            (wfl : wf l) (wfϕ₁ : well_formed ϕ₁) (wfϕ₂ : well_formed ϕ₂)
+    := ProofProperty0 P (@prf_weaken_conclusion_iter_under_implication Γ l ϕ₁ ϕ₂ wfl wfϕ₁ wfϕ₂) _.
+  Next Obligation. intros. solve_indif. Defined.
 
   Lemma prf_weaken_conclusion_iter_under_implication_meta Γ l g g':
     wf l ->
@@ -2485,6 +2471,13 @@ Section FOL_helpers.
     eapply Modus_ponens. 4: apply prf_weaken_conclusion_iter_under_implication.
     all: auto.
   Defined.
+
+  Program Canonical Structure prf_weaken_conclusion_iter_under_implication_meta_indifferent_S
+            (P : proofbpred) {Pip : IndifProp P} (Γ : Theory)
+            (l : list Pattern) (ϕ₁ ϕ₂ : Pattern)
+            (wfl : wf l) (wfϕ₁ : well_formed ϕ₁) (wfϕ₂ : well_formed ϕ₂)
+    := ProofProperty1 P (@prf_weaken_conclusion_iter_under_implication_meta Γ l ϕ₁ ϕ₂ wfl wfϕ₁ wfϕ₂) _.
+  Next Obligation. intros. solve_indif; assumption. Defined.
   
   Lemma MyGoal_weakenConclusion_under_first_implication Γ l g g':
     @mkMyGoal Σ Γ ((g ---> g') :: l) g ->

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -4034,10 +4034,37 @@ Lemma disj_equals_greater_1 {Σ : Signature} {syntax : Syntax} Γ ϕ₁ ϕ₂:
   Γ ⊢ (ϕ₁ ⊆ml ϕ₂) ---> ((ϕ₁ or ϕ₂) =ml ϕ₂).
 Proof.
   intros HΓ wfϕ₁ wfϕ₂.
-  toMyGoal.
-  { wf_auto2. }
-  mgIntro.
-  (* TODO *)
+  unshelve (eapply deduction_theorem_noKT).
+  2,3: wf_auto2.
+  2: exact HΓ.
+  {
+    apply phi_impl_total_phi_meta.
+    { wf_auto2. }
+    apply pf_iff_split.
+    1,2: wf_auto2.
+    - toMyGoal. wf_auto2. mgIntro. mgDestructOr 0.
+      + assert (Γ ∪ {[ϕ₁ ---> ϕ₂]} ⊢ ϕ₁ ---> ϕ₂).
+        { apply hypothesis. wf_auto2. set_solver. }
+        mgApplyMeta H. mgExactn 0.
+      + mgExactn 0.
+    - apply disj_right_intro; assumption.
+  }
+  {
+    simpl. rewrite !orbF.
+    Set Printing Implicit.
+    pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_ex_gen Σ (free_evars ϕ₁ ∪ free_evars ϕ₂)) (Γ ∪ {[ϕ₁ ---> ϕ₂]}) []).
+    simpl in Htmp. specialize (Htmp (ϕ₁ or ϕ₂) (ϕ₂)). simpl in Htmp.
+    apply Htmp; clear Htmp.
+    { apply indifferent_to_cast_uses_ex_gen. }
+    intros.
+
+    pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (free_evars ϕ₁ ∪ free_evars ϕ₂)) (Γ ∪ {[ϕ₁ ---> ϕ₂]})).
+    simpl in Htmp. specialize (Htmp [ϕ₁ or ϕ₂] [ϕ₁ or ϕ₂]). simpl in Htmp. rewrite Htmp; clear Htmp.
+    { apply indifferent_to_cast_uses_ex_gen. }
+    (* TODO lemmas for these. *)
+    unfold MyGoal_disj_elim. Search prf_disj_elim_iter_2_meta_meta.
+    { reflexivity. }    
+  }
 Abort.
 
 

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -3693,15 +3693,76 @@ Proof.
       apply not_not_intro.
       assumption.
     }
-    { simpl. Search uses_ex_gen.
+    { simpl.
       rewrite !orbF.
       rewrite orb_false_iff. split.
       {
         simpl.
-        Check MyGoal_intro_indifferent.
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_ex_gen Σ (free_evars ϕ ∪ ∅)) Γ [⊥]).
-        simpl in Htmp. eapply Htmp.
-        eapply indifferent_to_prop_uses_ex_gen.
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_ex_gen Σ (free_evars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) []).
+        simpl in Htmp. apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_ex_gen. }
+        unfold MyGoal_applyMetaIn.
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⊥] [⊥]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_ex_gen. }
+
+        pose proof (Htmp := prf_strenghten_premise_iter_meta_meta_indifferent).
+        specialize (Htmp (@uses_ex_gen Σ (free_evars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) [] [] (⌈ ϕ ⌉) ⊥ (⌈ ϕ ⌉)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        rewrite [(foldr (@patt_imp Σ) ⌈ ϕ ⌉ ([] ++ [⊥]))]/= in Htmp.
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_ex_gen. }
+        { reflexivity. }
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        2: { apply indifferent_to_cast_uses_ex_gen. }
+        2: { wf_auto2. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_ex_gen. }
+
+        pose proof (Htmp := @MyGoal_exactn_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [] [] (⌈ ϕ ⌉)). apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_ex_gen. }
+      }
+
+      {
+        simpl.
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_ex_gen Σ (free_evars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) []).
+        simpl in Htmp. apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_ex_gen. }
+        unfold MyGoal_applyMetaIn.
+        intros.
+
+        pose proof (Htmp := @MyGoal_add_indifferent Σ (@uses_ex_gen Σ (free_evars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_ex_gen. }
+        { reflexivity. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⌊ ! ϕ ⌋; ⌈ ϕ ⌉] [⌊ ! ϕ ⌋; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_ex_gen. }
+
+        pose proof (Htmp := @MyGoal_weakenConclusion_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_ex_gen. }
+        intros.
+
+
+        simpl in Htmp
+        Search MyGoal_weakenConclusion.
+        Search MyGoal_add.
+
       }
       Search cast_proof.
 

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -3819,21 +3819,17 @@ Proof.
   }
   {
     simpl. rewrite !orbF.
-    Set Printing Implicit.
-    pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_ex_gen Σ (free_evars ϕ₁ ∪ free_evars ϕ₂)) (Γ ∪ {[ϕ₁ ---> ϕ₂]}) []).
-    simpl in Htmp. specialize (Htmp (ϕ₁ or ϕ₂) (ϕ₂)). simpl in Htmp.
-    apply Htmp; clear Htmp.
-    { apply indifferent_to_cast_uses_ex_gen. }
-    intros.
-
-    pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (free_evars ϕ₁ ∪ free_evars ϕ₂)) (Γ ∪ {[ϕ₁ ---> ϕ₂]})).
-    simpl in Htmp. specialize (Htmp [ϕ₁ or ϕ₂] [ϕ₁ or ϕ₂]). simpl in Htmp. rewrite Htmp; clear Htmp.
-    { apply indifferent_to_cast_uses_ex_gen. }
-    (* TODO lemmas for these. *)
-    unfold MyGoal_disj_elim. Search prf_disj_elim_iter_2_meta_meta.
-    { reflexivity. }    
+    solve_indif. reflexivity.
   }
-Abort.
+  {
+    simpl. rewrite !orbF.
+    solve_indif. reflexivity.
+  }
+  {
+    simpl. rewrite !orbF.
+    solve_indif. reflexivity.
+  }
+Defined.
 
 
 Lemma disj_equals_greater_2_meta {Σ : Signature} {syntax : Syntax} Γ ϕ₁ ϕ₂:

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -3709,71 +3709,12 @@ Proof.
       rewrite orb_false_iff. split.
       {
         simpl.
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_ex_gen Σ (free_evars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) []).
-        simpl in Htmp. apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_ex_gen. }
-        unfold MyGoal_applyMetaIn.
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⊥] [⊥]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_ex_gen. }
-
-        pose proof (Htmp := prf_strenghten_premise_iter_meta_meta_indifferent).
-        specialize (Htmp (@uses_ex_gen Σ (free_evars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) [] [] (⌈ ϕ ⌉) ⊥ (⌈ ϕ ⌉)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        rewrite [(foldr (@patt_imp Σ) ⌈ ϕ ⌉ ([] ++ [⊥]))]/= in Htmp.
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_ex_gen. }
-        { reflexivity. }
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        2: { apply indifferent_to_cast_uses_ex_gen. }
-        2: { wf_auto2. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_ex_gen. }
-
-        pose proof (Htmp := @MyGoal_exactn_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [] [] (⌈ ϕ ⌉)). apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_ex_gen. }
+        solve_indif.
       }
 
       {
         simpl.
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_ex_gen Σ (free_evars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) []).
-        simpl in Htmp. apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_ex_gen. }
-        unfold MyGoal_applyMetaIn.
-        intros.
-
-        pose proof (Htmp := @MyGoal_add_indifferent Σ (@uses_ex_gen Σ (free_evars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_ex_gen. }
-        { reflexivity. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⌊ ! ϕ ⌋; ⌈ ϕ ⌉] [⌊ ! ϕ ⌋; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_ex_gen. }
-
-        pose proof (Htmp := @MyGoal_weakenConclusion_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_ex_gen. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_ex_gen. }
-        
-        reflexivity.
+        solve_indif; auto.
       }
     }
 
@@ -3782,71 +3723,12 @@ Proof.
       rewrite orb_false_iff. split.
       {
         simpl.
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_svar_subst Σ (free_svars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) []).
-        simpl in Htmp. apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_svar_subst. }
-        unfold MyGoal_applyMetaIn.
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⊥] [⊥]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_svar_subst. }
-
-        pose proof (Htmp := prf_strenghten_premise_iter_meta_meta_indifferent).
-        specialize (Htmp (@uses_svar_subst Σ (free_svars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) [] [] (⌈ ϕ ⌉) ⊥ (⌈ ϕ ⌉)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        rewrite [(foldr (@patt_imp Σ) ⌈ ϕ ⌉ ([] ++ [⊥]))]/= in Htmp.
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_svar_subst. }
-        { reflexivity. }
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        2: { apply indifferent_to_cast_uses_svar_subst. }
-        2: { wf_auto2. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_svar_subst. }
-
-        pose proof (Htmp := @MyGoal_exactn_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [] [] (⌈ ϕ ⌉)). apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_svar_subst. }
+        solve_indif.
       }
 
       {
         simpl.
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_svar_subst Σ (free_svars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) []).
-        simpl in Htmp. apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_svar_subst. }
-        unfold MyGoal_applyMetaIn.
-        intros.
-
-        pose proof (Htmp := @MyGoal_add_indifferent Σ (@uses_svar_subst Σ (free_svars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_svar_subst. }
-        { reflexivity. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⌊ ! ϕ ⌋; ⌈ ϕ ⌉] [⌊ ! ϕ ⌋; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_svar_subst. }
-
-        pose proof (Htmp := @MyGoal_weakenConclusion_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_svar_subst. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_svar_subst. }
-        
-        reflexivity.
+        solve_indif; auto.
       }
     }
 
@@ -3854,72 +3736,12 @@ Proof.
       rewrite !orbF.
       rewrite orb_false_iff. split.
       {
-        simpl.
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]}) []).
-        simpl in Htmp. apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_kt. }
-        unfold MyGoal_applyMetaIn.
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ ) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⊥] [⊥]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_kt. }
-
-        pose proof (Htmp := prf_strenghten_premise_iter_meta_meta_indifferent).
-        specialize (Htmp (@uses_kt Σ ) (Γ ∪ {[! ϕ]}) [] [] (⌈ ϕ ⌉) ⊥ (⌈ ϕ ⌉)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        specialize (Htmp ltac:(wf_auto2)).
-        rewrite [(foldr (@patt_imp Σ) ⌈ ϕ ⌉ ([] ++ [⊥]))]/= in Htmp.
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_kt. }
-        { reflexivity. }
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        2: { apply indifferent_to_cast_uses_kt. }
-        2: { wf_auto2. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_kt. }
-
-        pose proof (Htmp := @MyGoal_exactn_indifferent Σ (@uses_kt Σ ) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [] [] (⌈ ϕ ⌉)). apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_kt. }
+        solve_indif.
       }
 
       {
         simpl.
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]}) []).
-        simpl in Htmp. apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_kt. }
-        unfold MyGoal_applyMetaIn.
-        intros.
-
-        pose proof (Htmp := @MyGoal_add_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_kt. }
-        { reflexivity. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp [⌊ ! ϕ ⌋; ⌈ ϕ ⌉] [⌊ ! ϕ ⌋; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_kt. }
-
-        pose proof (Htmp := @MyGoal_weakenConclusion_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_prop_uses_kt. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
-        simpl in Htmp. specialize (Htmp  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_kt. }
-        
-        reflexivity.
+        solve_indif; auto.
       }
     }
     - eapply syllogism_intro with (B := ⌊ ⌈ ϕ ⌉ ⌋).
@@ -3942,28 +3764,10 @@ Proof.
       rewrite !orbF.
       rewrite orb_false_iff. split.
       {
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_ex_gen Σ (∅ ∪ free_evars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]}) []).
-        simpl in Htmp. specialize (Htmp Top (⌈ ϕ ⌉)). simpl in Htmp.
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_ex_gen. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (∅ ∪ free_evars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]})).
-        simpl in Htmp. specialize (Htmp [Top] [Top]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_ex_gen. }
-        { reflexivity. }
+        solve_indif. reflexivity.
       }
       {
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_ex_gen Σ (∅ ∪ free_evars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]}) []).
-        simpl in Htmp. specialize (Htmp (⌈ ϕ ⌉) Top). simpl in Htmp.
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_ex_gen. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (∅ ∪ free_evars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]})).
-        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉]  [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_ex_gen. }
-        reflexivity.
+        solve_indif.
       }
     }
 
@@ -3971,28 +3775,10 @@ Proof.
       rewrite !orbF.
       rewrite orb_false_iff. split.
       {
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_svar_subst Σ (∅ ∪ free_svars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]}) []).
-        simpl in Htmp. specialize (Htmp Top (⌈ ϕ ⌉)). simpl in Htmp.
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_svar_subst. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (∅ ∪ free_svars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]})).
-        simpl in Htmp. specialize (Htmp [Top] [Top]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_svar_subst. }
-        { reflexivity. }
+        solve_indif. reflexivity.
       }
       {
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_svar_subst Σ (∅ ∪ free_svars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]}) []).
-        simpl in Htmp. specialize (Htmp (⌈ ϕ ⌉) Top). simpl in Htmp.
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_svar_subst. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (∅ ∪ free_svars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]})).
-        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉]  [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_svar_subst. }
-        reflexivity.
+        solve_indif.
       }
     }
 
@@ -4000,28 +3786,10 @@ Proof.
       rewrite !orbF.
       rewrite orb_false_iff. split.
       {
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_kt Σ) (Γ ∪ {[⌈ ϕ ⌉]}) []).
-        simpl in Htmp. specialize (Htmp Top (⌈ ϕ ⌉)). simpl in Htmp.
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_kt. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[⌈ ϕ ⌉]})).
-        simpl in Htmp. specialize (Htmp [Top] [Top]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_kt. }
-        { reflexivity. }
+        solve_indif. reflexivity.
       }
       {
-        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_kt Σ) (Γ ∪ {[⌈ ϕ ⌉]}) []).
-        simpl in Htmp. specialize (Htmp (⌈ ϕ ⌉) Top). simpl in Htmp.
-        apply Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_kt. }
-        intros.
-
-        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[⌈ ϕ ⌉]})).
-        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉]  [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
-        { apply indifferent_to_cast_uses_kt. }
-        reflexivity.
+        solve_indif.
       }
     }
 

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -3758,13 +3758,160 @@ Proof.
         { apply indifferent_to_prop_uses_ex_gen. }
         intros.
 
-
-        simpl in Htmp
-        Search MyGoal_weakenConclusion.
-        Search MyGoal_add.
-
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (@free_evars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_ex_gen. }
+        
+        reflexivity.
       }
-      Search cast_proof.
+    }
+
+    { simpl.
+      rewrite !orbF.
+      rewrite orb_false_iff. split.
+      {
+        simpl.
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_svar_subst Σ (free_svars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) []).
+        simpl in Htmp. apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_svar_subst. }
+        unfold MyGoal_applyMetaIn.
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⊥] [⊥]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_svar_subst. }
+
+        pose proof (Htmp := prf_strenghten_premise_iter_meta_meta_indifferent).
+        specialize (Htmp (@uses_svar_subst Σ (free_svars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) [] [] (⌈ ϕ ⌉) ⊥ (⌈ ϕ ⌉)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        rewrite [(foldr (@patt_imp Σ) ⌈ ϕ ⌉ ([] ++ [⊥]))]/= in Htmp.
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_svar_subst. }
+        { reflexivity. }
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        2: { apply indifferent_to_cast_uses_svar_subst. }
+        2: { wf_auto2. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_svar_subst. }
+
+        pose proof (Htmp := @MyGoal_exactn_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [] [] (⌈ ϕ ⌉)). apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_svar_subst. }
+      }
+
+      {
+        simpl.
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_svar_subst Σ (free_svars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]}) []).
+        simpl in Htmp. apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_svar_subst. }
+        unfold MyGoal_applyMetaIn.
+        intros.
+
+        pose proof (Htmp := @MyGoal_add_indifferent Σ (@uses_svar_subst Σ (free_svars ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_svar_subst. }
+        { reflexivity. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⌊ ! ϕ ⌋; ⌈ ϕ ⌉] [⌊ ! ϕ ⌋; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_svar_subst. }
+
+        pose proof (Htmp := @MyGoal_weakenConclusion_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_svar_subst. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (@free_svars Σ ϕ ∪ ∅)) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_svar_subst. }
+        
+        reflexivity.
+      }
+    }
+
+    { simpl.
+      rewrite !orbF.
+      rewrite orb_false_iff. split.
+      {
+        simpl.
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]}) []).
+        simpl in Htmp. apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_kt. }
+        unfold MyGoal_applyMetaIn.
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ ) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⊥] [⊥]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_kt. }
+
+        pose proof (Htmp := prf_strenghten_premise_iter_meta_meta_indifferent).
+        specialize (Htmp (@uses_kt Σ ) (Γ ∪ {[! ϕ]}) [] [] (⌈ ϕ ⌉) ⊥ (⌈ ϕ ⌉)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        specialize (Htmp ltac:(wf_auto2)).
+        rewrite [(foldr (@patt_imp Σ) ⌈ ϕ ⌉ ([] ++ [⊥]))]/= in Htmp.
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_kt. }
+        { reflexivity. }
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        2: { apply indifferent_to_cast_uses_kt. }
+        2: { wf_auto2. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉] [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_kt. }
+
+        pose proof (Htmp := @MyGoal_exactn_indifferent Σ (@uses_kt Σ ) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [] [] (⌈ ϕ ⌉)). apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_kt. }
+      }
+
+      {
+        simpl.
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]}) []).
+        simpl in Htmp. apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_kt. }
+        unfold MyGoal_applyMetaIn.
+        intros.
+
+        pose proof (Htmp := @MyGoal_add_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_kt. }
+        { reflexivity. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp [⌊ ! ϕ ⌋; ⌈ ϕ ⌉] [⌊ ! ϕ ⌋; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_kt. }
+
+        pose proof (Htmp := @MyGoal_weakenConclusion_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_prop_uses_kt. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[! ϕ]})).
+        simpl in Htmp. specialize (Htmp  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]  [⌈ ! ! ϕ ⌉ ---> ⊥; ⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_kt. }
+        
+        reflexivity.
+      }
+    }
+    - 
 
 Defined.
 

--- a/matching-logic/src/Theories/Definedness.v
+++ b/matching-logic/src/Theories/Definedness.v
@@ -3643,6 +3643,19 @@ Proof.
   mgSplitAnd; mgIntro; mgExactn 0.
 Defined.
 
+Lemma def_def_phi_impl_tot_def_phi {Σ : Signature} {syntax : Syntax} Γ ϕ :
+  theory ⊆ Γ ->
+  well_formed ϕ ->
+  Γ ⊢ ⌈ ⌈ ϕ ⌉ ⌉ ---> ⌊ ⌈ ϕ ⌉ ⌋.
+Proof.
+  intros HΓ wfϕ.
+  eapply syllogism_intro.
+  1,3: wf_auto2.
+  2: { apply def_def_phi_impl_def_phi; assumption. }
+  { wf_auto2. }
+  apply def_phi_impl_tot_def_phi; assumption.
+Defined.
+
 
 Lemma ceil_is_predicate {Σ : Signature} {syntax : Syntax} Γ ϕ :
   theory ⊆ Γ ->
@@ -3655,7 +3668,6 @@ Proof.
   { wf_auto2. }
   { wf_auto2. }
   unfold patt_or.
-  Check syllogism_intro.
   apply syllogism_intro with (B := ⌈ ⌈ ϕ ⌉ ⌉).
   1,2,3: wf_auto2.
   - toMyGoal.
@@ -3670,7 +3682,6 @@ Proof.
     fromMyGoal. intros _ _. toMyGoal. wf_auto2.
     mgRewrite (@def_propagate_not Σ syntax Γ ϕ HΓ ltac:(wf_auto2)) at 1.
     fromMyGoal. intros _ _.
-    Check deduction_theorem_noKT.
     unshelve (eapply deduction_theorem_noKT).
     4: exact HΓ.
     2,3: wf_auto2.
@@ -3911,21 +3922,109 @@ Proof.
         reflexivity.
       }
     }
-    - 
+    - eapply syllogism_intro with (B := ⌊ ⌈ ϕ ⌉ ⌋).
+      1,2,3: wf_auto2.
+      { apply def_def_phi_impl_tot_def_phi; assumption. }
+      unshelve (eapply deduction_theorem_noKT).
+      2,3: wf_auto2.
+      2: exact HΓ.
+      {
+        apply phi_impl_total_phi_meta.
+        { wf_auto2. }
+        apply pf_iff_split.
+        1,2: wf_auto2.
+        + toMyGoal. wf_auto2. mgIntro. mgClear 0. fromMyGoal. intros _ _. apply top_holds.
+        + toMyGoal. wf_auto2. mgIntro. mgClear 0. fromMyGoal. intros _ _.
+          apply hypothesis. wf_auto2. set_solver.
+      }
 
-Defined.
+    { simpl.
+      rewrite !orbF.
+      rewrite orb_false_iff. split.
+      {
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_ex_gen Σ (∅ ∪ free_evars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]}) []).
+        simpl in Htmp. specialize (Htmp Top (⌈ ϕ ⌉)). simpl in Htmp.
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_ex_gen. }
+        intros.
 
-Lemma def_def_phi_impl_tot_def_phi {Σ : Signature} {syntax : Syntax} Γ ϕ :
-  theory ⊆ Γ ->
-  well_formed ϕ ->
-  Γ ⊢ ⌈ ⌈ ϕ ⌉ ⌉ ---> ⌊ ⌈ ϕ ⌉ ⌋.
-Proof.
-  intros HΓ wfϕ.
-  eapply syllogism_intro.
-  1,3: wf_auto2.
-  2: { apply def_def_phi_impl_def_phi; assumption. }
-  { wf_auto2. }
-  apply def_phi_impl_tot_def_phi; assumption.
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (∅ ∪ free_evars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]})).
+        simpl in Htmp. specialize (Htmp [Top] [Top]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_ex_gen. }
+        { reflexivity. }
+      }
+      {
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_ex_gen Σ (∅ ∪ free_evars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]}) []).
+        simpl in Htmp. specialize (Htmp (⌈ ϕ ⌉) Top). simpl in Htmp.
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_ex_gen. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_ex_gen Σ (∅ ∪ free_evars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]})).
+        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉]  [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_ex_gen. }
+        reflexivity.
+      }
+    }
+
+    { simpl.
+      rewrite !orbF.
+      rewrite orb_false_iff. split.
+      {
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_svar_subst Σ (∅ ∪ free_svars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]}) []).
+        simpl in Htmp. specialize (Htmp Top (⌈ ϕ ⌉)). simpl in Htmp.
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_svar_subst. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (∅ ∪ free_svars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]})).
+        simpl in Htmp. specialize (Htmp [Top] [Top]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_svar_subst. }
+        { reflexivity. }
+      }
+      {
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_svar_subst Σ (∅ ∪ free_svars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]}) []).
+        simpl in Htmp. specialize (Htmp (⌈ ϕ ⌉) Top). simpl in Htmp.
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_svar_subst. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_svar_subst Σ (∅ ∪ free_svars ϕ)) (Γ ∪ {[⌈ ϕ ⌉]})).
+        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉]  [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_svar_subst. }
+        reflexivity.
+      }
+    }
+
+    { simpl.
+      rewrite !orbF.
+      rewrite orb_false_iff. split.
+      {
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_kt Σ) (Γ ∪ {[⌈ ϕ ⌉]}) []).
+        simpl in Htmp. specialize (Htmp Top (⌈ ϕ ⌉)). simpl in Htmp.
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_kt. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[⌈ ϕ ⌉]})).
+        simpl in Htmp. specialize (Htmp [Top] [Top]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_kt. }
+        { reflexivity. }
+      }
+      {
+        pose proof (Htmp := @MyGoal_intro_indifferent Σ (@uses_kt Σ) (Γ ∪ {[⌈ ϕ ⌉]}) []).
+        simpl in Htmp. specialize (Htmp (⌈ ϕ ⌉) Top). simpl in Htmp.
+        apply Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_kt. }
+        intros.
+
+        pose proof (Htmp := @cast_proof_mg_hyps_indifferent Σ (@uses_kt Σ) (Γ ∪ {[⌈ ϕ ⌉]})).
+        simpl in Htmp. specialize (Htmp [⌈ ϕ ⌉]  [⌈ ϕ ⌉]). simpl in Htmp. rewrite Htmp; clear Htmp.
+        { apply indifferent_to_cast_uses_kt. }
+        reflexivity.
+      }
+    }
+
 Defined.
 
 Lemma disj_equals_greater_1 {Σ : Signature} {syntax : Syntax} Γ ϕ₁ ϕ₂:


### PR DESCRIPTION
* canonical structures for automation or prop/cast indifference of proofs and tactics
* more tactics now use cast_proof properly
* every tactic and proof that preserves no-ex-gen freeness (and similar)  now have a canonical instance
* finish the proof of `disj_equals_greater_1`