### PR TITLE
Proof object generation (WIP)

### DIFF
--- a/prover/_CoqProject
+++ b/prover/_CoqProject
@@ -1,5 +1,6 @@
 -R theories MatchingLogicProver
 
+theories/Matchers.v
 theories/MLTauto.v
 theories/Named.v
 theories/NamedProofSystem.v

--- a/prover/_CoqProject
+++ b/prover/_CoqProject
@@ -1,6 +1,7 @@
 -R theories MatchingLogicProver
 
 theories/Matchers.v
+theories/NMatchers.v
 theories/MLTauto.v
 theories/Named.v
 theories/NamedProofSystem.v

--- a/prover/theories/MMProofExtractor.v
+++ b/prover/theories/MMProofExtractor.v
@@ -495,7 +495,7 @@ Section gen.
               ++ acc)
            ((inl (existT _ pfpiq))::(inl (existT _ pfp))::(inr (lbl "proof-rule-mp"))::pfs') ;
 
-    proof2proof' Γ acc ((inl (existT ϕ (Ex_quan _ p y)))::pfs')
+    proof2proof' Γ acc ((inl (existT ϕ (Ex_quan _ p y _)))::pfs')
       := proof2proof'
            Γ
            ([lbl "proof-rule-exists"]

--- a/prover/theories/Matchers.v
+++ b/prover/theories/Matchers.v
@@ -1,0 +1,134 @@
+From Coq Require Import ssreflect ssrfun ssrbool.
+From Coq Require Import Ensembles Logic.Classical_Prop.
+From Coq Require Import Arith.Wf_nat Relations.Relation_Operators Wellfounded.Wellfounded.
+From Coq Require Import Logic.FunctionalExtensionality.
+From Coq.micromega Require Import Lia.
+
+From Equations Require Import Equations.
+
+From stdpp Require Import base option.
+
+From MatchingLogic Require Import
+     Utils.wflexprod Syntax Semantics DerivedOperators ProofSystem ProofMode
+     Utils.extralibrary
+.
+
+
+Import MatchingLogic.Syntax.Notations MatchingLogic.DerivedOperators.Notations.
+
+
+Global Set Transparent Obligations.
+Derive NoConfusion for Pattern.
+Derive Subterm for Pattern.
+
+
+Open Scope ml_scope.
+
+Equations match_not {Σ : Signature} (p : Pattern)
+  : ({ p' : Pattern & p = patt_not p'}) + (forall p', p <> patt_not p')
+  :=
+  match_not (p' ---> ⊥) := inl _ ;
+  match_not _ := inr _ .
+Solve Obligations with Tactics.program_simplify; CoreTactics.equations_simpl.
+Next Obligation.
+  intros. eapply existT. reflexivity.
+Defined.
+
+Lemma match_not_patt_not  {Σ : Signature} p: is_inl (match_not (patt_not p)).
+Proof.
+  funelim (match_not _). simpl. reflexivity.
+Qed.
+
+Equations match_or {Σ : Signature} (p : Pattern)
+  : ({ p1 : Pattern & {p2 : Pattern & p = patt_or p1 p2}}) + (forall p1 p2, p <> patt_or p1 p2)
+  :=
+  match_or (p1 ---> p2) with match_not p1 => {
+    | inl (existT p1' e) => inl _
+    | inr _ => inr _
+    } ;      
+  match_or _ := inr _.
+Solve Obligations with Tactics.program_simplify; CoreTactics.equations_simpl.
+Next Obligation.
+  intros. inversion e. subst. eapply existT. eapply existT. reflexivity.
+Defined.
+Next Obligation.
+  intros.
+  unfold patt_or.
+  assert (p1 <> patt_not p0). auto.
+  congruence.
+Defined.  
+
+Lemma match_or_patt_or  {Σ : Signature} p1 p2: is_inl (match_or (patt_or p1 p2)).
+Proof. reflexivity. Qed.
+
+Equations?  match_and {Σ : Signature} (p : Pattern)
+  : ({ p1 : Pattern & {p2 : Pattern & p = patt_and p1 p2}}) + (forall p1 p2, p <> patt_and p1 p2)
+  :=
+  match_and p with match_not p => {
+    | inr _ := inr _ ;
+    | inl (existT p' e') with match_or p' => {
+      | inr _ := inr _ ;
+      | inl (existT p1 (existT p2 e12)) with match_not p1 => {
+        | inr _ := inr _ ;
+        | inl (existT np1 enp1) with match_not p2 => {
+          | inr _ := inr _ ;
+          | inl (existT np2 enp2) := inl _
+          }
+        }
+      }                                        
+    }.
+Proof.
+  - subst. eapply existT. eapply existT. reflexivity.
+  - subst. intros. unfold not. intros Hcontra. inversion Hcontra.
+    subst. specialize (n p0). contradiction.
+  - subst. intros. unfold not. intros Hcontra. inversion Hcontra.
+    subst. specialize (n p0). contradiction.
+  - subst. intros. unfold not. intros Hcontra. inversion Hcontra.
+    subst. specialize (n (patt_not p1) (patt_not p2)). contradiction.
+  - intros. unfold not. intros Hcontra. subst.
+    specialize (n ((patt_or (patt_not p1) (patt_not p2)))). contradiction.
+Defined.
+
+Lemma match_and_patt_and  {Σ : Signature} p1 p2: is_inl (match_and (patt_and p1 p2)).
+Proof. reflexivity. Qed.
+
+Lemma match_and_patt_or  {Σ : Signature} p1 p2: is_inl (match_and (patt_or p1 p2)) = false.
+Proof.
+  funelim (match_and _); rewrite -Heqcall; simpl; try reflexivity.
+  subst. try inversion e'.
+Qed.
+
+Equations match_imp {Σ : Signature} (p : Pattern)
+  : ({ p1 : Pattern & {p2 : Pattern & p = patt_imp p1 p2}}) + (forall p1 p2, p <> patt_imp p1 p2)
+  :=
+  match_imp (p1 ---> p2) := inl _ ;
+  match_imp _ := inr _.
+Solve Obligations with Tactics.program_simplify; CoreTactics.equations_simpl.
+Next Obligation.
+  intros. eapply existT. eapply existT. reflexivity.
+Defined.
+
+Lemma match_imp_patt_imp {Σ : Signature} p1 p2: is_inl (match_imp (patt_imp p1 p2)).
+Proof. reflexivity. Qed.
+
+Equations match_bott {Σ : Signature} (p : Pattern)
+  : (p = patt_bott) + (p <> patt_bott)
+  :=
+  match_bott patt_bott := inl _ ;
+  match_bott _ := inr _.
+Solve Obligations with Tactics.program_simplify; CoreTactics.equations_simpl.
+Next Obligation. reflexivity. Defined.
+
+
+Equations match_a_impl_b_impl_c {Σ : Signature} (p : Pattern) :
+  ({a : Pattern & {b : Pattern & {c : Pattern & p = patt_imp a (patt_imp b c)}}})
+  + (forall (a b c : Pattern), p <> patt_imp a (patt_imp b c)) :=
+  match_a_impl_b_impl_c (p1 ---> (p2 ---> p3)) := inl _ ;
+  match_a_impl_b_impl_c _ := inr _ .
+Solve Obligations with Tactics.program_simplify; CoreTactics.equations_simpl.
+Next Obligation.
+  intros Σ p1 p2 p3.
+  do 3 eapply existT.
+  reflexivity.
+Defined.
+

--- a/prover/theories/NMatchers.v
+++ b/prover/theories/NMatchers.v
@@ -1,0 +1,138 @@
+From Coq Require Import ssreflect ssrfun ssrbool.
+From Coq Require Import Ensembles Logic.Classical_Prop.
+From Coq Require Import Arith.Wf_nat Relations.Relation_Operators Wellfounded.Wellfounded.
+From Coq Require Import Logic.FunctionalExtensionality.
+From Coq.micromega Require Import Lia.
+
+From Equations Require Import Equations.
+
+From stdpp Require Import base option.
+
+From MatchingLogic Require Import
+     Utils.wflexprod Syntax Semantics DerivedOperators ProofSystem ProofMode
+     Utils.extralibrary
+.
+
+Import MatchingLogic.Syntax.Notations MatchingLogic.DerivedOperators.Notations.
+
+From MatchingLogicProver Require Import Named.
+
+Global Set Transparent Obligations.
+Derive NoConfusion for NamedPattern.
+Derive Subterm for NamedPattern.
+
+
+Open Scope ml_scope.
+
+Equations nmatch_not {Σ : Signature} (p : NamedPattern)
+  : ({ p' : NamedPattern & p = npatt_not p'}) + (forall p', p <> npatt_not p')
+  :=
+  nmatch_not (npatt_imp p' npatt_bott) := inl _ ;
+  nmatch_not _ := inr _ .
+Solve Obligations with Tactics.program_simplify; CoreTactics.equations_simpl.
+Next Obligation.
+  intros. eapply existT. reflexivity.
+Defined.
+
+(*
+Lemma match_not_patt_not  {Σ : Signature} p: is_inl (match_not (patt_not p)).
+Proof.
+  funelim (match_not _). simpl. reflexivity.
+Qed.
+
+Equations match_or {Σ : Signature} (p : Pattern)
+  : ({ p1 : Pattern & {p2 : Pattern & p = patt_or p1 p2}}) + (forall p1 p2, p <> patt_or p1 p2)
+  :=
+  match_or (p1 ---> p2) with match_not p1 => {
+    | inl (existT p1' e) => inl _
+    | inr _ => inr _
+    } ;      
+  match_or _ := inr _.
+Solve Obligations with Tactics.program_simplify; CoreTactics.equations_simpl.
+Next Obligation.
+  intros. inversion e. subst. eapply existT. eapply existT. reflexivity.
+Defined.
+Next Obligation.
+  intros.
+  unfold patt_or.
+  assert (p1 <> patt_not p0). auto.
+  congruence.
+Defined.  
+
+Lemma match_or_patt_or  {Σ : Signature} p1 p2: is_inl (match_or (patt_or p1 p2)).
+Proof. reflexivity. Qed.
+
+Equations?  match_and {Σ : Signature} (p : Pattern)
+  : ({ p1 : Pattern & {p2 : Pattern & p = patt_and p1 p2}}) + (forall p1 p2, p <> patt_and p1 p2)
+  :=
+  match_and p with match_not p => {
+    | inr _ := inr _ ;
+    | inl (existT p' e') with match_or p' => {
+      | inr _ := inr _ ;
+      | inl (existT p1 (existT p2 e12)) with match_not p1 => {
+        | inr _ := inr _ ;
+        | inl (existT np1 enp1) with match_not p2 => {
+          | inr _ := inr _ ;
+          | inl (existT np2 enp2) := inl _
+          }
+        }
+      }                                        
+    }.
+Proof.
+  - subst. eapply existT. eapply existT. reflexivity.
+  - subst. intros. unfold not. intros Hcontra. inversion Hcontra.
+    subst. specialize (n p0). contradiction.
+  - subst. intros. unfold not. intros Hcontra. inversion Hcontra.
+    subst. specialize (n p0). contradiction.
+  - subst. intros. unfold not. intros Hcontra. inversion Hcontra.
+    subst. specialize (n (patt_not p1) (patt_not p2)). contradiction.
+  - intros. unfold not. intros Hcontra. subst.
+    specialize (n ((patt_or (patt_not p1) (patt_not p2)))). contradiction.
+Defined.
+
+Lemma match_and_patt_and  {Σ : Signature} p1 p2: is_inl (match_and (patt_and p1 p2)).
+Proof. reflexivity. Qed.
+
+Lemma match_and_patt_or  {Σ : Signature} p1 p2: is_inl (match_and (patt_or p1 p2)) = false.
+Proof.
+  funelim (match_and _); rewrite -Heqcall; simpl; try reflexivity.
+  subst. try inversion e'.
+Qed.
+*)
+
+Equations nmatch_imp {Σ : Signature} (p : NamedPattern)
+  : ({ p1 : NamedPattern & {p2 : NamedPattern & p = npatt_imp p1 p2}})
+    + (forall p1 p2, p <> npatt_imp p1 p2)
+  :=
+  nmatch_imp (npatt_imp p1 p2) := inl _ ;
+  nmatch_imp _ := inr _.
+Solve Obligations with Tactics.program_simplify; CoreTactics.equations_simpl.
+Next Obligation.
+  intros. eapply existT. eapply existT. reflexivity.
+Defined.
+
+(*
+Lemma match_imp_patt_imp {Σ : Signature} p1 p2: is_inl (match_imp (patt_imp p1 p2)).
+Proof. reflexivity. Qed.
+
+Equations match_bott {Σ : Signature} (p : Pattern)
+  : (p = patt_bott) + (p <> patt_bott)
+  :=
+  match_bott patt_bott := inl _ ;
+  match_bott _ := inr _.
+Solve Obligations with Tactics.program_simplify; CoreTactics.equations_simpl.
+Next Obligation. reflexivity. Defined.
+*)
+
+Equations nmatch_a_impl_b_impl_c {Σ : Signature} (p : NamedPattern) :
+  ({a : NamedPattern & {b : NamedPattern & {c : NamedPattern & p = npatt_imp a (npatt_imp b c)}}})
+  + (forall (a b c : NamedPattern), p <> npatt_imp a (npatt_imp b c)) :=
+  nmatch_a_impl_b_impl_c (npatt_imp p1 (npatt_imp p2 p3)) := inl _ ;
+  nmatch_a_impl_b_impl_c _ := inr _ .
+Solve Obligations with Tactics.program_simplify; CoreTactics.equations_simpl.
+Next Obligation.
+  intros Σ p1 p2 p3.
+  do 3 eapply existT.
+  reflexivity.
+Defined.
+

--- a/prover/theories/Named.v
+++ b/prover/theories/Named.v
@@ -116,15 +116,23 @@ Section named.
   Definition svm_incr (svm : SVarMap) : SVarMap :=
     kmap S svm.
 
-  Definition incr_one (phi : Pattern) : Pattern :=
+  Definition incr_one_evar (phi : Pattern) : Pattern :=
     match phi with
     | patt_bound_evar n => patt_bound_evar (S n)
-    | patt_bound_svar n => patt_bound_svar (S n)
     | x => x
     end.
 
-  Definition cache_incr (cache : gmap Pattern NamedPattern) : gmap Pattern NamedPattern :=
-    kmap incr_one cache.
+  Definition incr_one_svar (phi : Pattern) : Pattern :=
+    match phi with
+    | patt_bound_svar n => patt_bound_svar (S n)
+    | x => x
+    end.
+  
+  Definition cache_incr_evar (cache : gmap Pattern NamedPattern) : gmap Pattern NamedPattern :=
+    kmap incr_one_evar cache.
+
+  Definition cache_incr_svar (cache : gmap Pattern NamedPattern) : gmap Pattern NamedPattern :=
+    kmap incr_one_svar cache.
 
   Definition evm_fresh (evm : EVarMap) (ϕ : Pattern) : evar
     := evar_fresh (elements (free_evars ϕ ∪ (list_to_set (map snd (map_to_list evm))))).
@@ -212,14 +220,14 @@ Section named.
          | patt_exists phi
            => let: x := evs_fresh used_evars phi in
               let: used_evars_ex := used_evars ∪ {[x]} in
-              let: cache_ex := <[patt_bound_evar 0:=npatt_evar x]>(cache_incr cache) in
+              let: cache_ex := <[patt_bound_evar 0:=npatt_evar x]>(cache_incr_evar cache) in
               let: (nphi, cache', used_evars', used_svars')
                  := to_NamedPattern2' phi cache_ex used_evars_ex used_svars in
               (npatt_exists x nphi, cache', used_evars', used_svars)
          | patt_mu phi
            => let: X := svs_fresh used_svars phi in
               let: used_svars_ex := used_svars ∪ {[X]} in
-              let: cache_ex := <[patt_bound_svar 0:=npatt_svar X]>(cache_incr cache) in
+              let: cache_ex := <[patt_bound_svar 0:=npatt_svar X]>(cache_incr_svar cache) in
               let: (nphi, cache', used_evars', used_svars')
                  := to_NamedPattern2' phi cache_ex used_evars used_svars_ex in
               (npatt_mu X nphi, cache', used_evars', used_svars)

--- a/prover/theories/Named.v
+++ b/prover/theories/Named.v
@@ -183,6 +183,7 @@ Section named.
   Definition not_contain_bound_evar_0 ϕ : Prop := ~~ bevar_occur ϕ 0.
   Definition not_contain_bound_svar_0 ϕ : Prop := ~~ bsvar_occur ϕ 0.
 
+  (* pre: all dangling variables of [\phi] are in [cache].  *)
   Fixpoint to_NamedPattern2'
            (ϕ : Pattern)
            (cache : gmap Pattern NamedPattern)
@@ -554,6 +555,11 @@ Section named_test.
   Definition phi_ex := (patt_imp phi_ex1 phi_ex2).
   Compute to_NamedPattern phi_ex.
   Compute to_NamedPattern2 phi_ex.
+
+  Compute to_NamedPattern2 (@patt_mu sig (patt_mu (patt_bound_svar 1))).
+
+  (* FIXME: decrease after poping out *)
+  Compute to_NamedPattern2 (@patt_mu sig (patt_imp (patt_mu (patt_bound_svar 1)) (patt_bound_svar 0))).
 
   Definition phi_mu1 := (@patt_mu sig (patt_mu (patt_bound_svar 0))).
   Definition phi_mu2 := (@patt_mu sig (patt_bound_svar 0)).

--- a/prover/theories/NamedProofSystem.v
+++ b/prover/theories/NamedProofSystem.v
@@ -5,7 +5,7 @@ From Coq Require Import Strings.String.
 From Equations Require Import Equations.
 
 From stdpp Require Export base.
-From MatchingLogic Require Import Syntax SignatureHelper ProofSystem Helpers.FOL_helpers.
+From MatchingLogic Require Import Syntax SignatureHelper ProofSystem ProofMode.
 From MatchingLogicProver Require Import MMProofExtractor Named.
 
 From stdpp Require Import base finite gmap mapset listset_nodup numbers propset.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -121,7 +121,20 @@ Section proof_system_translation.
       erewrite Heqp2.
       simpl.
       exact Hnone_g0.
-    - 
+    -
+      pose proof (Hnone_g0 := IHϕ₁
+                                (<[BoundVarSugar.b0:=npatt_evar (evs_fresh evs ϕ₁)]> (cache_incr C))
+                                (evs ∪ {[evs_fresh evs ϕ₁]}) s ϕ₂)
+      .
+      feed specialize Hnone_g0.
+      { rewrite Heqp2. simpl. exact Hnone. }
+      
+      destruct (decide (ϕ₂ = BoundVarSugar.b0)).
+      { subst ϕ₂. rewrite lookup_insert in Hnone_g0. inversion Hnone_g0. }
+      Search lookup insert.
+      rewrite lookup_insert_ne in Hnone_g0.
+      { apply not_eq_sym. assumption. }
+      (* TODO cache_incr preserves lookup *)
   Qed.
 
   Lemma subcache_prop (C C' : Cache) (p : Pattern) (np : NamedPattern) :

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -350,6 +350,19 @@ Section proof_system_translation.
         exact (corr_prop_subcache cache' cache pfcorr Hsub).
       + admit.
       + admit.
+    - repeat case_match; simpl.
+      + remember pfcorr as pfcorr'; clear Heqpfcorr'.
+        unfold corr_prop in pfcorr'.
+        specialize (pfcorr' (patt_imp p (patt_imp q p)) n Heqo).
+        destruct pfcorr' as [[[cache' evs'] svs'] [Hnone [H Hsub]]]. simpl in Hnone.
+        assert ({ pq | n = npatt_imp pq.1 (npatt_imp pq.2 pq.1) }) by admit.
+        simpl (cache', evs', svs').1.1 in H. simpl (cache', evs', svs').1.2 in H.
+        simpl (cache', evs', svs').2 in H. subst.
+        apply translation'. apply P1; assumption.
+        exact (sub_prop_subcache cache' cache pfsub Hsub).
+        exact (corr_prop_subcache cache' cache pfcorr Hsub).
+      + admit.
+      + admit.
     - case_match.
       + simpl.
         pose proof (pfcorr _ _ Heqo) as [cache0 [evs0 [svs0 [Hnone H]]]].

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -76,33 +76,52 @@ Section proof_system_translation.
     C !! ϕ₂ = None.
   Proof.
     intros Hnone.
-    induction ϕ₂.
+    move: C evs svs ϕ₂ Hnone.
+    induction ϕ₁; intros C evs svs ϕ₂ Hnone.
     all:
       match type of Hnone with
-      | _ !! ?THIS = None => remember THIS as ϕ₂'
+      | (to_NamedPattern2' ?THIS _ _ _).1.1.2 !! _ = None => remember THIS as ϕ₁'
       end;
-      destruct (decide (ϕ₁ = ϕ₂')).
+      destruct (decide (ϕ₁' = ϕ₂)).
+
+    all:
+      subst ϕ₁'; simpl in *.
+
     all:
       match goal with
-      | [ e: ?ϕ₁ = ?ϕ₂', Heqϕ2': ?ϕ₂' = ?ϕ₃  |- _]
-        => subst ϕ₂'; subst ϕ₁;
+      | [ne: ?x <> ?y |- _]
+        => idtac "there"
+      | _
+        => subst;
            simpl in *;
            case_match;
            simpl in *;
            try congruence;
            auto
-      | _ => idtac "there"
       end.
-    
-    
-      try (subst ϕ₂'; simpl in Hnone; case_match; simpl in *; auto).
-      try (rewrite <- e in Hnone; rewrite lookup_insert in Hnone; inversion Hnone).
-      - simpl in Hnone; repeat case_match; subst; simpl in *; auto;
-        try rewrite lookup_insert_ne in Hnone; auto.
-      inversion Heqp; subst; clear Heqp. Print to_NamedPattern2'.
-    Search insert lookup.
-    Check lookup_insert_
-    rewrite H in Heqo; inversion Heqo; reflexivity.
+
+    all:
+      repeat case_match; simpl in *; subst; auto;
+      try (rewrite lookup_insert_ne in Hnone; auto);
+      inversion Heqp; subst; clear Heqp.
+
+    -
+      pose proof (Hnone_g0 := IHϕ₁2 g0 e0 s0 ϕ₂).
+      rewrite Heqp5 in Hnone_g0. simpl in Hnone_g0. specialize (Hnone_g0 Hnone).
+      clear Heqp5.
+      eapply IHϕ₁1.
+      erewrite Heqp2.
+      simpl.
+      exact Hnone_g0.
+    -
+      pose proof (Hnone_g0 := IHϕ₁2 g0 e0 s0 ϕ₂).
+      rewrite Heqp5 in Hnone_g0. simpl in Hnone_g0. specialize (Hnone_g0 Hnone).
+      clear Heqp5.
+      eapply IHϕ₁1.
+      erewrite Heqp2.
+      simpl.
+      exact Hnone_g0.
+    - 
   Qed.
 
   Lemma subcache_prop (C C' : Cache) (p : Pattern) (np : NamedPattern) :

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -4,7 +4,7 @@ From Coq Require Import Strings.String.
 From Equations Require Import Equations.
 
 From stdpp Require Export base.
-From MatchingLogic Require Import Syntax Semantics SignatureHelper ProofSystem Helpers.FOL_helpers.
+From MatchingLogic Require Import Syntax Semantics SignatureHelper ProofSystem ProofMode.
 From MatchingLogicProver Require Import Named NamedProofSystem.
 
 From stdpp Require Import base finite gmap mapset listset_nodup numbers propset.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -5,11 +5,16 @@ From Equations Require Import Equations.
 
 From stdpp Require Export base.
 From MatchingLogic Require Import Syntax Semantics SignatureHelper ProofSystem ProofMode.
-From MatchingLogicProver Require Import Named NamedProofSystem.
+From MatchingLogicProver Require Import Named NamedProofSystem Matchers.
 
 From stdpp Require Import base finite gmap mapset listset_nodup numbers propset.
 
 Import ProofSystem.Notations.
+
+(* TODO: move this near to the definition of Pattern *)
+Derive NoConfusion for Pattern.
+Derive Subterm for Pattern.
+
 
 Section proof_system_translation.
 
@@ -217,8 +222,11 @@ Section proof_system_translation.
 
     translation' G phi (@P1 _ _ p q wfp wfq) _ _ _ _ _
       with (cache !! (patt_imp p (patt_imp q p))) => {
-      | Some (npatt_imp p' (npatt_imp q' p'')) := (_, cache, used_evars, used_svars) ;
-      | Some x := False_rect _ _ ;
+(*      | Some (npatt_imp p' (npatt_imp q' p'')) := (_, cache, used_evars, used_svars) ;*)
+      | Some x with (match_a_impl_b_impl_c x) => {
+          | inl _ := _ ;
+          | inr _ := (False_rect _ _ );
+        }
       | None with (cache !! (patt_imp q p)) => {
         | None :=
           let: tn_p := to_NamedPattern2' p cache used_evars used_svars in
@@ -350,9 +358,9 @@ Section proof_system_translation.
         unfold corr_prop in pfcorr'.
         specialize (pfcorr' (patt_imp p (patt_imp q p)) n Heqo).
         destruct pfcorr' as [[[cache' evs'] svs'] [Hnone [H Hsub]]]. simpl in Hnone.
-        assert ({ pq | n = npatt_imp pq.1 (npatt_imp pq.2 pq.1) }) by admit.
         simpl (cache', evs', svs').1.1 in H. simpl (cache', evs', svs').1.2 in H.
-        simpl (cache', evs', svs').2 in H. subst.
+        simpl (cache', evs', svs').2 in H. simpl in H. subst.
+        assert ({ pq | n = npatt_imp pq.1 (npatt_imp pq.2 pq.1) }) by admit.
         destruct H0 as [[p' q'] Hpq].
         repeat split. rewrite Hpq. simpl.
         apply N_P1. admit. admit.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -60,7 +60,9 @@ Section proof_system_translation.
       end.
 
   Lemma sub_prop_empty: sub_prop ∅.
-  Admitted.
+  Proof.
+    unfold sub_prop; intros; inversion H.
+  Qed.
 
   Lemma sub_prop_step (C : Cache) (p : Pattern) (evs : EVarSet) (svs : SVarSet):
     sub_prop C ->
@@ -93,7 +95,9 @@ Section proof_system_translation.
       }.
 
   Lemma corr_prop_empty: corr_prop ∅.
-  Admitted.
+  Proof.
+    unfold corr_prop; intros; inversion H.
+  Qed.
 
   Lemma corr_prop_step (C : Cache) (p : Pattern) (evs : EVarSet) (svs : SVarSet):
     corr_prop C ->
@@ -214,7 +218,7 @@ Section proof_system_translation.
     translation' G phi (@P1 _ _ p q wfp wfq) _ _ _ _ _
       with (cache !! (patt_imp p (patt_imp q p))) => {
       | Some (npatt_imp p' (npatt_imp q' p'')) := (_, cache, used_evars, used_svars) ;
-      | Some _ := (False_rect _ _) ;
+      | Some x := False_rect _ _ ;
       | None with (cache !! (patt_imp q p)) => {
         | None :=
           let: tn_p := to_NamedPattern2' p cache used_evars used_svars in

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -70,6 +70,22 @@ Section proof_system_translation.
       try (rewrite Heqo; reflexivity);
       try (rewrite lookup_insert; reflexivity).
   Qed.
+
+  Instance incr_one_inj : Inj eq eq incr_one.
+  Proof.
+    unfold Inj. intros x y H.
+    induction x,y; simpl in *; congruence.
+  Qed.
+  
+  Lemma cache_incr_lookup_None (ϕ : Pattern) (C : Cache):
+    cache_incr C !! ϕ = None ->
+    C !! ϕ = None.
+  Proof.
+    intros H.
+    unfold cache_incr in *.
+    rewrite lookup_kmap_None in H.
+    apply H.
+  Abort.              
   
   Lemma to_NamedPattern2'_None (ϕ₁ ϕ₂ : Pattern) (C : Cache) (evs : EVarSet) (svs : SVarSet):
     (to_NamedPattern2' ϕ₁ C evs svs).1.1.2 !! ϕ₂ = None ->
@@ -131,10 +147,24 @@ Section proof_system_translation.
       
       destruct (decide (ϕ₂ = BoundVarSugar.b0)).
       { subst ϕ₂. rewrite lookup_insert in Hnone_g0. inversion Hnone_g0. }
-      Search lookup insert.
       rewrite lookup_insert_ne in Hnone_g0.
       { apply not_eq_sym. assumption. }
       (* TODO cache_incr preserves lookup *)
+      Print incr_one.
+      admit.
+    - pose proof (Hnone_g0 := IHϕ₁
+                                (<[BoundVarSugar.B0:=npatt_svar (svs_fresh s ϕ₁)]> (cache_incr C))
+                                evs
+                                (s ∪ {[svs_fresh s ϕ₁]}) ϕ₂)
+      .
+      feed specialize Hnone_g0.
+      { rewrite Heqp2. simpl. exact Hnone. }
+
+      destruct (decide (ϕ₂ = BoundVarSugar.B0)).
+      { subst ϕ₂. rewrite lookup_insert in Hnone_g0. inversion Hnone_g0. }
+      rewrite lookup_insert_ne in Hnone_g0.
+      { apply not_eq_sym. assumption. }
+      admit.
   Qed.
 
   Lemma subcache_prop (C C' : Cache) (p : Pattern) (np : NamedPattern) :

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -196,7 +196,8 @@ Section proof_system_translation.
   (*
      Non-Addition lemma. phi <= psi -> psi \not \in C -> psi \not \in (toNamedPattern2' phi C).2
    *)
-
+  Check False_rect. Check eq_refl.
+  Obligation Tactic := idtac.
   Equations? translation' (G : Theory) (phi : Pattern) (prf : G ⊢ phi)
            (cache : Cache) (pfsub : sub_prop cache) (pfcorr : corr_prop cache)
            (used_evars : EVarSet) (used_svars : SVarSet)
@@ -212,10 +213,8 @@ Section proof_system_translation.
 
     translation' G phi (@P1 _ _ p q wfp wfq) _ _ _ _ _
       with (cache !! (patt_imp p (patt_imp q p))) => {
-      | Some pqp_named with pqp_named => {
-          | npatt_imp p' (npatt_imp q' p'') := _ ;
-          | _ := _ ;
-        }
+      | Some (npatt_imp p' (npatt_imp q' p'')) := (_, cache, used_evars, used_svars) ;
+      | Some _ := (False_rect _ _) ;
       | None with (cache !! (patt_imp q p)) => {
         | None :=
           let: tn_p := to_NamedPattern2' p cache used_evars used_svars in
@@ -335,7 +334,12 @@ Section proof_system_translation.
     translation' _ _ _ _ _ _ _ _ := _.
 
   Proof.
-    - admit.
+    all: try(
+      lazymatch goal with
+      | [ |- (Is_true (named_well_formed _)) ] => admit
+      | _ => idtac
+      end).
+(*    - admit.*)
     - admit.
     - repeat case_match; simpl.
       + remember pfcorr as pfcorr'; clear Heqpfcorr'.
@@ -345,9 +349,11 @@ Section proof_system_translation.
         assert ({ pq | n = npatt_imp pq.1 (npatt_imp pq.2 pq.1) }) by admit.
         simpl (cache', evs', svs').1.1 in H. simpl (cache', evs', svs').1.2 in H.
         simpl (cache', evs', svs').2 in H. subst.
-        apply translation'. apply P1; assumption.
-        exact (sub_prop_subcache cache' cache pfsub Hsub).
-        exact (corr_prop_subcache cache' cache pfcorr Hsub).
+        destruct H0 as [[p' q'] Hpq].
+        repeat split. rewrite Hpq. simpl.
+        apply N_P1. admit. admit.
+        (* cache, evar_map, svar_map *)
+        exact cache. apply used_evars. apply used_svars.
       + admit.
       + admit.
     - repeat case_match; simpl.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -473,15 +473,11 @@ Section proof_system_translation.
 
       specialize (IHp2 e s0).
       rewrite Heqp1 in IHp2. simpl in IHp2.
+      apply cache_continuous_add_not_bound.
+      intros Hcontra. inversion Hcontra.
+      apply IHp2.
 
-      destruct IHp2 as [H1g H2g].
-      split.
-      + destruct H1g as [
-      
-      
-      
-      simpl
-      simpl in Hcached.
+    -
 
       
   Lemma sub_prop_step (C : Cache) (p : Pattern) (evs : EVarSet) (svs : SVarSet):

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -1950,51 +1950,25 @@ Qed.
           
           + 
             destruct (decide (is_bound_evar pincr1)), (decide (is_bound_evar pincr2)).
-            * unfold sub_prop in Hsub.
+            * 
+              unfold sub_prop in Hsub.
               pose proof (Hsub1 := Hsub (patt_app pincr1 pincr2) np1 Hpincr2).
               simpl in Hsub1.
-              unfold cache_incr_evar.
-              specialize (Hsub (incr_one_evar pincr1) (incr_one_evar pincr2)).
-              specialize (Hsub Hpincr2)
-              destruct Hsub as [np' [nq' [Hsub1 Hsub2]]].
-            destruct (decide (pincr1 = BoundVarSugar.b0)),(decide (pincr2 = BoundVarSugar.b0)).
-            * subst pincr1 pincr2.
-              exists (npatt_evar (evs_fresh evs p0)),(npatt_evar (evs_fresh evs p0)).
-              split; apply lookup_insert.
-            * subst pincr1.
-              exists (npatt_evar (evs_fresh evs p0)), nq'.
-              split.
+              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
+              pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr1 (evs_fresh evs p0) Hcont ltac:(assumption)).
+              feed specialize Hshift1.
               {
-                apply lookup_insert.
+                exists np'. exact Hnp'.
               }
+              destruct Hshift1 as [np'1 Hnp'1].
+              pose proof (Hshift2 := bound_evar_cont_cache_shift C pincr2 (evs_fresh evs p0) Hcont ltac:(assumption)).
+              feed specialize Hshift2.
               {
-                rewrite lookup_insert_ne. apply not_eq_sym. assumption.
-
+                exists nq'. exact Hnq'.
               }
-            split.
-            exists np',nq'.
-            Search pincr1.
-
-
-            destruct H as [[H1 H2]|H].
-            subst p00 np.
-
-          (rewrite lookup_union_Some in H';[|apply remove_disjoint_keep_e]);
-          (
-            destruct H' as [H'|H'];
-            [|(unfold keep_bound_evars in H';
-               rewrite map_filter_lookup_Some in H';
-               destruct H' as [_ Hcontra];
-               destruct Hcontra as [x Hcontra];
-               inversion Hcontra
-              )]
-          ).
-          + destruct Hsub as [np' [nq' [Hsub1 Hsub2]]].
-            exists np', nq'.
-            (* If p1_1 (or p1_2) is not a bevar, then this should be easy.
-               However, if it is a bevar,
-            *)
-          }
+              destruct Hshift2 as [nq'2 Hnq'2].
+              exists np'1,nq'2.
+              split. exact Hnp'1. exact Hnq'2.
         }
          Print sub_prop.
         Print cache_incr_evar. Print incr_one_evar.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -398,6 +398,38 @@ Section proof_system_translation.
         simpl in Hneg. apply Hneg. exact I.
   Qed.        
   
+  Lemma remove_disjoint_keep_e C1 C2:
+    remove_bound_evars C1 ##ₘ keep_bound_evars C2.
+  Proof.
+    unfold remove_bound_evars.
+    unfold keep_bound_evars.
+    rewrite map_disjoint_spec.
+    intros i x y H1 H2.
+    rewrite map_filter_lookup_Some in H1.
+    destruct H1 as [H11 H12].
+    unfold is_bound_evar_entry in H12. simpl in H12.
+    rewrite map_filter_lookup_Some in H2. destruct H2 as [H21 H22].
+    unfold is_bound_evar_entry in H22. simpl in H22.
+    contradiction.
+  Qed.
+
+Lemma remove_disjoint_keep_s C1 C2:
+  remove_bound_svars C1 ##ₘ keep_bound_svars C2.
+Proof.
+  unfold remove_bound_svars.
+  unfold keep_bound_svars.
+  rewrite map_disjoint_spec.
+  intros i x y H1 H2.
+  rewrite map_filter_lookup_Some in H1.
+  destruct H1 as [H11 H12].
+  unfold is_bound_svar_entry in H12. simpl in H12.
+  rewrite map_filter_lookup_Some in H2. destruct H2 as [H21 H22].
+  unfold is_bound_svar_entry in H22. simpl in H22.
+  contradiction.
+Qed.
+
+
+
   Lemma cache_continuous_step (C : Cache) (p : Pattern) (evs : EVarSet) (svs : SVarSet):
     dangling_vars_cached C p ->
     cache_continuous_prop C ->
@@ -623,7 +655,6 @@ Section proof_system_translation.
         * rewrite Hk in H.
           destruct H as [e He].
           exists e.
-          Search union lookup Some.
           rewrite lookup_union_Some.
           --
             right.
@@ -634,20 +665,26 @@ Section proof_system_translation.
             ++
               exact He.
             ++ unfold is_bound_evar_entry. simpl. exists k'. reflexivity.
-          -- 
-            unfold remove_bound_evars.
-            unfold keep_bound_evars.
-            rewrite map_disjoint_spec.
-            intros.
-            Search filter lookup Some.
-            rewrite map_filter_lookup_Some in H0.
-            destruct H0 as [H0 H1].
-            unfold is_bound_evar_entry in H1. simpl in H1.
-            rewrite map_filter_lookup_Some in H. destruct H as [H2 H3].
-            unfold is_bound_evar_entry in H3. simpl in H3.
-            contradiction.
+          -- apply remove_disjoint_keep_e.
         * apply Hk.
-
+          destruct H as [e He].
+          exists e.
+          rewrite lookup_union_Some in He.
+          2: { apply remove_disjoint_keep_e. }
+          destruct He as [He|He].
+          --
+            unfold remove_bound_evars in He.
+            Search filter lookup Some.
+            rewrite map_filter_lookup_Some in He.
+            destruct He as [He1 He2].
+            unfold is_bound_evar_entry in He2. simpl in He2.
+            exfalso. apply He2. exists k'. reflexivity.
+          --
+            unfold keep_bound_evars in He.
+            rewrite map_filter_lookup_Some in He.
+            destruct He as [He1 He2].
+            exact He1.
+      + 
   Qed.
 
 

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -423,7 +423,7 @@ Qed.
       + destruct Hcall as [Hp' Hnp'].
         subst.
         split.
-        { constructor. }
+        { constructor. reflexivity. }
         split; intros HContra; inversion HContra; inversion H.
       + destruct Hcall as [Hp' Hnp'].
         subst.
@@ -434,7 +434,7 @@ Qed.
       + destruct Hcall as [Hp' Hnp'].
         subst.
         split.
-        { constructor. }
+        { constructor. reflexivity. }
         split; intros HContra; inversion HContra; inversion H.
       + destruct Hcall as [Hp' Hnp'].
         subst.
@@ -463,7 +463,7 @@ Qed.
       + destruct Hcall as [Hp' Hnp'].
         subst.
         split.
-        { constructor. }
+        { constructor. reflexivity. }
         split; intros HContra; inversion HContra; inversion H.
       + destruct Hcall as [Hp' Hnp'].
         subst.
@@ -489,7 +489,7 @@ Qed.
       {
         destruct Hcall; subst p' np'.
         split.
-        { constructor. }
+        { constructor. reflexivity. }
         split; intros Hcontra; inversion Hcontra; inversion H.
       }
       destruct Hcall as [Hp' Hgp'].
@@ -524,7 +524,7 @@ Qed.
       + destruct Hcall as [Hp' Hnp'].
         subst.
         split.
-        { constructor. }
+        { constructor. reflexivity. }
         split; intros HContra; inversion HContra; inversion H.
       + destruct Hcall as [Hp' Hnp'].
         subst.
@@ -550,7 +550,7 @@ Qed.
     {
       destruct Hcall; subst p' np'.
       split.
-      { constructor. }
+      { constructor. reflexivity. }
       split; intros Hcontra; inversion Hcontra; inversion H.
     }
     destruct Hcall as [Hp' Hgp'].
@@ -766,7 +766,6 @@ Qed.
         rewrite map_filter_lookup_Some in Hnp'.
         destruct Hnp' as [Hcontra _]. rewrite HCp' in Hcontra. inversion Hcontra.
       }
-
   Qed.
 
   Definition cache_continuous_prop (C : Cache) : Prop :=

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -2493,7 +2493,9 @@ Qed.
          Q? (np' == np?)
        ]
    *)
+  Abort.
 
+  (*
   (*
      Non-Addition lemma. phi <= psi -> psi \not \in C -> psi \not \in (toNamedPattern2' phi C).2
    *)
@@ -2731,5 +2733,5 @@ Qed.
       Search to_NamedPattern2'.
       Print Table Search Blacklist. simpl.
   Abort.
-
+*)
 End proof_system_translation.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -1653,8 +1653,20 @@ Qed.
             destruct Hnp1 as [pincr [Hpincr1 Hpincr2]];
             destruct pincr; simpl in Hpincr1; inversion Hpincr1;
             subst; exact Hpincr2
+          );(rewrite lookup_insert_ne in Hnp1;[discriminate|]);
+          (rewrite lookup_union_Some in H';[|apply remove_disjoint_keep_e]);
+          (
+            destruct H' as [H'|H'];
+            [|(unfold keep_bound_evars in H';
+               rewrite map_filter_lookup_Some in H';
+               destruct H' as [_ Hcontra];
+               destruct Hcontra as [x Hcontra];
+               inversion Hcontra
+              )]
           ).
-          + destruct Hsub as [np' [nq' [Hsub1 Hsub2]]].
+          + 
+            
+            destruct Hsub as [np' [nq' [Hsub1 Hsub2]]].
             exists np', nq'.
             (* If p1_1 (or p1_2) is not a bevar, then this should be easy.
                However, if it is a bevar,

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -1835,117 +1835,6 @@ Qed.
         -- if_equal_then_cached H Heqp0 Heqp1.
         -- if_not_equal_boc_1 H' Hsub'' (patt_imp p1 p2) (npatt_imp n0 n1).
 
-    * repeat case_match_in_hyp H.
-        repeat case_match_in_hyp Heqp.
-        subst. simpl in *. invert_tuples.
-        rewrite lookup_insert_Some in H.
-
-        assert (HdanglingCp1: dangling_vars_cached C p1).
-        { eapply dangling_vars_cached_app_proj1. apply Hdangling. }
-        pose proof (Hext1 := to_NamedPattern2'_extends_cache C p1 evs svs).
-        rewrite Heqp0 in Hext1. simpl in Hext1.
-        pose proof (Hcont' := cache_continuous_step C p1 evs svs HdanglingCp1 Hcont).
-        rewrite Heqp0 in Hcont'.
-        simpl in Hcont'.
-
-        assert (Hdanglingg0p2: dangling_vars_cached g0 p2).
-        {
-          eapply dangling_vars_subcache.
-          2:{ apply Hext1. }
-          eapply dangling_vars_cached_app_proj2.
-          apply Hdangling.
-        }
-        pose proof (Hcont'' := cache_continuous_step g0 p2 e0 s0 Hdanglingg0p2 Hcont').
-        rewrite Heqp1 in Hcont''.
-        simpl in Hcont''.
-        pose proof (Hsub' := IHp1 C HdanglingCp1 Hcont Hsub evs svs).
-        rewrite Heqp0 in Hsub'; simpl in Hsub'.
-        pose proof (Hsub'' := IHp2 g0 Hdanglingg0p2 Hcont' Hsub' e0 s0).
-        rewrite Heqp1 in Hsub''; simpl in Hsub''.
-
-        destruct p0; auto.
-        --
-          destruct H as [[H H']|[H H']];[(inversion H; subst; clear H)|].
-        {
-          unfold sub_prop in Hsub''.
-          pose proof (Htmp := Hsub'' (patt_app p0_1 p0_2) np H').
-          simpl in Htmp. destruct Htmp as [np0_1 [np0_2 [Hp0_1 Hp0_2]]].
-          destruct (decide (patt_imp p1 p2 = p0_1)), (decide (patt_imp p1 p2 = p0_2)); subst.
-          --
-            exists (npatt_imp n0 n1), (npatt_imp n0 n1).
-            split; apply lookup_insert.
-          --
-            exists (npatt_imp n0 n1), np0_2.
-            split. apply lookup_insert.
-            rewrite <- Hp0_2. apply lookup_insert_ne. assumption.
-          --
-            exists np0_1, (npatt_imp n0 n1).
-            split. rewrite <- Hp0_1. apply lookup_insert_ne. assumption.
-            apply lookup_insert.
-          --
-            exists np0_1, np0_2.
-            split. rewrite <- Hp0_1. apply lookup_insert_ne. assumption.
-            rewrite <- Hp0_2. apply lookup_insert_ne. assumption.
-        }
-        --
-      destruct H as [[H H']|[H H']];[(inversion H; subst; clear H)|].
-      { 
-        exists n0,n1.
-        pose proof (Htmp := to_NamedPattern2'_ensures_present p0_1 C evs svs).
-        rewrite Heqp0 in Htmp. simpl in Htmp.
-        pose proof (Hec := to_NamedPattern2'_extends_cache g0 p0_2 e0 s0).
-        rewrite Heqp1 in Hec. simpl in Hec.
-        pose proof (Htmp2 := to_NamedPattern2'_ensures_present p0_2 g0 e0 s0).
-        rewrite Heqp1 in Htmp2. simpl in Htmp2.
-        eapply lookup_weaken with (m2 := g) in Htmp;[|assumption].
-        rewrite -Htmp -Htmp2.
-        split; apply lookup_insert_ne. apply imp_neq1. apply imp_neq2.
-      }
-      {
-        unfold sub_prop in Hsub''.
-        pose proof (Htmp := Hsub'' (patt_imp p0_1 p0_2) np H').
-        simpl in Htmp. destruct Htmp as [np0_1 [np0_2 [Hp0_1 Hp0_2]]].
-        destruct (decide (patt_imp p1 p2 = p0_1)), (decide (patt_imp p1 p2 = p0_2)); subst.
-        --
-          exists (npatt_imp n0 n1), (npatt_imp n0 n1).
-          split; apply lookup_insert.
-        --
-          exists (npatt_imp n0 n1), np0_2.
-          split. apply lookup_insert.
-          rewrite <- Hp0_2. apply lookup_insert_ne. assumption.
-        --
-          exists np0_1, (npatt_imp n0 n1).
-          split. rewrite <- Hp0_1. apply lookup_insert_ne. assumption.
-          apply lookup_insert.
-        --
-          exists np0_1, np0_2.
-          split. rewrite <- Hp0_1. apply lookup_insert_ne. assumption.
-          rewrite <- Hp0_2. apply lookup_insert_ne. assumption.
-      } 
-    --
-      destruct H as [[H H']|[H H']];[(inversion H; subst; clear H)|].
-      {
-        unfold sub_prop in Hsub''.
-        pose proof (Htmp := Hsub'' (patt_exists p0) np H').
-        simpl in Htmp. destruct Htmp as [np' Hnp'].
-        destruct (decide (patt_imp p1 p2 = p0)).
-        ++
-          subst p0. exists (npatt_imp n0 n1). apply lookup_insert.
-        ++
-          exists np'. rewrite <- Hnp'. apply lookup_insert_ne. assumption.
-      }
-      --
-        destruct H as [[H H']|[H H']];[(inversion H; subst; clear H)|].
-        {
-          unfold sub_prop in Hsub''.
-          pose proof (Htmp := Hsub'' (patt_mu p0) np H').
-          simpl in Htmp. destruct Htmp as [np' Hnp'].
-          destruct (decide (patt_imp p1 p2 = p0)).
-          ++
-            subst p0. exists (npatt_imp n0 n1). apply lookup_insert.
-          ++
-            exists np'. rewrite <- Hnp'. apply lookup_insert_ne. assumption.
-        }
       * repeat case_match_in_hyp H.
         repeat case_match_in_hyp Heqp.
         subst. simpl in *. invert_tuples.
@@ -1970,261 +1859,81 @@ Qed.
           unfold sub_prop.
           intros p1 np1 Hnp1.
           rewrite HeqC' in Hnp1.
-          destruct p1; try exact I;
-            (rewrite lookup_insert_ne in Hnp1;[discriminate|]);
-            unfold cache_incr_evar in Hnp1;
-            rewrite lookup_kmap_Some in Hnp1;
-            destruct Hnp1 as [pincr [Hpincr1 Hpincr2]];
-            destruct pincr; simpl in Hpincr1; inversion Hpincr1; clear Hpincr1;
-            subst.
-          
-          + 
-            destruct (decide (is_bound_evar pincr1)), (decide (is_bound_evar pincr2)).
-            * 
-              unfold sub_prop in Hsub.
-              pose proof (Hsub1 := Hsub (patt_app pincr1 pincr2) np1 Hpincr2).
-              simpl in Hsub1.
-              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
-              pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr1 (evs_fresh evs p0) Hcont ltac:(assumption)).
-              feed specialize Hshift1.
-              {
-                exists np'. exact Hnp'.
-              }
-              destruct Hshift1 as [np'1 Hnp'1].
-              pose proof (Hshift2 := bound_evar_cont_cache_shift C pincr2 (evs_fresh evs p0) Hcont ltac:(assumption)).
-              feed specialize Hshift2.
-              {
-                exists nq'. exact Hnq'.
-              }
-              destruct Hshift2 as [nq'2 Hnq'2].
-              exists np'1,nq'2.
-              split. exact Hnp'1. exact Hnq'2.
-            * unfold sub_prop in Hsub.
-              pose proof (Hsub1 := Hsub (patt_app pincr1 pincr2) np1 Hpincr2).
-              simpl in Hsub1.
-              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
-              pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr1 (evs_fresh evs p0) Hcont ltac:(assumption)).
-              feed specialize Hshift1.
-              {
-                exists np'. exact Hnp'.
-              }
-              destruct Hshift1 as [np'1 Hnp'1].
-              exists np'1, nq'.
-              split.
-              { exact Hnp'1. }
-              rewrite lookup_insert_ne.
-              { intros Hcontra. apply n. subst pincr2. exists 0. reflexivity. }
-              unfold cache_incr_evar.
-              replace pincr2 with (incr_one_evar pincr2).
-              2: {
-                destruct pincr2; try reflexivity.
-                exfalso. apply n. exists n1. reflexivity.
-              }
-              rewrite lookup_kmap. exact Hnq'.
-            * unfold sub_prop in Hsub.
-              pose proof (Hsub1 := Hsub (patt_app pincr1 pincr2) np1 Hpincr2).
-              simpl in Hsub1.
-              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
-              pose proof (Hshift2 := bound_evar_cont_cache_shift C pincr2 (evs_fresh evs p0) Hcont ltac:(assumption)).
-              feed specialize Hshift2.
-              {
-                exists nq'. exact Hnq'.
-              }
-              destruct Hshift2 as [nq'2 Hnq'2].
-              exists np', nq'2.
-              split.
-              {
-                rewrite lookup_insert_ne.
-                { intros Hcontra. apply n. subst pincr1. exists 0. reflexivity. }
-                unfold cache_incr_evar.
-                replace pincr1 with (incr_one_evar pincr1).
-                2: {
-                  destruct pincr1; try reflexivity.
-                  exfalso. apply n. exists n1. reflexivity.
-                }
-                rewrite lookup_kmap. exact Hnp'.
-              }
-              { exact Hnq'2. }
-            * 
-              unfold sub_prop in Hsub.
-              pose proof (Hsub1 := Hsub (patt_app pincr1 pincr2) np1 Hpincr2).
-              simpl in Hsub1.
-              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
-              exists np', nq'.
-              split.
-              {
-                rewrite lookup_insert_ne.
-                { intros Hcontra. apply n. subst pincr1. exists 0. reflexivity. }
-                unfold cache_incr_evar.
-                replace pincr1 with (incr_one_evar pincr1).
-                2: {
-                  destruct pincr1; try reflexivity.
-                  exfalso. apply n. exists n2. reflexivity.
-                }
-                rewrite lookup_kmap. exact Hnp'.
-              }
-              {
-                rewrite lookup_insert_ne.
-                { intros Hcontra. apply n1. subst pincr2. exists 0. reflexivity. }
-                unfold cache_incr_evar.
-                replace pincr2 with (incr_one_evar pincr2).
-                2: {
-                  destruct pincr2; try reflexivity.
-                  exfalso. apply n1. exists n2. reflexivity.
-                }
-                rewrite lookup_kmap. exact Hnq'.
-              }
-          + destruct (decide (is_bound_evar pincr1)), (decide (is_bound_evar pincr2)).
-            * 
-              unfold sub_prop in Hsub.
-              pose proof (Hsub1 := Hsub (patt_imp pincr1 pincr2) np1 Hpincr2).
-              simpl in Hsub1.
-              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
-              pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr1 (evs_fresh evs p0) Hcont ltac:(assumption)).
-              feed specialize Hshift1.
-              {
-                exists np'. exact Hnp'.
-              }
-              destruct Hshift1 as [np'1 Hnp'1].
-              pose proof (Hshift2 := bound_evar_cont_cache_shift C pincr2 (evs_fresh evs p0) Hcont ltac:(assumption)).
-              feed specialize Hshift2.
-              {
-                exists nq'. exact Hnq'.
-              }
-              destruct Hshift2 as [nq'2 Hnq'2].
-              exists np'1,nq'2.
-              split. exact Hnp'1. exact Hnq'2.
-            * unfold sub_prop in Hsub.
-              pose proof (Hsub1 := Hsub (patt_imp pincr1 pincr2) np1 Hpincr2).
-              simpl in Hsub1.
-              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
-              pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr1 (evs_fresh evs p0) Hcont ltac:(assumption)).
-              feed specialize Hshift1.
-              {
-                exists np'. exact Hnp'.
-              }
-              destruct Hshift1 as [np'1 Hnp'1].
-              exists np'1, nq'.
-              split.
-              { exact Hnp'1. }
-              rewrite lookup_insert_ne.
-              { intros Hcontra. apply n. subst pincr2. exists 0. reflexivity. }
-              unfold cache_incr_evar.
-              replace pincr2 with (incr_one_evar pincr2).
-              2: {
-                destruct pincr2; try reflexivity.
-                exfalso. apply n. exists n1. reflexivity.
-              }
-              rewrite lookup_kmap. exact Hnq'.
-            * unfold sub_prop in Hsub.
-              pose proof (Hsub1 := Hsub (patt_imp pincr1 pincr2) np1 Hpincr2).
-              simpl in Hsub1.
-              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
-              pose proof (Hshift2 := bound_evar_cont_cache_shift C pincr2 (evs_fresh evs p0) Hcont ltac:(assumption)).
-              feed specialize Hshift2.
-              {
-                exists nq'. exact Hnq'.
-              }
-              destruct Hshift2 as [nq'2 Hnq'2].
-              exists np', nq'2.
-              split.
-              {
-                rewrite lookup_insert_ne.
-                { intros Hcontra. apply n. subst pincr1. exists 0. reflexivity. }
-                unfold cache_incr_evar.
-                replace pincr1 with (incr_one_evar pincr1).
-                2: {
-                  destruct pincr1; try reflexivity.
-                  exfalso. apply n. exists n1. reflexivity.
-                }
-                rewrite lookup_kmap. exact Hnp'.
-              }
-              { exact Hnq'2. }
-            * 
-              unfold sub_prop in Hsub.
-              pose proof (Hsub1 := Hsub (patt_imp pincr1 pincr2) np1 Hpincr2).
-              simpl in Hsub1.
-              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
-              exists np', nq'.
-              split.
-              {
-                rewrite lookup_insert_ne.
-                { intros Hcontra. apply n. subst pincr1. exists 0. reflexivity. }
-                unfold cache_incr_evar.
-                replace pincr1 with (incr_one_evar pincr1).
-                2: {
-                  destruct pincr1; try reflexivity.
-                  exfalso. apply n. exists n2. reflexivity.
-                }
-                rewrite lookup_kmap. exact Hnp'.
-              }
-              {
-                rewrite lookup_insert_ne.
-                { intros Hcontra. apply n1. subst pincr2. exists 0. reflexivity. }
-                unfold cache_incr_evar.
-                replace pincr2 with (incr_one_evar pincr2).
-                2: {
-                  destruct pincr2; try reflexivity.
-                  exfalso. apply n1. exists n2. reflexivity.
-                }
-                rewrite lookup_kmap. exact Hnq'.
-              }
-          + destruct (decide (is_bound_evar pincr)).
-          * 
-            unfold sub_prop in Hsub.
-            pose proof (Hsub1 := Hsub (patt_exists pincr) np1 Hpincr2).
-            simpl in Hsub1.
-            destruct Hsub1 as [np' Hnp'].
-            pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr (evs_fresh evs p0) Hcont ltac:(assumption)).
-            feed specialize Hshift1.
-            {
-              exists np'. exact Hnp'.
-            }
-            destruct Hshift1 as [np'1 Hnp'1].
-            exists np'1.
-            exact Hnp'1.
-          * unfold sub_prop in Hsub.
-            pose proof (Hsub1 := Hsub (patt_exists pincr) np1 Hpincr2).
-            simpl in Hsub1.
-            destruct Hsub1 as [np' Hnp'].
-            rewrite lookup_insert_ne.
-            { intros Hcontra. apply n. subst pincr. exists 0. reflexivity. }
-            unfold cache_incr_evar.
-            replace pincr with (incr_one_evar pincr).
-            2: {
-              destruct pincr; try reflexivity.
-              exfalso. apply n. exists n1. reflexivity.
-            }
-            rewrite lookup_kmap.
-            exists np'. exact Hnp'.
-            + destruct (decide (is_bound_evar pincr)).
-            * 
-              unfold sub_prop in Hsub.
-              pose proof (Hsub1 := Hsub (patt_mu pincr) np1 Hpincr2).
-              simpl in Hsub1.
-              destruct Hsub1 as [np' Hnp'].
-              pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr (evs_fresh evs p0) Hcont ltac:(assumption)).
-              feed specialize Hshift1.
-              {
-                exists np'. exact Hnp'.
-              }
-              destruct Hshift1 as [np'1 Hnp'1].
-              exists np'1.
-              exact Hnp'1.
-            * unfold sub_prop in Hsub.
-              pose proof (Hsub1 := Hsub (patt_mu pincr) np1 Hpincr2).
-              simpl in Hsub1.
-              destruct Hsub1 as [np' Hnp'].
-              rewrite lookup_insert_ne.
-              { intros Hcontra. apply n. subst pincr. exists 0. reflexivity. }
-              unfold cache_incr_evar.
-              replace pincr with (incr_one_evar pincr).
-              2: {
-                destruct pincr; try reflexivity.
-                exfalso. apply n. exists n1. reflexivity.
-              }
-              rewrite lookup_kmap.
-              exists np'. exact Hnp'.
+
+          Local Ltac destruct_lookup_in_C' Hnp :=
+            match type of Hnp with
+            | ((_ !! ?P) = _) =>
+            (rewrite lookup_insert_ne in Hnp;[discriminate|]);
+            unfold cache_incr_evar in Hnp;
+            rewrite lookup_kmap_Some in Hnp;
+            destruct Hnp as [pincr [Hpincr1 Hpincr2]];
+            assert (Hpincreq: pincr = P);
+            [(destruct pincr; simpl in Hpincr1; inversion Hpincr1; reflexivity)|];
+            subst pincr; clear Hpincr1; rename Hpincr2 into Hnp
+            end.
+
+            Local Ltac propagate_cached_into_C' HeqC' Hcp1_1 Hnbound :=
+              match goal with
+              | [ |- bound_or_cached _ ?p1_1] =>
+                destruct Hcp1_1 as [np1_1 Hnp1_1];
+                right;
+                exists np1_1;
+                rewrite HeqC';
+                rewrite lookup_insert_ne;
+                [(
+                  intros HContra; subst p1_1;
+                  apply Hnbound; exists 0; reflexivity
+                )|];
+                unfold cache_incr_evar;
+                replace (p1_1) with (incr_one_evar p1_1);
+                [|(destruct p1_1; try reflexivity;
+                  exfalso; apply Hnbound; eexists; reflexivity)
+                ];
+                rewrite lookup_kmap;
+                exact Hnp1_1
+              end.
+
+              Local Ltac propagate_bound p1_1 Hnbound :=
+                destruct (decide (is_bound_evar p1_1)) as [Hbound|Hnbound];
+                [(
+                  left;
+                  unfold is_bound_evar in Hbound;
+                  destruct Hbound as [b Hbound];
+                  subst p1_1;
+                  reflexivity
+                )|].
+
+                Local Ltac make_subpattern_boc Hsub Hnp1 subpattern Hsubcached :=
+                  match type of Hnp1 with
+                  | (?C !! ?big_pattern = Some ?np1) =>
+                    pose proof (Hsub1 := Hsub big_pattern np1 Hnp1);
+                    simpl in Hsub1;
+                    assert (Hsubboc: bound_or_cached C subpattern) by (destruct_and?; assumption);
+                    destruct Hsubboc as [Hsubbound|Hsubcached];
+                    [(left; exact Hsubbound)|]
+                  end.
+
+          Local Ltac subpattern_boc HeqC' Hsub Hnp1 p1_1 :=
+            let Hnbound := fresh "Hnbound" in
+            propagate_bound p1_1 Hnbound;
+            destruct_lookup_in_C' Hnp1;
+            let Hsubcached := fresh "Hsubcached" in
+            make_subpattern_boc Hsub Hnp1 p1_1 Hsubcached;
+            propagate_cached_into_C' HeqC' Hsubcached Hnbound.
+
+          destruct p1; try exact I.
+          {            
+            split.
+            { subpattern_boc HeqC' Hsub Hnp1 p1_1. }
+            { subpattern_boc HeqC' Hsub Hnp1 p1_2. }
+          }
+          {
+            split.
+            { subpattern_boc HeqC' Hsub Hnp1 p1_1. }
+            { subpattern_boc HeqC' Hsub Hnp1 p1_2. }
+          }
+          { subpattern_boc HeqC' Hsub Hnp1 p1. }
+          { subpattern_boc HeqC' Hsub Hnp1 p1. }
         }
         epose proof (IH1 := IHp C' HdanglingC'p0 HcontC' HsubC' _ _).
         erewrite Heqp0 in IH1. simpl in IH1.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -313,7 +313,7 @@ Section proof_system_translation.
                     match history with
                     | [] => False
                     | (x::xs) =>
-                        x.1 = p /\
+                        x.1 = p /\ x.2.1.1.1 = np /\
 (*                        x.2.1.1.2 !! p = None /\ *)
                           (match (last (x::xs)) with
                           | None => False
@@ -374,12 +374,103 @@ Section proof_system_translation.
     - repeat case_match. subst.
       inversion Heqp. subst. clear Heqp.
       simpl.
+
       unfold history_generator. intros p' np' Hp'.
+      
+      
+      destruct (decide (p' = patt_app p1 p2)).
+      + subst p'.
+
+        pose proof (Htmp := Heqp0).
+        apply (f_equal fst) in Htmp.
+        apply (f_equal fst) in Htmp.
+        pose proof (Htmp' := Htmp).
+        apply (f_equal fst) in Htmp.
+        apply (f_equal snd) in Htmp'.
+        assert (g !! p1 = Some n).
+        { simpl in Htmp. simpl in Htmp'. rewrite -Htmp. rewrite -Htmp'.          
+          apply to_NamedPattern2'_ensures_present.
+        }
+        clear Htmp Htmp'.
+        pose proof (Htmp := Heqp1).
+        apply (f_equal fst) in Htmp.
+        apply (f_equal fst) in Htmp.
+        pose proof (Htmp' := Htmp).
+        apply (f_equal fst) in Htmp.
+        apply (f_equal snd) in Htmp'.
+        assert (g1 !! p2 = Some n0).
+        { simpl in Htmp,Htmp'. rewrite -Htmp -Htmp'.
+          apply to_NamedPattern2'_ensures_present.
+        }
+        clear Htmp Htmp'.
+
+        pose proof (IH1 := IHp1 C evs svs cpC).
+        rewrite Heqp0 in IH1. simpl in IH1.
+        pose proof (IH2 := IHp2 g e s0 IH1).
+        rewrite Heqp1 in IH2. simpl in IH2.
+
+
+        unfold history_generator in IH2.
+        pose proof (IH2' := IH2 p2 n0 H0).
+        destruct IH2' as [hist Hhist].
+        destruct hist as [|h hist];[inversion Hhist|].
+        destruct_and!; subst.
+
+        eapply (existT ((patt_app p1 h.1, (np', g1, e1, s))::h::hist)).
+        split_and!; auto.
+        intros i.
+        destruct i.
+        * simpl. clear H2. repeat case_match. simpl.
+          exists (patt_app p1 p).
+          simpl in *. subst.
+          split. admit.
+          repeat f_equal.
+          case_match.
+          Search c.
+        * simpl. apply H5.
+        
+        admit.
+      +
+        pose proof (IH1 := IHp1 C evs svs cpC).
+        rewrite Heqp0 in IH1. simpl in IH1.
+        pose proof (IH2 := IHp2 g e s0 IH1).
+        rewrite Heqp1 in IH2. simpl in IH2.
+      
+        unfold history_generator in IH2.
+        specialize (IH2 p' np').
+      
+        rewrite lookup_insert_ne in Hp'.
+        { apply not_eq_sym. assumption. }
+        specialize (IH2 Hp').
+        destruct IH2 as [hist Hhist].
+        destruct hist as [| h hist] ;[inversion Hhist|].
+        destruct_and!. subst.
+        apply (existT (h::hist)).
+        simpl. split_and!; auto; simpl.
+
+      
       destruct (decide (p' = patt_app p1 p2)).
       + (subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np';
-          apply (existT [(patt_app p1 p2, (to_NamedPattern2' (patt_app p1 p2) ∅ ∅ ∅))]); simpl; split;[reflexivity|]
+          apply (existT [(patt_app p1 p2, (to_NamedPattern2' (patt_app p1 p2) C evs svs))]); simpl; split;[reflexivity|]
         ).
-        repeat case_match;(split;[|auto]); reflexivity.
+        repeat case_match;(split;[|auto]); simpl.
+        * inversion Heqo1.
+        * inversion Heqo1.
+        * inversion Heqo.
+        * inversion Heqo.
+        * inversion Heqo1.
+        * inversion Heqo1.
+        * inversion Heqp10; clear Heqp10; subst.
+          inversion Heqp; clear Heqp; subst.
+          inversion Heqp0; clear Heqp0; subst.
+          rewrite Heqp1 in Heqp5. inversion Heqp5.
+          reflexivity.
+        * subst. inversion Heqp10; clear Heqp10; subst.
+          inversion Heqp; clear Heqp; subst.
+          inversion Heqp0; clear Heqp0; subst.
+          rewrite Heqp1 in Heqp5. inversion Heqp5; clear Heqp5; subst.
+          
+          
         
       + (rewrite lookup_insert_ne in Hp';[(apply not_eq_sym; assumption)|idtac]).
         specialize (IHp1 C evs svs cpC).
@@ -545,6 +636,7 @@ Section proof_system_translation.
     apply Hg' in Hpresent.
     destruct Hpresent as [history Hhistory].
     destruct history;[inversion Hhistory|].
+    
     induction history; simpl in *.
     - subst. clear Hg'. simpl in *.
       case_match.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -420,21 +420,21 @@ Section proof_system_translation.
            just started. In other words, history behaves as if we started from
            the nested existential and mu patterns.
          *)
-        apply (existT [(p', (np', ∅, ∅, ∅))]).
-        simpl.
-        rewrite lookup_empty; auto.
+        apply (existT [(p', (to_NamedPattern2' p' ∅ ∅ ∅))]).
+        simpl. repeat split; auto.
       }
       unfold history_generator. intros p' np' Hp'.
       destruct (decide (p' = patt_exists p)).
       + (subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np';
-          apply (existT [(patt_exists p, (n0, C, evs, svs))]); simpl; split; auto
+          apply (existT [(patt_exists p, (to_NamedPattern2' (patt_exists p) ∅ ∅ ∅))]); simpl; split; auto
         ).
+        
       +
         inversion Heqp0. subst. clear Heqp0.
         simpl in Hp'.
         destruct (decide (is_bound_evar p')).
-        * apply (existT [(p', (np', ∅, ∅, ∅))]).
-          simpl. rewrite lookup_empty. split; auto.
+        * apply (existT [(p', (to_NamedPattern2' p' ∅ ∅ ∅))]).
+          simpl. repeat split; auto.
         * 
           unfold history_generator in IHp.
           specialize (IHp p' np').
@@ -478,21 +478,20 @@ Section proof_system_translation.
            just started. In other words, history behaves as if we started from
            the nested existential and mu patterns.
          *)
-        apply (existT [(p', (np', ∅, ∅, ∅))]).
-        simpl.
-        rewrite lookup_empty; auto.
+        apply (existT [(p', (to_NamedPattern2' p' ∅ ∅ ∅))]).
+        simpl. repeat split; auto.
       }
       unfold history_generator. intros p' np' Hp'.
       destruct (decide (p' = patt_mu p)).
       + (subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np';
-          apply (existT [(patt_mu p, (n0, C, evs, svs))]); simpl; split; auto
+          apply (existT [(patt_mu p, (to_NamedPattern2' (patt_mu p) ∅ ∅ ∅))]); simpl; split; auto
         ).
       +
         inversion Heqp0. subst. clear Heqp0.
         simpl in Hp'.
         destruct (decide (is_bound_svar p')).
-        * apply (existT [(p', (np', ∅, ∅, ∅))]).
-          simpl. rewrite lookup_empty. split; auto.
+        * apply (existT [(p', (to_NamedPattern2' p' ∅ ∅ ∅))]).
+          simpl. repeat split; auto.
         * 
           unfold history_generator in IHp.
           specialize (IHp p' np').

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -714,13 +714,33 @@ Qed.
             inversion Hwitness.
           }
         * destruct H as [s1 Hs1].
+          (*destruct (decide (C !! patt_bound_svar k' = Some ))*)
+          (* Three cases may happen:
+            (1) C !! patt_bound_svar k' = Some (npatt_svar _)
+            (2) C !! patt_bound_svar k' = Some _ (* but not npatt_svar *)
+            (3) C !! patt_bound_svar k' = None
+          *)
+          (*
+          destruct (C !! patt_bound_svar k').
+          {
+
+          }
           exists s1.
           rewrite lookup_union_Some in Hs1.
           2: { apply remove_disjoint_keep_e. }
           destruct Hs1 as [Hs1|Hs1].
           --
-            
-  Qed.
+            epose proof (Honly := onlyAddsSubpatterns _ _ _ _).
+            erewrite Heqp1 in Honly.
+            simpl in Honly.
+            specialize (Honly (patt_bound_svar k')).
+            unfold remove_bound_evars in Hs1.
+            rewrite map_filter_lookup_Some in Hs1.
+            destruct Hs1 as [Hs11 Hs12].
+            rewrite Hs11 in Honly.
+
+*)
+  Abort.
 
 
       
@@ -879,6 +899,30 @@ Qed.
            that is, \exists k. patt_bound_evar k' \in C iff k' < k
            (and the same for bound_svar)
          *)
+        assert(HsubC' : sub_prop C').
+        {
+          unfold sub_prop.
+          intros p1 np1 Hnp1.
+          specialize (Hsub p1 np1).
+          rewrite HeqC' in Hnp1.
+          destruct p1; try exact I;
+          feed specialize Hsub;
+          try(
+            (rewrite lookup_insert_ne in Hnp1;[discriminate|]);
+            unfold cache_incr_evar in Hnp1;
+            rewrite lookup_kmap_Some in Hnp1;
+            destruct Hnp1 as [pincr [Hpincr1 Hpincr2]];
+            destruct pincr; simpl in Hpincr1; inversion Hpincr1;
+            subst; exact Hpincr2
+          ).
+          + destruct Hsub as [np' [nq' [Hsub1 Hsub2]]].
+            exists np', nq'.
+            (* If p1_1 (or p1_2) is not a bevar, then this should be easy.
+               However, if it is a bevar,
+            *)
+          }
+        }
+         Print sub_prop.
         Print cache_incr_evar. Print incr_one_evar.
         Print to_NamedPattern2'.
         (* b0 ---> b0 *)

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -313,7 +313,7 @@ Section proof_system_translation.
                     match history with
                     | [] => False
                     | (x::xs) =>
-                        x.1 = p /\ x.2.1.1.1 = np  /\
+                        x.1 = p /\
 (*                        x.2.1.1.2 !! p = None /\ *)
                           (match (last (x::xs)) with
                           | None => False
@@ -376,14 +376,10 @@ Section proof_system_translation.
       simpl.
       unfold history_generator. intros p' np' Hp'.
       destruct (decide (p' = patt_app p1 p2)).
-      + subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np'.
-          apply (existT [(patt_app p1 p2, (to_NamedPattern2' (patt_app p1 p2) C evs svs))]); simpl; split;[reflexivity|]
-        .
-        repeat case_match; simpl in *.
-        1,3: inversion Heqo1.
-        * subst. inversion Heqp; subst; clear Heqp.
-        
-        repeat case_match;(split;[|auto]); simpl. 2: { reflexivity.
+      + (subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np';
+          apply (existT [(patt_app p1 p2, (to_NamedPattern2' (patt_app p1 p2) ∅ ∅ ∅))]); simpl; split;[reflexivity|]
+        ).
+        repeat case_match;(split;[|auto]); reflexivity.
         
       + (rewrite lookup_insert_ne in Hp';[(apply not_eq_sym; assumption)|idtac]).
         specialize (IHp1 C evs svs cpC).

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -1657,7 +1657,21 @@ Qed.
   Lemma is_not_subformula_2 p q:
     ~is_subformula_of_ind (patt_app q (patt_exists p)) p.
   Proof. Admitted.
-  
+
+  Lemma bound_evar_is_bound_var p:
+    is_bound_evar p ->
+    is_bound_var p.
+  Proof.
+    intros [b H]. subst p. simpl. exact I.
+  Qed.
+
+  Lemma bound_svar_is_bound_var p:
+    is_bound_svar p ->
+    is_bound_var p.
+  Proof.
+    intros [b H]. subst p. simpl. exact I.
+  Qed.
+
   Lemma sub_prop_step (C : Cache) (p : Pattern) (evs : EVarSet) (svs : SVarSet):
     dangling_vars_cached C p ->
     cache_continuous_prop C ->
@@ -1938,6 +1952,33 @@ Qed.
         epose proof (IH1 := IHp C' HdanglingC'p0 HcontC' HsubC' _ _).
         erewrite Heqp0 in IH1. simpl in IH1.
         destruct p00; try exact I.
+        {
+          split.
+          {
+            destruct (decide (is_bound_evar p00_1)) as [Hbound|Hnbound].
+            {
+              left. apply bound_evar_is_bound_var. exact Hbound.
+            }
+            right.
+            destruct (decide (p00_1 = patt_exists p0)) as [Hsame|Hnsame].
+            {
+              exists (npatt_exists (evs_fresh evs p0) n0).
+              subst.
+              apply lookup_insert.
+            }
+            rewrite lookup_insert_ne.
+            { apply not_eq_sym. apply Hnsame. }
+
+            destruct H as [H|H].
+            {
+              destruct H as [Hcontra _]. inversion Hcontra.
+            }
+            destruct H as [_ H].
+            pose proof (IH1 (patt_app p00_1 p00_2)).
+            exists npatt_bott.
+            rewrite lookup_union_Some.
+          }
+        }
         --
           destruct H as [[H H']|[H H']];[(inversion H; subst; clear H)|].
         {

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -347,8 +347,56 @@ Section proof_system_translation.
     - destruct H as [e Hcontra]. inversion Hcontra.
   Qed.
 
-
-Check dangling_vars_cached.
+  Definition is_bound_var (p : Pattern) :=
+    match p with
+    | patt_bound_evar _ => True
+    | patt_bound_svar _ => True
+    | _ => False
+    end.
+  
+  Lemma cache_continuous_add_not_bound (C : Cache) (p : Pattern) (np : NamedPattern) :
+    ~ is_bound_var p ->
+    cache_continuous_prop C ->
+    cache_continuous_prop (<[p := np]> C).
+  Proof.
+    intros Hneg Hcache.
+    destruct Hcache as [Hcachee Hcaches].
+    split.
+    - destruct Hcachee as [k Hcachee].
+      exists k; intros.
+      specialize (Hcachee k').
+      destruct Hcachee as [Hl Hr].
+      split; intros.
+      + specialize (Hl H).
+        destruct Hl as [e Hl].
+        exists e.
+        rewrite <- Hl. eapply lookup_insert_ne.
+        unfold not; destruct p; intros; try inversion H0.
+        simpl in Hneg. apply Hneg. exact I.
+      + apply Hr.
+        destruct H as [e H].
+        exists e.
+        rewrite <- H. symmetry. eapply lookup_insert_ne.
+        unfold not; destruct p; intros; try inversion H0.
+        simpl in Hneg. apply Hneg. exact I.
+    - destruct Hcaches as [k Hcaches].
+      exists k; intros.
+      specialize (Hcaches k').
+      destruct Hcaches as [Hl Hr].
+      split; intros.
+      + specialize (Hl H).
+        destruct Hl as [e Hl].
+        exists e.
+        rewrite <- Hl. eapply lookup_insert_ne.
+        unfold not; destruct p; intros; try inversion H0.
+        simpl in Hneg. apply Hneg. exact I.
+      + apply Hr.
+        destruct H as [e H].
+        exists e.
+        rewrite <- H. symmetry. eapply lookup_insert_ne.
+        unfold not; destruct p; intros; try inversion H0.
+        simpl in Hneg. apply Hneg. exact I.
+  Qed.        
   
   Lemma cache_continuous_step (C : Cache) (p : Pattern) (evs : EVarSet) (svs : SVarSet):
     dangling_vars_cached C p ->

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -684,7 +684,42 @@ Qed.
             rewrite map_filter_lookup_Some in He.
             destruct He as [He1 He2].
             exact He1.
-      + 
+      + destruct HCs as [k Hk].
+        exists k.
+        intros k'.
+        rewrite Hk.
+        split; intros H.
+        * destruct H as [s1 Hs1].
+          exists s1.
+          apply lookup_union_Some.
+          { apply remove_disjoint_keep_e.  }
+          left.
+          unfold remove_bound_evars.
+          rewrite map_filter_lookup_Some.
+          split.
+          {
+            epose proof (Hext := to_NamedPattern2'_extends_cache _ _ _ _).
+            erewrite Heqp1 in Hext. simpl in Hext.
+            eapply lookup_weaken;[|eassumption].
+            rewrite lookup_insert_ne.
+            { discriminate. }
+            unfold cache_incr_evar.
+            rewrite lookup_kmap_Some.
+            exists (patt_bound_svar k').
+            split.
+            * reflexivity.
+            * exact Hs1.
+          }
+          { unfold is_bound_evar_entry. simpl. intros [witness Hwitness].
+            inversion Hwitness.
+          }
+        * destruct H as [s1 Hs1].
+          exists s1.
+          rewrite lookup_union_Some in Hs1.
+          2: { apply remove_disjoint_keep_e. }
+          destruct Hs1 as [Hs1|Hs1].
+          --
+            
   Qed.
 
 

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -467,6 +467,25 @@ Section proof_system_translation.
         rewrite -Htmp -Htmp2.
         split; apply lookup_insert_ne. apply imp_neq1. apply imp_neq2.
 
+      * admit.
+      * admit.
+      * admit.
+
+      * remember (evs ∪ {[evs_fresh evs p0]}) as evs'.
+        remember (<[BoundVarSugar.b0:=npatt_evar (evs_fresh evs p0)]> (cache_incr_evar C)) as C'.
+        (* need to show sub_prop C' holds *)
+        (* likely need invariant that caches are continuous for bound variables;
+           that is, \exists k. patt_bound_evar k' \in C iff k' < k
+           (and the same for bound_svar)
+         *)
+        Print cache_incr_evar. Print incr_one_evar.
+        Print to_NamedPattern2'.
+        (* b0 ---> b0 *)
+        pose proof (Hsub' := IHp C' Hsub evs' s).
+        rewrite Heqp0 in Hsub'; simpl in Hsub'.
+      pose proof (Hsub'' := IHp2 g0 Hsub' e0 s0);
+      rewrite Heqp1 in Hsub''; simpl in Hsub'');
+
 
       * inversion Heqp; subst; clear Heqp.
 

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -29,13 +29,7 @@ Section proof_system_translation.
   Definition well_formed_translation (phi : Pattern) (wfphi : is_true (well_formed phi))
     : (named_well_formed (to_NamedPattern2 phi)).
   Admitted.
-
-  Lemma named_pattern_imp (phi psi : Pattern) :
-    npatt_imp (to_NamedPattern2 phi) (to_NamedPattern2 psi) =
-    to_NamedPattern2 (patt_imp phi psi).
-  Proof.
-  Admitted.
-    
+   
   (*
   Print ML_proof_system. Check @hypothesis. Check N_hypothesis.
  Program Fixpoint translation (Gamma : Theory) (phi : Pattern) (prf : Gamma ⊢ phi)
@@ -262,252 +256,6 @@ Section proof_system_translation.
         }
         { intros Hcontra. apply n0. destruct Hcontra. simpl in H. subst ψ. exists x. reflexivity. }
   Qed. 
-  (* Why this lemma? It is just a consequence of [to_NamedPattern2'_extends_cache]. *)
-  (* We assume that \phi_2 is well_formed *)
-  (*
-  Lemma to_NamedPattern2'_None (ϕ₁ ϕ₂ : Pattern) (C : Cache) (evs : EVarSet) (svs : SVarSet):
-    dangling_vars_cached C ϕ₁ ->
-    (to_NamedPattern2' ϕ₁ C evs svs).1.1.2 !! ϕ₂ = None ->
-    C !! ϕ₂ = None.
-  Proof.
-    intros Hcached Hnone.
-    Check to_NamedPattern2'_extends_cache.
-    
-    move: C evs svs ϕ₂ Hcached Hnone.
-    induction ϕ₁; intros C evs svs ϕ₂ Hcached Hnone.
-    all:
-      match type of Hnone with
-      | (to_NamedPattern2' ?THIS _ _ _).1.1.2 !! _ = None => remember THIS as ϕ₁'
-      end;
-      destruct (decide (ϕ₁' = ϕ₂)).
-
-    all:
-      subst ϕ₁'; simpl in *.
-
-    all:
-      match goal with
-      | [ne: ?x <> ?y |- _]
-        => idtac "there"
-      | _
-        => subst;
-           simpl in *;
-           case_match;
-           simpl in *;
-           try congruence;
-           auto
-      end.
-
-    all:
-      repeat case_match; simpl in *; subst; auto;
-      try (rewrite lookup_insert_ne in Hnone; auto);
-      inversion Heqp; subst; clear Heqp.
-
-    -
-      assert (Hcached1: dangling_vars_cached C ϕ₁1).
-      {
-        unfold dangling_vars_cached in Hcached.
-        destruct Hcached as [Hcachede Hcacheds].
-        unfold dangling_vars_cached,dangling_evars_cached,dangling_svars_cached in *.
-        split; intros b Hb.
-        + specialize (Hcachede b).
-          simpl in Hcachede.
-          feed specialize Hcachede.
-          { apply orb_prop_intro. left. exact Hb. }
-          exact Hcachede.
-        + specialize (Hcacheds b).
-          simpl in Hcachede.
-          feed specialize Hcacheds.
-          { apply orb_prop_intro. left. exact Hb. }
-          exact Hcacheds.
-      }
-      assert (Hcached2: dangling_vars_cached C ϕ₁2).
-      {
-        unfold dangling_vars_cached in Hcached.
-        destruct Hcached as [Hcachede Hcacheds].
-        unfold dangling_vars_cached,dangling_evars_cached,dangling_svars_cached in *.
-        split; intros b Hb.
-        + specialize (Hcachede b).
-          simpl in Hcachede.
-          feed specialize Hcachede.
-          { apply orb_prop_intro. right. exact Hb. }
-          exact Hcachede.
-        + specialize (Hcacheds b).
-          simpl in Hcachede.
-          feed specialize Hcacheds.
-          { apply orb_prop_intro. right. exact Hb. }
-          exact Hcacheds.
-      }
-
-      
-      pose proof (Hnone_g0 := IHϕ₁2 g0 e0 s0 ϕ₂).
-      rewrite Heqp5 in Hnone_g0. simpl in Hnone_g0.
-
-      pose proof (Hsub1 := to_NamedPattern2'_extends_cache C ϕ₁1 evs svs).
-      rewrite Heqp2 in Hsub1. simpl in Hsub1.
-      pose proof (Hsub2 := to_NamedPattern2'_extends_cache g0 ϕ₁2 e0 s0).
-      rewrite Heqp5 in Hsub2. simpl in Hsub2.
-      pose proof (Hcached_g0 := dangling_vars_subcache _ _ _ Hcached2 Hsub1).
-      specialize (Hnone_g0 Hcached_g0 Hnone).
-      clear Hcached_g0 IHϕ₁2 Heqp5.
-
-      specialize (IHϕ₁1 C evs svs ϕ₂).
-      rewrite Heqp2 in IHϕ₁1. clear Heqp2. simpl in IHϕ₁1.
-      specialize (IHϕ₁1 Hcached1 Hnone_g0). exact IHϕ₁1.
-    -
-      assert (Hcached1: dangling_vars_cached C ϕ₁1).
-      {
-        unfold dangling_vars_cached in Hcached.
-        destruct Hcached as [Hcachede Hcacheds].
-        unfold dangling_vars_cached,dangling_evars_cached,dangling_svars_cached in *.
-        split; intros b Hb.
-        + specialize (Hcachede b).
-          simpl in Hcachede.
-          feed specialize Hcachede.
-          { apply orb_prop_intro. left. exact Hb. }
-          exact Hcachede.
-        + specialize (Hcacheds b).
-          simpl in Hcachede.
-          feed specialize Hcacheds.
-          { apply orb_prop_intro. left. exact Hb. }
-          exact Hcacheds.
-      }
-      assert (Hcached2: dangling_vars_cached C ϕ₁2).
-      {
-        unfold dangling_vars_cached in Hcached.
-        destruct Hcached as [Hcachede Hcacheds].
-        unfold dangling_vars_cached,dangling_evars_cached,dangling_svars_cached in *.
-        split; intros b Hb.
-        + specialize (Hcachede b).
-          simpl in Hcachede.
-          feed specialize Hcachede.
-          { apply orb_prop_intro. right. exact Hb. }
-          exact Hcachede.
-        + specialize (Hcacheds b).
-          simpl in Hcachede.
-          feed specialize Hcacheds.
-          { apply orb_prop_intro. right. exact Hb. }
-          exact Hcacheds.
-      }
-
-      
-      pose proof (Hnone_g0 := IHϕ₁2 g0 e0 s0 ϕ₂).
-      rewrite Heqp5 in Hnone_g0. simpl in Hnone_g0.
-
-      pose proof (Hsub1 := to_NamedPattern2'_extends_cache C ϕ₁1 evs svs).
-      rewrite Heqp2 in Hsub1. simpl in Hsub1.
-      pose proof (Hsub2 := to_NamedPattern2'_extends_cache g0 ϕ₁2 e0 s0).
-      rewrite Heqp5 in Hsub2. simpl in Hsub2.
-      pose proof (Hcached_g0 := dangling_vars_subcache _ _ _ Hcached2 Hsub1).
-      specialize (Hnone_g0 Hcached_g0 Hnone).
-      clear Hcached_g0 IHϕ₁2 Heqp5.
-
-      specialize (IHϕ₁1 C evs svs ϕ₂).
-      rewrite Heqp2 in IHϕ₁1. clear Heqp2. simpl in IHϕ₁1.
-      specialize (IHϕ₁1 Hcached1 Hnone_g0). exact IHϕ₁1.
-
-    -
-
-      rewrite lookup_union_None in Hnone.
-      destruct Hnone as [Hnone1 Hnone2].
-      unfold remove_bound_evars in Hnone1.
-      rewrite map_filter_lookup_None in Hnone1.
-      unfold keep_bound_evars in Hnone2.
-      rewrite map_filter_lookup_None in Hnone2.
-
-      destruct Hnone2 as [Hnone2|Hnone2].
-      { exact Hnone2. }
-      
-      
-      pose proof (Hnone_g0 := IHϕ₁
-                                (<[BoundVarSugar.b0:=npatt_evar (evs_fresh evs ϕ₁)]> (cache_incr_evar C))
-                                (evs ∪ {[evs_fresh evs ϕ₁]}) s ϕ₂)
-      .
-      feed specialize Hnone_g0.
-      {
-        destruct Hcached as [Hcachede Hcacheds].
-        unfold dangling_vars_cached,dangling_evars_cached,dangling_svars_cached.
-        unfold dangling_vars_cached,dangling_evars_cached,dangling_svars_cached in Hcachede, Hcacheds.
-        simpl in Hcachede,Hcacheds.
-        split; intros dbi Hdbi.
-        + 
-          destruct dbi as [| dbi'].
-          * exists (npatt_evar (evs_fresh evs ϕ₁)).
-            rewrite lookup_insert. reflexivity.
-          * apply Hcachede in Hdbi. destruct Hdbi as [nϕ Hnϕ].
-            rewrite lookup_insert_ne.
-            { discriminate. }
-            unfold cache_incr_evar.
-            setoid_rewrite lookup_kmap_Some.
-            2: { apply _. }
-            exists nϕ. exists (patt_bound_evar (dbi')).
-            simpl. split;[reflexivity|auto].
-        + rewrite lookup_insert_ne.
-          { discriminate. }
-          setoid_rewrite lookup_kmap_Some.
-          2: { apply _. }
-          specialize (Hcacheds dbi Hdbi).
-          destruct Hcacheds as [nϕ Hnϕ].
-          exists nϕ,(patt_bound_svar dbi).
-          simpl. split;[reflexivity|assumption].
-      }
-      { rewrite Heqp2. simpl.
-        pose proof (Hsub := to_NamedPattern2'_extends_cache ((<[BoundVarSugar.b0:=npatt_evar (evs_fresh evs ϕ₁)]>
-                                                                (cache_incr_evar C))) ϕ₁ (evs ∪ {[evs_fresh evs ϕ₁]}) s).
-        rewrite Heqp2 in Hsub. simpl in Hsub.
-        unfold is_bound_evar_entry in Hnone1,Hnone2. simpl in Hnone1,Hnone2.
-
-        remember (g0 !! ϕ₂) as onϕ.
-        destruct onϕ as [nϕ|];[|reflexivity].
-        
-        destruct Hnone1 as [Hnone1|Hnone1].
-        { exact Hnone1. }
-        exfalso.
-        specialize (Hnone1 nϕ eq_refl).
-        apply Hnone1. eapply Hnone2.
-       
-        admit.
-      }
-      
-      destruct (decide (ϕ₂ = BoundVarSugar.b0)).
-      { subst ϕ₂. rewrite lookup_insert in Hnone_g0. inversion Hnone_g0. }
-      rewrite lookup_insert_ne in Hnone_g0.
-      { apply not_eq_sym. assumption. }
-      
-      assert(H0: forall b, g !! (patt_bound_evar b) = None -> well_formed_closed_ex_aux ϕ₂ b).
-      {
-        
-      }
-      apply cache_incr_evar_lookup_None.
-      { intros b.
-        destruct ϕ₂; try congruence.
-        intros Hcontra.
-        rewrite Hcontra in H0. simpl in H0.
-        specialize (H0 n2 Hnone).
-        case_match. inversion Hcontra. lia. apply H0.
-      }
-      { exact Hnone_g0. }
-      (* TODO cache_incr preserves lookup *)
-      Print incr_one.
-      admit.
-    - pose proof (Hnone_g0 := IHϕ₁
-                                (<[BoundVarSugar.B0:=npatt_svar (svs_fresh s ϕ₁)]> (cache_incr C))
-                                evs
-                                (s ∪ {[svs_fresh s ϕ₁]}) ϕ₂)
-      .
-      feed specialize Hnone_g0.
-      { rewrite Heqp2. simpl. exact Hnone. }
-
-      destruct (decide (ϕ₂ = BoundVarSugar.B0)).
-      { subst ϕ₂. rewrite lookup_insert in Hnone_g0. inversion Hnone_g0. }
-      rewrite lookup_insert_ne in Hnone_g0.
-      { apply not_eq_sym. assumption. }
-      admit.
-  Qed.
-*)
-
-  Lemma subcache_prop (C C' : Cache) (p : Pattern) (np : NamedPattern) :
-    C !! p = Some np -> map_subseteq C C' -> C' !! p = Some np.
-  Admitted.
 
   (* A subpattern property of the cache: with any pattern it contains its direct subpatterns. *)
   Definition sub_prop (C : Cache) :=
@@ -529,6 +277,7 @@ Section proof_system_translation.
     sub_prop (to_NamedPattern2' p C evs svs).1.1.2.
   Admitted.
 
+  (*
   Lemma sub_prop_subcache (C C' : Cache) :
     sub_prop C' -> map_subseteq C C' -> sub_prop C.
   Proof.
@@ -540,6 +289,7 @@ Section proof_system_translation.
       (* need induction hypothesis *)
       admit. admit.
   Admitted.
+   *)
 
   About to_NamedPattern2'.
   (* A correspondence property of the cache: any named pattern it contains is a translation
@@ -548,11 +298,14 @@ Section proof_system_translation.
 
   Print ex.
 
-  (*Example ex (l : list nat) (x:nat) : l!!x = Some x.*)
-  (* x !! i == pattern * cache * evs * svs *)
-  (* svarset, namedpattern * cache * evs * svs *)
-  (* Maybe rename to [history_generator], [historian] or something like that *)
-  Definition corr_prop (C : Cache) :=
+  Search last.
+
+  (* s_1 $ s_2
+     C0 = ∅
+     1. to_namedPattern2'  (s_1 $ s_2) ∅
+     1.1. to_namedPattern2' s_1  ∅  ==> {(s₁, ns₁)}. hist(_) => {[(s₁, (ns₁, ∅))] &  }
+   *)
+  Definition history_generator (C : Cache) :=
     forall (p : @Pattern signature) (np : @NamedPattern signature),
       C !! p = Some np ->
       { history : list (@Pattern signature * ((@NamedPattern signature) * Cache * (@EVarSet signature) * (@SVarSet signature)))
@@ -560,23 +313,30 @@ Section proof_system_translation.
                     match history with
                     | [] => False
                     | (x::xs) =>
-                        x.2.1.1.2 !! p = None /\
+                        x.1 = p /\
+(*                        x.2.1.1.2 !! p = None /\ *)
+                          (match (last (x::xs)) with
+                          | None => False
+                          | Some (p_l, x_l) => x_l = (to_NamedPattern2' p_l ∅ ∅ ∅)
+                          end) /\
                           forall (i:nat),
                             match xs!!i with
                             | None => True
-                            | Some (p_i, (np_i, c_i, evs_i, svs_i)) =>
-                                ((x::xs)!!i) = Some (p_i,(to_NamedPattern2' p_i c_i evs_i svs_i))
+                            | Some (p_Si, (np_Si, c_Si, evs_Si, svs_Si)) =>
+                                exists p_i,
+                                c_Si !! p_i = None /\
+                                ((x::xs)!!i) = Some (p_i,(to_NamedPattern2' p_i c_Si evs_Si svs_Si))
                             end
                     end
       }.
 
-  Lemma corr_prop_subseteq (C₁ C₂ : Cache) :
+  Lemma history_generator_subseteq (C₁ C₂ : Cache) :
     C₁ ⊆ C₂ ->
-    corr_prop C₂ ->
-    corr_prop C₁.
+    history_generator C₂ ->
+    history_generator C₁.
   Proof.
     intros Hsub Hc.
-    unfold corr_prop in *.
+    unfold history_generator in *.
     intros p np Hp.
     specialize (Hc p np).
     feed specialize Hc.
@@ -584,27 +344,29 @@ Section proof_system_translation.
     exact Hc.
   Defined. (* I think this should not be opaque. *)
   
-  Lemma corr_prop_step (C : Cache) (p : Pattern) (evs : EVarSet) (svs : SVarSet):
-    corr_prop C ->
-    corr_prop (to_NamedPattern2' p C evs svs).1.1.2.
+  Lemma history_generator_step (C : Cache) (p : Pattern) (evs : EVarSet) (svs : SVarSet):
+    history_generator C ->
+    history_generator (to_NamedPattern2' p C evs svs).1.1.2.
   Proof.
     intros cpC.
     move: C evs svs cpC.
     induction p; intros C evs svs cpC; simpl; case_match.
 
     (* [p] was in cache -> the history function stays the same. Solves 10 subgoals *)
-    all: try (solve[unfold corr_prop; intros p' np' Hp'; simpl in Hp'; specialize (cpC p' np' Hp'); exact cpC]).
+    all: try (solve[unfold history_generator; intros p' np' Hp'; simpl in Hp'; specialize (cpC p' np' Hp'); exact cpC]).
     (* 10 subgoals remain - the pattern p' was not found in cache. *)
     (* Base cases *)
     1,2,3,4,5,7: simpl; intros p' np' Hp';
-    match type of Hp' with
+    lazymatch type of Hp' with
     | (<[?q:=?nq]> _ !! p' = _ ) =>
         destruct (decide (p' = q));
         [(subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np';
-          apply (existT [(q, (nq, C, evs, svs))]); simpl; split; auto
+          apply (existT [(q, (to_NamedPattern2' q ∅ ∅ ∅))]); simpl;
+          split;[reflexivity|]; case_match;[inversion Heqo0|];
+          split;[|auto];reflexivity
          )
         |(rewrite lookup_insert_ne in Hp';[(apply not_eq_sym; assumption)|idtac];
-         unfold corr_prop in cpC; specialize (cpC p' np' Hp'); apply cpC)
+         unfold history_generator in cpC; specialize (cpC p' np' Hp'); apply cpC)
         ]
     end.
 
@@ -612,11 +374,13 @@ Section proof_system_translation.
     - repeat case_match. subst.
       inversion Heqp. subst. clear Heqp.
       simpl.
-      unfold corr_prop. intros p' np' Hp'.
+      unfold history_generator. intros p' np' Hp'.
       destruct (decide (p' = patt_app p1 p2)).
       + (subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np';
-          apply (existT [(patt_app p1 p2, (npatt_app n n0, C, evs, svs))]); simpl; split; auto
+          apply (existT [(patt_app p1 p2, (to_NamedPattern2' (patt_app p1 p2) ∅ ∅ ∅))]); simpl; split;[reflexivity|]
         ).
+        repeat case_match;(split;[|auto]); reflexivity.
+        
       + (rewrite lookup_insert_ne in Hp';[(apply not_eq_sym; assumption)|idtac]).
         specialize (IHp1 C evs svs cpC).
         rewrite Heqp0 in IHp1. simpl in IHp1.
@@ -626,11 +390,13 @@ Section proof_system_translation.
     - repeat case_match. subst.
       inversion Heqp. subst. clear Heqp.
       simpl.
-      unfold corr_prop. intros p' np' Hp'.
+      unfold history_generator. intros p' np' Hp'.
       destruct (decide (p' = patt_imp p1 p2)).
       + (subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np';
-          apply (existT [(patt_imp p1 p2, (npatt_imp n n0, C, evs, svs))]); simpl; split; auto
+          apply (existT [(patt_imp p1 p2, (to_NamedPattern2' (patt_imp p1 p2) ∅ ∅ ∅))]); simpl; split;[reflexivity|]
         ).
+        repeat case_match;(split;[|auto]); reflexivity.
+        
       + (rewrite lookup_insert_ne in Hp';[(apply not_eq_sym; assumption)|idtac]).
         specialize (IHp1 C evs svs cpC).
         rewrite Heqp0 in IHp1. simpl in IHp1.
@@ -646,7 +412,7 @@ Section proof_system_translation.
       rewrite -> Heqp1 in IHp. simpl in IHp.
       feed specialize IHp.
       {
-        unfold corr_prop. intros p' np' Hp'.
+        unfold history_generator. intros p' np' Hp'.
         inversion Heqp0. subst. clear Heqp0.
         (* So what does the cache = ∅ mean here? 
            Recall that we start with empty cache when translating pattern.
@@ -658,7 +424,7 @@ Section proof_system_translation.
         simpl.
         rewrite lookup_empty; auto.
       }
-      unfold corr_prop. intros p' np' Hp'.
+      unfold history_generator. intros p' np' Hp'.
       destruct (decide (p' = patt_exists p)).
       + (subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np';
           apply (existT [(patt_exists p, (n0, C, evs, svs))]); simpl; split; auto
@@ -670,7 +436,7 @@ Section proof_system_translation.
         * apply (existT [(p', (np', ∅, ∅, ∅))]).
           simpl. rewrite lookup_empty. split; auto.
         * 
-          unfold corr_prop in IHp.
+          unfold history_generator in IHp.
           specialize (IHp p' np').
           feed specialize IHp.
           {
@@ -704,7 +470,7 @@ Section proof_system_translation.
       rewrite -> Heqp1 in IHp. simpl in IHp.
       feed specialize IHp.
       {
-        unfold corr_prop. intros p' np' Hp'.
+        unfold history_generator. intros p' np' Hp'.
         inversion Heqp0. subst. clear Heqp0.
         (* So what does the cache = ∅ mean here? 
            Recall that we start with empty cache when translating pattern.
@@ -716,7 +482,7 @@ Section proof_system_translation.
         simpl.
         rewrite lookup_empty; auto.
       }
-      unfold corr_prop. intros p' np' Hp'.
+      unfold history_generator. intros p' np' Hp'.
       destruct (decide (p' = patt_mu p)).
       + (subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np';
           apply (existT [(patt_mu p, (n0, C, evs, svs))]); simpl; split; auto
@@ -728,7 +494,7 @@ Section proof_system_translation.
         * apply (existT [(p', (np', ∅, ∅, ∅))]).
           simpl. rewrite lookup_empty. split; auto.
         * 
-          unfold corr_prop in IHp.
+          unfold history_generator in IHp.
           specialize (IHp p' np').
           feed specialize IHp.
           {
@@ -761,12 +527,30 @@ Section proof_system_translation.
         (cache : Cache)
         (evs : EVarSet)
         (svs : SVarSet):
-    corr_prop cache ->
+    history_generator cache ->
     (to_NamedPattern2' (patt_imp p (patt_imp q p)) cache evs svs).1.1.1
     = npatt_imp np' (npatt_imp nq' np'') ->
     np'' = np'.
   Proof.
-    intros Hcorr_cache H.
+    intros Hg H. Search to_NamedPattern2'.
+    remember (patt_imp p (patt_imp q p)) as pqp.
+    pose proof (Hpresent := to_NamedPattern2'_ensures_present pqp cache evs svs).
+    rewrite H in Hpresent.
+    match type of H with
+    | (?e.1.1.1 = _) => remember e as Call
+    end.
+    remember (Call.1.1.2) as cache'.
+    
+    pose proof (Hg' := history_generator_step cache pqp evs svs Hg).
+    rewrite -HeqCall in Hg'. rewrite -Heqcache' in Hg'.
+    apply Hg' in Hpresent.
+    destruct Hpresent as [history Hhistory].
+    destruct history;[inversion Hhistory|].
+    induction history; simpl in *.
+    - subst. clear Hg'. simpl in *.
+      case_match.
+      + simpl in *. subst.
+    
     simpl in H.
     case_match.
     - admit.
@@ -784,8 +568,8 @@ Section proof_system_translation.
            By monotonicity (Lemma ???), ???
          *)
         simpl.
-        Check corr_prop_step. About corr_prop_step.
-        pose proof (Hcorr_g := corr_prop_step cache p evs svs Hcorr_cache).
+        Check history_generator_step. About history_generator_step.
+        pose proof (Hcorr_g := history_generator_step cache p evs svs Hcorr_cache).
         rewrite Heqp3 in Hcorr_g. simpl in Hcorr_g.
         (* pose proof (Hcorr_g _ _ Heqo0).
         destruct X as [[[cache' evs'] svs'] [Hnone [H Hsub]]]. simpl in H.
@@ -821,7 +605,7 @@ Section proof_system_translation.
   Check False_rect. Check eq_refl.
   Obligation Tactic := idtac.
   Equations? translation' (G : Theory) (phi : Pattern) (prf : G ⊢ phi)
-           (cache : Cache) (pfsub : sub_prop cache) (pfcorr : corr_prop cache)
+           (cache : Cache) (pfsub : sub_prop cache) (pfcorr : history_generator cache)
            (used_evars : EVarSet) (used_svars : SVarSet)
     : (NP_ML_proof_system (theory_translation G)
                           (to_NamedPattern2' phi (cache)
@@ -968,7 +752,7 @@ Section proof_system_translation.
     - admit.
     - repeat case_match; simpl.
       + remember pfcorr as pfcorr'; clear Heqpfcorr'.
-         Print corr_prop.
+         Print history_generator.
         inversion pfcorr as [ | cache1 cache2 evs1 svs1 (patt_imp p (patt_imp q p)) ].
         { subst. inversion Heqo. }
         
@@ -1003,7 +787,7 @@ Section proof_system_translation.
       + admit.
     - repeat case_match; simpl.
       + remember pfcorr as pfcorr'; clear Heqpfcorr'.
-        unfold corr_prop in pfcorr'.
+        unfold history_generator in pfcorr'.
         specialize (pfcorr' (patt_imp p (patt_imp q p)) n Heqo).
         destruct pfcorr' as [[[cache' evs'] svs'] [Hnone [H Hsub]]]. simpl in Hnone.
         assert ({ pq | n = npatt_imp pq.1 (npatt_imp pq.2 pq.1) }) by admit.
@@ -1011,7 +795,7 @@ Section proof_system_translation.
         simpl (cache', evs', svs').2 in H. subst.
         apply translation'. apply P1; assumption.
         exact (sub_prop_subcache cache' cache pfsub Hsub).
-        exact (corr_prop_subcache cache' cache pfcorr Hsub).
+        exact (history_generator_subcache cache' cache pfcorr Hsub).
       + admit.
       + admit.
     - case_match.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -289,34 +289,43 @@ Section proof_system_translation.
     intros Hsub.
     destruct (lookup p C) eqn:Hcache.
     - destruct p eqn:Hp; unfold to_NamedPattern2'; simpl in *; rewrite Hcache; auto.
-    - destruct p eqn:Hp; simpl in *; rewrite Hcache; simpl.
-      unfold sub_prop in *. intros.
-      destruct p0; auto.
-      1,2: (rewrite lookup_insert_Some in H;
+    - move: C Hsub Hcache.
+      induction p; intros C Hsub Hcache; simpl in *; rewrite Hcache; simpl;
+        unfold sub_prop in *; intros;
+        try rename p0 into p00;
+        rename p into p0;
+      try lazymatch type of H with
+      | <[?P := ?NP]> _ !! _ = _ =>
+      destruct p0; auto;
+      try (rewrite lookup_insert_Some in H;
         destruct H as [[H1 H2] | [H3 H4]]; subst; auto; try inversion H1;
         apply Hsub in H4;
         destruct H4 as [np' [nq' [H4 H5]]];
-        destruct (decide (patt_free_evar x = p0_1)), (decide (patt_free_evar x = p0_2)); subst;
-        [(exists (npatt_evar x), (npatt_evar x);
+        destruct (decide (P = p0_1)), (decide (P = p0_2)); subst;
+        [(exists NP, NP;
           split; apply lookup_insert)
-        |(exists (npatt_evar x), nq';
+        |(exists NP, nq';
           split; [(apply lookup_insert)|(
           rewrite <- H5;
           apply lookup_insert_ne; assumption)])
-        |(exists np', (npatt_evar x);
+        |(exists np', NP;
           split; [(rewrite <- H4; apply lookup_insert_ne; assumption)
           |apply lookup_insert])
         |(exists np', nq';
           split; [(rewrite <- H4; apply lookup_insert_ne; assumption)|
                       (rewrite <- H5; apply lookup_insert_ne; assumption)])
-      ]).
-      1,2: rewrite lookup_insert_Some in H;
+      ]);
+      try (rewrite lookup_insert_Some in H;
       destruct H as [[H1 H2] | [H3 H4]]; subst; auto; try inversion H1;
       apply Hsub in H4;
       destruct H4 as [np' H4];
-      destruct (decide (patt_free_evar x = p0)); subst;
-      [(exists (npatt_evar x); apply lookup_insert)
-      |(exists np'; rewrite <- H4; apply lookup_insert_ne; assumption)].
+      destruct (decide (P = p0)); subst;
+      [(exists NP; apply lookup_insert)
+      |(exists np'; rewrite <- H4; apply lookup_insert_ne; assumption)])
+          end.
+      + repeat case_match; subst; auto; simpl in *.
+        inversion Heqp1; subst; clear Heqp1.
+        inversion Heqp; subst; clear Heqp.
   Admitted.
 
   (*

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -441,19 +441,117 @@ Section proof_system_translation.
         inversion Hnp'.
     - repeat case_match. invert_tuples.
       simpl in *.
-      (* TODO move this somewhere *)
-      (*
-      unfold dangling_vars_cached in HCached.
-      destruct HCached as [Hcachede Hcacheds].
-      unfold dangling_evars_cached in Hcachede.
-      unfold dangling_svars_cached in Hcacheds.
       pose proof (IH1 := IHp1 C evs svs).
       feed specialize IH1.
-      {
-
+      { eapply dangling_vars_cached_app_proj1. apply HCached. }
+      specialize (IH1 p').
+      rewrite Heqp1 in IH1. simpl in IH1.
+      pose proof (IH2 := IHp2 g0 e0 s0).
+      pose proof (Hextends := to_NamedPattern2'_extends_cache C p1 evs svs).
+      rewrite Heqp1 in Hextends. simpl in Hextends.
+      feed specialize IH2.
+      { eapply dangling_vars_subcache;[|apply Hextends].
+      eapply dangling_vars_cached_app_proj2. apply HCached.
       }
-      *)
-  
+      specialize (IH2 p').
+      rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      {
+        destruct Hcall; subst p' np'.
+        split.
+        { constructor. }
+        split; intros Hcontra; inversion Hcontra; inversion H.
+      }
+      destruct Hcall as [Hp' Hgp'].
+      rewrite Heqp2 in IH2. simpl in IH2.
+      specialize (IH1 HCp').
+      destruct (g0 !! p') eqn:Hg0p'.
+      {
+        feed specialize IH1.
+        {
+          exists n. reflexivity.
+        }
+        destruct IH1 as [Hp'p1 [Hbep' Hbsp']].
+        split.
+        {
+          apply sub_app_l. exact Hp'p1.
+        }
+        split. apply Hbep'. apply Hbsp'.
+      }
+      specialize (IH2 Hg0p').
+      feed specialize IH2.
+      {
+        exists np'. exact Hgp'.
+      }
+      destruct IH2 as [Hp'p2 [Hbep' Hbsp']].
+      split.
+      {
+        apply sub_app_r. exact Hp'p2.
+      }
+      split. exact Hbep'. exact Hbsp'.
+    - rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        split.
+        { constructor. }
+        split; intros HContra; inversion HContra; inversion H.
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        rewrite HCp' in Hnp'.
+        inversion Hnp'.
+    - repeat case_match. invert_tuples.
+    simpl in *.
+    pose proof (IH1 := IHp1 C evs svs).
+    feed specialize IH1.
+    { eapply dangling_vars_cached_app_proj1. apply HCached. }
+    specialize (IH1 p').
+    rewrite Heqp1 in IH1. simpl in IH1.
+    pose proof (IH2 := IHp2 g0 e0 s0).
+    pose proof (Hextends := to_NamedPattern2'_extends_cache C p1 evs svs).
+    rewrite Heqp1 in Hextends. simpl in Hextends.
+    feed specialize IH2.
+    { eapply dangling_vars_subcache;[|apply Hextends].
+    eapply dangling_vars_cached_app_proj2. apply HCached.
+    }
+    specialize (IH2 p').
+    rewrite lookup_insert_Some in Hcall.
+    destruct Hcall as [Hcall|Hcall].
+    {
+      destruct Hcall; subst p' np'.
+      split.
+      { constructor. }
+      split; intros Hcontra; inversion Hcontra; inversion H.
+    }
+    destruct Hcall as [Hp' Hgp'].
+    rewrite Heqp2 in IH2. simpl in IH2.
+    specialize (IH1 HCp').
+    destruct (g0 !! p') eqn:Hg0p'.
+    {
+      feed specialize IH1.
+      {
+        exists n. reflexivity.
+      }
+      destruct IH1 as [Hp'p1 [Hbep' Hbsp']].
+      split.
+      {
+        apply sub_imp_l. exact Hp'p1.
+      }
+      split. apply Hbep'. apply Hbsp'.
+    }
+    specialize (IH2 Hg0p').
+    feed specialize IH2.
+    {
+      exists np'. exact Hgp'.
+    }
+    destruct IH2 as [Hp'p2 [Hbep' Hbsp']].
+    split.
+    {
+      apply sub_imp_r. exact Hp'p2.
+    }
+    split. exact Hbep'. exact Hbsp'.
+  -
+    
   Admitted.
 
   Definition cache_continuous_prop (C : Cache) : Prop :=
@@ -591,23 +689,20 @@ Qed.
       intros Hcontra.
       inversion Hcontra.
     - repeat case_match. subst. invert_tuples. simpl.
-      unfold dangling_vars_cached in Hcached.
-      destruct Hcached as [Hcachede Hcacheds].
-      unfold dangling_evars_cached in Hcachede.
-      unfold dangling_svars_cached in Hcacheds.
       
       specialize (IHp1 C).
       feed specialize IHp1.
-      {
-        split; unfold dangling_evars_cached; unfold dangling_svars_cached; intros.
-        + apply Hcachede. simpl.
-          rewrite H. reflexivity.
-        + apply Hcacheds. simpl. rewrite H. reflexivity.
-      }
+      { eapply dangling_vars_cached_app_proj1. apply Hcached. }
       { apply Hsub. }
       specialize (IHp1 evs svs).
       rewrite Heqp0 in IHp1. simpl in IHp1.
 
+
+      unfold dangling_vars_cached in Hcached.
+      destruct Hcached as [Hcachede Hcacheds].
+      unfold dangling_evars_cached in Hcachede.
+      unfold dangling_svars_cached in Hcacheds.
+    
       specialize (IHp2 g).
       feed specialize IHp2.
       {

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -316,6 +316,66 @@ Section proof_system_translation.
             end).
 
 
+  Lemma dangling_vars_cached_app_proj1 C p1 p2:
+    dangling_vars_cached C (patt_app p1 p2) ->
+    dangling_vars_cached C p1.
+  Proof.
+    intros Hcached.
+    unfold dangling_vars_cached in Hcached.
+    destruct Hcached as [Hcachede Hcacheds].
+    unfold dangling_evars_cached in Hcachede.
+    unfold dangling_svars_cached in Hcacheds.
+    split; unfold dangling_evars_cached; unfold dangling_svars_cached; intros.
+    + apply Hcachede. simpl.
+      rewrite H. reflexivity.
+    + apply Hcacheds. simpl. rewrite H. reflexivity.
+  Qed.
+
+  Lemma dangling_vars_cached_app_proj2 C p1 p2:
+    dangling_vars_cached C (patt_app p1 p2) ->
+    dangling_vars_cached C p2.
+  Proof.
+    intros Hcached.
+    unfold dangling_vars_cached in Hcached.
+    destruct Hcached as [Hcachede Hcacheds].
+    unfold dangling_evars_cached in Hcachede.
+    unfold dangling_svars_cached in Hcacheds.
+    split; unfold dangling_evars_cached; unfold dangling_svars_cached; intros.
+    + apply Hcachede. simpl.
+      rewrite H. apply orb_comm.
+    + apply Hcacheds. simpl. rewrite H. apply orb_comm.
+  Qed.
+
+  Lemma dangling_vars_cached_imp_proj1 C p1 p2:
+    dangling_vars_cached C (patt_imp p1 p2) ->
+    dangling_vars_cached C p1.
+  Proof.
+    intros Hcached.
+    unfold dangling_vars_cached in Hcached.
+    destruct Hcached as [Hcachede Hcacheds].
+    unfold dangling_evars_cached in Hcachede.
+    unfold dangling_svars_cached in Hcacheds.
+    split; unfold dangling_evars_cached; unfold dangling_svars_cached; intros.
+    + apply Hcachede. simpl.
+      rewrite H. reflexivity.
+    + apply Hcacheds. simpl. rewrite H. reflexivity.
+  Qed.
+
+  Lemma dangling_vars_cached_imp_proj2 C p1 p2:
+    dangling_vars_cached C (patt_imp p1 p2) ->
+    dangling_vars_cached C p2.
+  Proof.
+    intros Hcached.
+    unfold dangling_vars_cached in Hcached.
+    destruct Hcached as [Hcachede Hcacheds].
+    unfold dangling_evars_cached in Hcachede.
+    unfold dangling_svars_cached in Hcacheds.
+    split; unfold dangling_evars_cached; unfold dangling_svars_cached; intros.
+    + apply Hcachede. simpl.
+      rewrite H. apply orb_comm.
+    + apply Hcacheds. simpl. rewrite H. apply orb_comm.
+  Qed.
+
   Lemma onlyAddsSubpatterns (C : Cache) (p : Pattern) (evs : EVarSet) (svs: SVarSet):
     dangling_vars_cached C p ->
     forall (p' : Pattern),
@@ -381,6 +441,18 @@ Section proof_system_translation.
         inversion Hnp'.
     - repeat case_match. invert_tuples.
       simpl in *.
+      (* TODO move this somewhere *)
+      (*
+      unfold dangling_vars_cached in HCached.
+      destruct HCached as [Hcachede Hcacheds].
+      unfold dangling_evars_cached in Hcachede.
+      unfold dangling_svars_cached in Hcacheds.
+      pose proof (IH1 := IHp1 C evs svs).
+      feed specialize IH1.
+      {
+
+      }
+      *)
   
   Admitted.
 

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -2196,6 +2196,164 @@ Qed.
               rewrite lookup_kmap.
               exists np'. exact Hnp'.
         }
+        epose proof (IH1 := IHp C' HdanglingC'p0 HcontC' HsubC' _ _).
+        erewrite Heqp0 in IH1. simpl in IH1.
+        destruct p00; try exact I.
+        --
+          destruct H as [[H H']|[H H']];[(inversion H; subst; clear H)|].
+        {
+          rewrite lookup_union_Some in H'.
+          2: { apply remove_disjoint_keep_e. }
+          destruct H' as [H'|H'].
+          2: {
+            unfold keep_bound_evars in H'.
+            rewrite map_filter_lookup_Some in H'.
+            destruct H' as [_ HContra].
+            unfold is_bound_evar_entry in HContra.
+            simpl in HContra. destruct HContra as [nn HContra]. inversion HContra.
+          }
+          unfold remove_bound_evars in H'.
+          rewrite map_filter_lookup_Some in H'.
+          destruct H' as [H' _].
+          pose proof (Htmp := IH1 (patt_app p00_1 p00_2) np H').
+          simpl in Htmp.
+          destruct Htmp as [np0_1 [np0_2 [Hp0_1 Hp0_2]]].
+          destruct (decide (patt_exists p0 = p00_1)), (decide (patt_exists p0 = p00_2)); subst.
+          ++
+            exists (npatt_exists (evs_fresh evs p0) n0), (npatt_exists (evs_fresh evs p0) n0).
+            split; apply lookup_insert.
+          ++
+            rewrite lookup_insert.
+            rewrite lookup_insert_ne.
+            { assumption. }
+            destruct (decide (is_bound_evar p00_2)).
+            {
+              destruct (C !! p00_2) eqn:HCp002.
+              {
+                exists (npatt_exists (evs_fresh evs p0) n0), n1.
+                split;[reflexivity|].
+                rewrite lookup_union_Some.
+                2: { apply remove_disjoint_keep_e. }
+                right.
+                unfold keep_bound_evars.
+                rewrite map_filter_lookup_Some.
+                split;[exact HCp002|].
+                unfold is_bound_evar_entry. simpl. assumption.
+              }
+              {
+                unfold is_bound_evar in i.
+                destruct i as [b Hb]. subst p00_2.
+                epose proof (Honly := onlyAddsSubpatterns _ _ _ _).
+                erewrite Heqp0 in Honly. simpl in Honly.
+                specialize (Honly HdanglingC'p0).
+                (*specialize (Honly (patt_bound_evar b)).*)
+                (*
+                  Now we have [H': g0 !! patt_app (patt_exists p0) (patt_bound_evar b) = Some np]
+                  and since [g0] comes from [C'], that is,
+                  from [(<[BoundVarSugar.b0:=npatt_evar (evs_fresh evs p0)]>
+                        (cache_incr_evar C))],
+                  and [patt_app] cannot be added by [cache_incr_evar] or the insert
+                  because it is not a bound evar,
+                  it follows that [patt_app (patt_exists p0) (patt_bound_evar b)]
+                  either (1) was in [C], or (2) was added to [g0] by a recursive call
+                  (see [Heqp0]).
+                  If (1) is the case, then by [Hsub: sub_prop C], we have [patt_bound_evar b]
+                  in [C] - and we can choose the right part of the union
+                  (that is, [keep_bound_evars C !! patt_bound_evar b = Some _]).
+                  But if (2) is the case, then by [Honly],
+                  [patt_app (patt_exists p0) (patt_bound_evar b)] is a subpattern
+                  of [p0] - which is a nonsense, contradiction.
+
+                *)
+                feed specialize Honly.
+                {
+
+                }
+              }
+
+              exists (npatt_exists (evs_fresh evs p0) n0), np0_2.
+              split.
+              rewrite lookup_union_Some.
+              2: { apply remove_disjoint_keep_e. }
+              right.
+            }
+            {
+              exists (npatt_exists (evs_fresh evs p0) n0), np0_2.
+              split. apply lookup_insert.
+              rewrite lookup_insert_ne;[assumption|].
+              rewrite lookup_union_Some.
+              2: { apply remove_disjoint_keep_e. }
+            }
+            rewrite <- Hp0_2. apply lookup_insert_ne. assumption.
+        --
+          exists np0_1, (npatt_app n0 n1).
+          split. rewrite <- Hp0_1. apply lookup_insert_ne. assumption.
+          apply lookup_insert.
+        --
+          exists np0_1, np0_2.
+          split. rewrite <- Hp0_1. apply lookup_insert_ne. assumption.
+          rewrite <- Hp0_2. apply lookup_insert_ne. assumption.
+      }
+      --
+    destruct H as [[H H']|[H H']];[(inversion H; subst; clear H)|].
+      {
+      unfold sub_prop in Hsub''.
+      pose proof (Htmp := Hsub'' (patt_imp p0_1 p0_2) np H').
+      simpl in Htmp. destruct Htmp as [np0_1 [np0_2 [Hp0_1 Hp0_2]]].
+      destruct (decide (patt_app p1 p2 = p0_1)), (decide (patt_app p1 p2 = p0_2)); subst.
+      --
+        exists (npatt_app n0 n1), (npatt_app n0 n1).
+        split; apply lookup_insert.
+      --
+        exists (npatt_app n0 n1), np0_2.
+        split. apply lookup_insert.
+        rewrite <- Hp0_2. apply lookup_insert_ne. assumption.
+      --
+        exists np0_1, (npatt_app n0 n1).
+        split. rewrite <- Hp0_1. apply lookup_insert_ne. assumption.
+        apply lookup_insert.
+      --
+        exists np0_1, np0_2.
+        split. rewrite <- Hp0_1. apply lookup_insert_ne. assumption.
+        rewrite <- Hp0_2. apply lookup_insert_ne. assumption.
+    } 
+  --
+    destruct H as [[H H']|[H H']];[(inversion H; subst; clear H)|].
+    { 
+      exists n0,n1.
+      pose proof (Htmp := to_NamedPattern2'_ensures_present p0_1 C evs svs).
+      rewrite Heqp0 in Htmp. simpl in Htmp.
+      pose proof (Hec := to_NamedPattern2'_extends_cache g0 p0_2 e0 s0).
+      rewrite Heqp1 in Hec. simpl in Hec.
+      pose proof (Htmp2 := to_NamedPattern2'_ensures_present p0_2 g0 e0 s0).
+      rewrite Heqp1 in Htmp2. simpl in Htmp2.
+      eapply lookup_weaken with (m2 := g) in Htmp;[|assumption].
+      rewrite -Htmp -Htmp2.
+      split; apply lookup_insert_ne. apply app_neq1. apply app_neq2.
+    }
+    {
+      unfold sub_prop in Hsub''.
+      pose proof (Htmp := Hsub'' (patt_exists p0) np H').
+      simpl in Htmp. destruct Htmp as [np' Hnp'].
+      destruct (decide (patt_app p1 p2 = p0)).
+      ++
+        subst p0. exists (npatt_app n0 n1). apply lookup_insert.
+      ++
+        exists np'. rewrite <- Hnp'. apply lookup_insert_ne. assumption.
+    }
+    --
+      destruct H as [[H H']|[H H']];[(inversion H; subst; clear H)|].
+      {
+        unfold sub_prop in Hsub''.
+        pose proof (Htmp := Hsub'' (patt_mu p0) np H').
+        simpl in Htmp. destruct Htmp as [np' Hnp'].
+        destruct (decide (patt_app p1 p2 = p0)).
+        ++
+          subst p0. exists (npatt_app n0 n1). apply lookup_insert.
+        ++
+          exists np'. rewrite <- Hnp'. apply lookup_insert_ne. assumption.
+      }
+        
          Print sub_prop.
         Print cache_incr_evar. Print incr_one_evar.
         Print to_NamedPattern2'.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -1786,20 +1786,16 @@ Qed.
         rewrite Heqp0 in Hsub'; simpl in Hsub'.
         pose proof (Hsub'' := IHp2 g0 Hdanglingg0p2 Hcont' Hsub' e0 s0).
         rewrite Heqp1 in Hsub''; simpl in Hsub''.
-        
-        destruct p0; auto.
-        -- destruct H as [[H _]|[_ H']].
-           { if_equal_then_cached H Heqp0 Heqp1. }
-           { if_not_equal_boc_2 H' Hsub'' (patt_app p1 p2) (npatt_app n0 n1). }
-        -- destruct H as [[H H']|[H H']].
-           { if_equal_then_cached H Heqp0 Heqp1. }
-           { if_not_equal_boc_2 H' Hsub'' (patt_app p1 p2) (npatt_app n0 n1). }
-        -- destruct H as [[H H']|[H H']].
-           { if_equal_then_cached H Heqp0 Heqp1. }
-           { if_not_equal_boc_1 H' Hsub'' (patt_app p1 p2) (npatt_app n0 n1). }
-        -- destruct H as [[H H']|[H H']].
-           { if_equal_then_cached H Heqp0 Heqp1. }
-           { if_not_equal_boc_1 H' Hsub'' (patt_app p1 p2) (npatt_app n0 n1). }
+
+        destruct p0; auto; destruct H as [[H _]|[_ H']].
+        -- if_equal_then_cached H Heqp0 Heqp1.
+        -- if_not_equal_boc_2 H' Hsub'' (patt_app p1 p2) (npatt_app n0 n1).
+        -- if_equal_then_cached H Heqp0 Heqp1.
+        -- if_not_equal_boc_2 H' Hsub'' (patt_app p1 p2) (npatt_app n0 n1).
+        -- if_equal_then_cached H Heqp0 Heqp1.
+        -- if_not_equal_boc_1 H' Hsub'' (patt_app p1 p2) (npatt_app n0 n1).
+        -- if_equal_then_cached H Heqp0 Heqp1.
+        -- if_not_equal_boc_1 H' Hsub'' (patt_app p1 p2) (npatt_app n0 n1).
 
       * repeat case_match_in_hyp H.
         repeat case_match_in_hyp Heqp.
@@ -1829,19 +1825,15 @@ Qed.
         pose proof (Hsub'' := IHp2 g0 Hdanglingg0p2 Hcont' Hsub' e0 s0).
         rewrite Heqp1 in Hsub''; simpl in Hsub''.
 
-        destruct p0; auto.
-        -- destruct H as [[H _]|[_ H']].
-           { if_equal_then_cached H Heqp0 Heqp1. }
-           { if_not_equal_boc_2 H' Hsub'' (patt_imp p1 p2) (npatt_imp n0 n1). }
-        -- destruct H as [[H H']|[H H']].
-           { if_equal_then_cached H Heqp0 Heqp1. }
-           { if_not_equal_boc_2 H' Hsub'' (patt_imp p1 p2) (npatt_imp n0 n1). }
-        -- destruct H as [[H H']|[H H']].
-           { if_equal_then_cached H Heqp0 Heqp1. }
-           { if_not_equal_boc_1 H' Hsub'' (patt_imp p1 p2) (npatt_imp n0 n1). }
-        -- destruct H as [[H H']|[H H']].
-           { if_equal_then_cached H Heqp0 Heqp1. }
-           { if_not_equal_boc_1 H' Hsub'' (patt_imp p1 p2) (npatt_imp n0 n1). }
+        destruct p0; auto; destruct H as [[H _]|[_ H']].
+        -- if_equal_then_cached H Heqp0 Heqp1.
+        -- if_not_equal_boc_2 H' Hsub'' (patt_imp p1 p2) (npatt_imp n0 n1).
+        -- if_equal_then_cached H Heqp0 Heqp1.
+        -- if_not_equal_boc_2 H' Hsub'' (patt_imp p1 p2) (npatt_imp n0 n1).
+        -- if_equal_then_cached H Heqp0 Heqp1.
+        -- if_not_equal_boc_1 H' Hsub'' (patt_imp p1 p2) (npatt_imp n0 n1).
+        -- if_equal_then_cached H Heqp0 Heqp1.
+        -- if_not_equal_boc_1 H' Hsub'' (patt_imp p1 p2) (npatt_imp n0 n1).
 
     * repeat case_match_in_hyp H.
         repeat case_match_in_hyp Heqp.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -313,7 +313,7 @@ Section proof_system_translation.
                     match history with
                     | [] => False
                     | (x::xs) =>
-                        x.1 = p /\
+                        x.1 = p /\ x.2.1.1.1 = np  /\
 (*                        x.2.1.1.2 !! p = None /\ *)
                           (match (last (x::xs)) with
                           | None => False
@@ -376,10 +376,14 @@ Section proof_system_translation.
       simpl.
       unfold history_generator. intros p' np' Hp'.
       destruct (decide (p' = patt_app p1 p2)).
-      + (subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np';
-          apply (existT [(patt_app p1 p2, (to_NamedPattern2' (patt_app p1 p2) ∅ ∅ ∅))]); simpl; split;[reflexivity|]
-        ).
-        repeat case_match;(split;[|auto]); reflexivity.
+      + subst p'; rewrite lookup_insert in Hp'; inversion Hp'; clear Hp'; subst np'.
+          apply (existT [(patt_app p1 p2, (to_NamedPattern2' (patt_app p1 p2) C evs svs))]); simpl; split;[reflexivity|]
+        .
+        repeat case_match; simpl in *.
+        1,3: inversion Heqo1.
+        * subst. inversion Heqp; subst; clear Heqp.
+        
+        repeat case_match;(split;[|auto]); simpl. 2: { reflexivity.
         
       + (rewrite lookup_insert_ne in Hp';[(apply not_eq_sym; assumption)|idtac]).
         specialize (IHp1 C evs svs cpC).

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -406,8 +406,12 @@ Section proof_system_translation.
     intros Hcached Hsub.
     move: C Hcached Hsub evs svs.
     induction p; intros C Hcached Hsub evs svs; simpl; case_match; simpl; try apply Hsub.
-    - admit.
-    - admit.
+    - apply cache_continuous_add_not_bound;[|exact Hsub].
+      intros Hcontra.
+      inversion Hcontra.
+    - apply cache_continuous_add_not_bound;[|exact Hsub].
+      intros Hcontra.
+      inversion Hcontra.
     - destruct Hcached as [Hcachede Hcacheds].
       unfold dangling_evars_cached in Hcachede.
       specialize (Hcachede n). simpl in Hcachede.
@@ -422,9 +426,9 @@ Section proof_system_translation.
       specialize (Hcacheds erefl).
       destruct Hcacheds as [nϕ Hnϕ].
       rewrite Hnϕ in Heqo. inversion Heqo.
-    - admit.
-    - admit.
-    - admit.
+    - apply cache_continuous_add_not_bound;[|exact Hsub].
+      intros Hcontra.
+      inversion Hcontra.
     - repeat case_match. subst. invert_tuples. simpl.
       unfold dangling_vars_cached in Hcached.
       destruct Hcached as [Hcachede Hcacheds].
@@ -476,8 +480,76 @@ Section proof_system_translation.
       apply cache_continuous_add_not_bound.
       intros Hcontra. inversion Hcontra.
       apply IHp2.
+    - apply cache_continuous_add_not_bound;[|exact Hsub].
+      intros Hcontra.
+      inversion Hcontra.
+    - repeat case_match. subst. invert_tuples. simpl.
+      unfold dangling_vars_cached in Hcached.
+      destruct Hcached as [Hcachede Hcacheds].
+      unfold dangling_evars_cached in Hcachede.
+      unfold dangling_svars_cached in Hcacheds.
+      
+      specialize (IHp1 C).
+      feed specialize IHp1.
+      {
+        split; unfold dangling_evars_cached; unfold dangling_svars_cached; intros.
+        + apply Hcachede. simpl.
+          rewrite H. reflexivity.
+        + apply Hcacheds. simpl. rewrite H. reflexivity.
+      }
+      { apply Hsub. }
+      specialize (IHp1 evs svs).
+      rewrite Heqp0 in IHp1. simpl in IHp1.
 
-    -
+      specialize (IHp2 g).
+      feed specialize IHp2.
+      {
+        split; unfold dangling_evars_cached; unfold dangling_svars_cached; intros.
+        + pose proof (Hextends := to_NamedPattern2'_extends_cache C p1 evs svs).
+          rewrite Heqp0 in Hextends. simpl in Hextends.
+          specialize (Hcachede b).
+          feed specialize Hcachede.
+          {
+            simpl. rewrite H. apply orb_comm.
+          }
+          destruct Hcachede as [nϕ Hnϕ].
+          exists nϕ.
+          eapply lookup_weaken; eassumption.
+
+        + pose proof (Hextends := to_NamedPattern2'_extends_cache C p1 evs svs).
+          rewrite Heqp0 in Hextends. simpl in Hextends.
+          specialize (Hcacheds b).
+          feed specialize Hcacheds.
+          {
+            simpl. rewrite H. apply orb_comm.
+          }
+          destruct Hcacheds as [nϕ Hnϕ].
+          exists nϕ.
+          eapply lookup_weaken; eassumption.
+      }
+      { apply IHp1. }
+
+      specialize (IHp2 e s0).
+      rewrite Heqp1 in IHp2. simpl in IHp2.
+      apply cache_continuous_add_not_bound.
+      intros Hcontra. inversion Hcontra.
+      apply IHp2.
+    - repeat case_match. subst. invert_tuples. simpl.
+      unfold dangling_vars_cached in Hcached.
+      destruct Hcached as [Hcachede Hcacheds].
+      unfold dangling_evars_cached in Hcachede.
+      unfold dangling_svars_cached in Hcacheds.
+      specialize (IHp (<[BoundVarSugar.b0:=npatt_evar (evs_fresh evs p)]>
+      (cache_incr_evar C))).
+      feed specialize IHp.
+      {
+        split; unfold dangling_evars_cached; unfold dangling_svars_cached; intros.
+        + pose proof (Hcachedeb := Hcachede (b - 1)).
+          simpl in Hcachedeb.
+          apply Hcachede. simpl.
+          rewrite H. reflexivity.
+        + apply Hcacheds. simpl. rewrite H. reflexivity.
+      }
 
       
   Lemma sub_prop_step (C : Cache) (p : Pattern) (evs : EVarSet) (svs : SVarSet):

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -1969,6 +1969,232 @@ Qed.
               destruct Hshift2 as [nq'2 Hnq'2].
               exists np'1,nq'2.
               split. exact Hnp'1. exact Hnq'2.
+            * unfold sub_prop in Hsub.
+              pose proof (Hsub1 := Hsub (patt_app pincr1 pincr2) np1 Hpincr2).
+              simpl in Hsub1.
+              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
+              pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr1 (evs_fresh evs p0) Hcont ltac:(assumption)).
+              feed specialize Hshift1.
+              {
+                exists np'. exact Hnp'.
+              }
+              destruct Hshift1 as [np'1 Hnp'1].
+              exists np'1, nq'.
+              split.
+              { exact Hnp'1. }
+              rewrite lookup_insert_ne.
+              { intros Hcontra. apply n. subst pincr2. exists 0. reflexivity. }
+              unfold cache_incr_evar.
+              replace pincr2 with (incr_one_evar pincr2).
+              2: {
+                destruct pincr2; try reflexivity.
+                exfalso. apply n. exists n1. reflexivity.
+              }
+              rewrite lookup_kmap. exact Hnq'.
+            * unfold sub_prop in Hsub.
+              pose proof (Hsub1 := Hsub (patt_app pincr1 pincr2) np1 Hpincr2).
+              simpl in Hsub1.
+              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
+              pose proof (Hshift2 := bound_evar_cont_cache_shift C pincr2 (evs_fresh evs p0) Hcont ltac:(assumption)).
+              feed specialize Hshift2.
+              {
+                exists nq'. exact Hnq'.
+              }
+              destruct Hshift2 as [nq'2 Hnq'2].
+              exists np', nq'2.
+              split.
+              {
+                rewrite lookup_insert_ne.
+                { intros Hcontra. apply n. subst pincr1. exists 0. reflexivity. }
+                unfold cache_incr_evar.
+                replace pincr1 with (incr_one_evar pincr1).
+                2: {
+                  destruct pincr1; try reflexivity.
+                  exfalso. apply n. exists n1. reflexivity.
+                }
+                rewrite lookup_kmap. exact Hnp'.
+              }
+              { exact Hnq'2. }
+            * 
+              unfold sub_prop in Hsub.
+              pose proof (Hsub1 := Hsub (patt_app pincr1 pincr2) np1 Hpincr2).
+              simpl in Hsub1.
+              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
+              exists np', nq'.
+              split.
+              {
+                rewrite lookup_insert_ne.
+                { intros Hcontra. apply n. subst pincr1. exists 0. reflexivity. }
+                unfold cache_incr_evar.
+                replace pincr1 with (incr_one_evar pincr1).
+                2: {
+                  destruct pincr1; try reflexivity.
+                  exfalso. apply n. exists n2. reflexivity.
+                }
+                rewrite lookup_kmap. exact Hnp'.
+              }
+              {
+                rewrite lookup_insert_ne.
+                { intros Hcontra. apply n1. subst pincr2. exists 0. reflexivity. }
+                unfold cache_incr_evar.
+                replace pincr2 with (incr_one_evar pincr2).
+                2: {
+                  destruct pincr2; try reflexivity.
+                  exfalso. apply n1. exists n2. reflexivity.
+                }
+                rewrite lookup_kmap. exact Hnq'.
+              }
+          + destruct (decide (is_bound_evar pincr1)), (decide (is_bound_evar pincr2)).
+            * 
+              unfold sub_prop in Hsub.
+              pose proof (Hsub1 := Hsub (patt_imp pincr1 pincr2) np1 Hpincr2).
+              simpl in Hsub1.
+              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
+              pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr1 (evs_fresh evs p0) Hcont ltac:(assumption)).
+              feed specialize Hshift1.
+              {
+                exists np'. exact Hnp'.
+              }
+              destruct Hshift1 as [np'1 Hnp'1].
+              pose proof (Hshift2 := bound_evar_cont_cache_shift C pincr2 (evs_fresh evs p0) Hcont ltac:(assumption)).
+              feed specialize Hshift2.
+              {
+                exists nq'. exact Hnq'.
+              }
+              destruct Hshift2 as [nq'2 Hnq'2].
+              exists np'1,nq'2.
+              split. exact Hnp'1. exact Hnq'2.
+            * unfold sub_prop in Hsub.
+              pose proof (Hsub1 := Hsub (patt_imp pincr1 pincr2) np1 Hpincr2).
+              simpl in Hsub1.
+              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
+              pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr1 (evs_fresh evs p0) Hcont ltac:(assumption)).
+              feed specialize Hshift1.
+              {
+                exists np'. exact Hnp'.
+              }
+              destruct Hshift1 as [np'1 Hnp'1].
+              exists np'1, nq'.
+              split.
+              { exact Hnp'1. }
+              rewrite lookup_insert_ne.
+              { intros Hcontra. apply n. subst pincr2. exists 0. reflexivity. }
+              unfold cache_incr_evar.
+              replace pincr2 with (incr_one_evar pincr2).
+              2: {
+                destruct pincr2; try reflexivity.
+                exfalso. apply n. exists n1. reflexivity.
+              }
+              rewrite lookup_kmap. exact Hnq'.
+            * unfold sub_prop in Hsub.
+              pose proof (Hsub1 := Hsub (patt_imp pincr1 pincr2) np1 Hpincr2).
+              simpl in Hsub1.
+              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
+              pose proof (Hshift2 := bound_evar_cont_cache_shift C pincr2 (evs_fresh evs p0) Hcont ltac:(assumption)).
+              feed specialize Hshift2.
+              {
+                exists nq'. exact Hnq'.
+              }
+              destruct Hshift2 as [nq'2 Hnq'2].
+              exists np', nq'2.
+              split.
+              {
+                rewrite lookup_insert_ne.
+                { intros Hcontra. apply n. subst pincr1. exists 0. reflexivity. }
+                unfold cache_incr_evar.
+                replace pincr1 with (incr_one_evar pincr1).
+                2: {
+                  destruct pincr1; try reflexivity.
+                  exfalso. apply n. exists n1. reflexivity.
+                }
+                rewrite lookup_kmap. exact Hnp'.
+              }
+              { exact Hnq'2. }
+            * 
+              unfold sub_prop in Hsub.
+              pose proof (Hsub1 := Hsub (patt_imp pincr1 pincr2) np1 Hpincr2).
+              simpl in Hsub1.
+              destruct Hsub1 as [np' [nq' [Hnp' Hnq']]].
+              exists np', nq'.
+              split.
+              {
+                rewrite lookup_insert_ne.
+                { intros Hcontra. apply n. subst pincr1. exists 0. reflexivity. }
+                unfold cache_incr_evar.
+                replace pincr1 with (incr_one_evar pincr1).
+                2: {
+                  destruct pincr1; try reflexivity.
+                  exfalso. apply n. exists n2. reflexivity.
+                }
+                rewrite lookup_kmap. exact Hnp'.
+              }
+              {
+                rewrite lookup_insert_ne.
+                { intros Hcontra. apply n1. subst pincr2. exists 0. reflexivity. }
+                unfold cache_incr_evar.
+                replace pincr2 with (incr_one_evar pincr2).
+                2: {
+                  destruct pincr2; try reflexivity.
+                  exfalso. apply n1. exists n2. reflexivity.
+                }
+                rewrite lookup_kmap. exact Hnq'.
+              }
+          + destruct (decide (is_bound_evar pincr)).
+          * 
+            unfold sub_prop in Hsub.
+            pose proof (Hsub1 := Hsub (patt_exists pincr) np1 Hpincr2).
+            simpl in Hsub1.
+            destruct Hsub1 as [np' Hnp'].
+            pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr (evs_fresh evs p0) Hcont ltac:(assumption)).
+            feed specialize Hshift1.
+            {
+              exists np'. exact Hnp'.
+            }
+            destruct Hshift1 as [np'1 Hnp'1].
+            exists np'1.
+            exact Hnp'1.
+          * unfold sub_prop in Hsub.
+            pose proof (Hsub1 := Hsub (patt_exists pincr) np1 Hpincr2).
+            simpl in Hsub1.
+            destruct Hsub1 as [np' Hnp'].
+            rewrite lookup_insert_ne.
+            { intros Hcontra. apply n. subst pincr. exists 0. reflexivity. }
+            unfold cache_incr_evar.
+            replace pincr with (incr_one_evar pincr).
+            2: {
+              destruct pincr; try reflexivity.
+              exfalso. apply n. exists n1. reflexivity.
+            }
+            rewrite lookup_kmap.
+            exists np'. exact Hnp'.
+            + destruct (decide (is_bound_evar pincr)).
+            * 
+              unfold sub_prop in Hsub.
+              pose proof (Hsub1 := Hsub (patt_mu pincr) np1 Hpincr2).
+              simpl in Hsub1.
+              destruct Hsub1 as [np' Hnp'].
+              pose proof (Hshift1 := bound_evar_cont_cache_shift C pincr (evs_fresh evs p0) Hcont ltac:(assumption)).
+              feed specialize Hshift1.
+              {
+                exists np'. exact Hnp'.
+              }
+              destruct Hshift1 as [np'1 Hnp'1].
+              exists np'1.
+              exact Hnp'1.
+            * unfold sub_prop in Hsub.
+              pose proof (Hsub1 := Hsub (patt_mu pincr) np1 Hpincr2).
+              simpl in Hsub1.
+              destruct Hsub1 as [np' Hnp'].
+              rewrite lookup_insert_ne.
+              { intros Hcontra. apply n. subst pincr. exists 0. reflexivity. }
+              unfold cache_incr_evar.
+              replace pincr with (incr_one_evar pincr).
+              2: {
+                destruct pincr; try reflexivity.
+                exfalso. apply n. exists n1. reflexivity.
+              }
+              rewrite lookup_kmap.
+              exists np'. exact Hnp'.
         }
          Print sub_prop.
         Print cache_incr_evar. Print incr_one_evar.

--- a/prover/theories/TEST_MMProofExtractor.v
+++ b/prover/theories/TEST_MMProofExtractor.v
@@ -301,6 +301,7 @@ Module MMTest.
     ∅ ⊢ ϕ11.
   Proof.
     apply Ex_quan.
+    { wf_auto2. }
   Qed.
 
   Definition ϕtest := (A ---> A) ---> (A ---> B) ---> (A ---> B).


### PR DESCRIPTION
In this (rather large) PR, we begin quite a serious reworking of the proof object extraction mechanism.
We introduce a nominal/named version of matching logic patterns, which uses names for variables.
We also have a named version for proofs. We provide a nontrivial translation function from the locally nameless representation of patterns into named representation of patterns; this translation function should preserve proofs.
We begin a work on showing that it actually does so. For this purpose, we prove several lemmas about the pattern translation function.