### PR TITLE
Proof object generation cached_p_impl_called_with_p

### DIFF
--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -783,6 +783,563 @@ Qed.
       }
   Qed.
 
+  Lemma onlyAddsSubpatterns2 (C : Cache) (p : Pattern) (evs : EVarSet) (svs: SVarSet):
+    forall (p' : Pattern),
+      C !! p' = None ->
+      (exists (np' : NamedPattern),
+          (to_NamedPattern2' p C evs svs).1.1.2 !! p' = Some np') ->
+      is_subformula_of_ind p' p.
+  Proof.
+    move: C evs svs.
+    induction p; intros C evs svs p' HCp' [np' Hcall]; simpl in Hcall; case_match;
+      simpl in Hcall; try (rewrite HCp' in Hcall; inversion Hcall).
+    - rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        { constructor. reflexivity. }
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        rewrite HCp' in Hnp'.
+        inversion Hnp'.
+    - rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        { constructor. reflexivity. }
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        rewrite HCp' in Hnp'.
+        inversion Hnp'.
+    - rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      {
+        destruct Hcall. subst. constructor. reflexivity.
+      }
+      {
+        destruct Hcall as [_ HContra]. rewrite HCp' in HContra. inversion HContra.
+      }
+    - rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      {
+        destruct Hcall. subst. constructor. reflexivity.
+      }
+      {
+        destruct Hcall as [_ HContra]. rewrite HCp' in HContra. inversion HContra.
+      }
+    - rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        { constructor. reflexivity. }
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        rewrite HCp' in Hnp'.
+        inversion Hnp'.
+    - repeat case_match. invert_tuples.
+      simpl in *.
+      pose proof (IH1 := IHp1 C evs svs).
+      specialize (IH1 p').
+      rewrite Heqp1 in IH1. simpl in IH1.
+      pose proof (IH2 := IHp2 g0 e0 s0).
+      pose proof (Hextends := to_NamedPattern2'_extends_cache C p1 evs svs).
+      rewrite Heqp1 in Hextends. simpl in Hextends.
+      specialize (IH2 p').
+      rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      {
+        destruct Hcall; subst p' np'.
+        { constructor. reflexivity. }
+      }
+      destruct Hcall as [Hp' Hgp'].
+      rewrite Heqp2 in IH2. simpl in IH2.
+      specialize (IH1 HCp').
+      destruct (g0 !! p') eqn:Hg0p'.
+      {
+        feed specialize IH1.
+        {
+          exists n. reflexivity.
+        }
+        apply sub_app_l. exact IH1.
+      }
+      specialize (IH2 Hg0p').
+      feed specialize IH2.
+      {
+        exists np'. exact Hgp'.
+      }
+      apply sub_app_r. exact IH2.
+    - rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        { constructor. reflexivity. }
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        rewrite HCp' in Hnp'.
+        inversion Hnp'.
+    - repeat case_match. invert_tuples.
+    simpl in *.
+    pose proof (IH1 := IHp1 C evs svs).
+    specialize (IH1 p').
+    rewrite Heqp1 in IH1. simpl in IH1.
+    pose proof (IH2 := IHp2 g0 e0 s0).
+    pose proof (Hextends := to_NamedPattern2'_extends_cache C p1 evs svs).
+    rewrite Heqp1 in Hextends. simpl in Hextends.
+    specialize (IH2 p').
+    rewrite lookup_insert_Some in Hcall.
+    destruct Hcall as [Hcall|Hcall].
+    {
+      destruct Hcall; subst p' np'.
+      { constructor. reflexivity. }
+    }
+    destruct Hcall as [Hp' Hgp'].
+    rewrite Heqp2 in IH2. simpl in IH2.
+    specialize (IH1 HCp').
+    destruct (g0 !! p') eqn:Hg0p'.
+    {
+      feed specialize IH1.
+      {
+        exists n. reflexivity.
+      }
+      apply sub_imp_l. exact IH1.
+    }
+    specialize (IH2 Hg0p').
+    feed specialize IH2.
+    {
+      exists np'. exact Hgp'.
+    }
+    apply sub_imp_r. exact IH2.
+    - repeat case_match. invert_tuples.
+      simpl in *.
+      rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      { destruct Hcall as [Hp' Hnp']. subst p' np'.
+        constructor. reflexivity.
+      }
+      destruct Hcall as [Hp' Hnp'].
+      rewrite lookup_union_Some in Hnp'.
+      2: { apply remove_disjoint_keep_e. }
+      destruct Hnp' as [Hnp'|Hnp'].
+      {
+        unfold remove_bound_evars in Hnp'.
+        rewrite map_filter_lookup_Some in Hnp'.
+        destruct Hnp' as [Hg0p' Hbep'].
+        pose proof (IH := IHp (<[BoundVarSugar.b0:=npatt_evar (evs_fresh evs p)]>
+        (cache_incr_evar C)) (evs ∪ {[evs_fresh evs p]}) s).
+        rewrite Heqp3 in IH. simpl in IH.
+        specialize (IH p').
+        unfold is_bound_evar_entry in Hbep'. simpl in Hbep'.
+        feed specialize IH.
+        {
+          destruct (decide (p' = BoundVarSugar.b0)).
+          {
+            subst p'. exfalso. apply Hbep'. exists 0. reflexivity.
+          }
+          rewrite lookup_insert_ne.
+          { apply not_eq_sym. assumption. }
+          unfold cache_incr_evar.
+          replace p' with (incr_one_evar p').
+          2: {
+            destruct p'; simpl; try reflexivity.
+            exfalso. apply Hbep'. exists n1. reflexivity.
+          }
+          rewrite lookup_kmap_None.
+          intros p'' Hp''.
+          apply (inj incr_one_evar) in Hp''.
+          subst p''.
+          exact HCp'.
+        }
+        {
+          exists np'. exact Hg0p'.
+        }
+        { apply sub_exists. exact IH. }
+      }
+      {
+        unfold keep_bound_evars in Hnp'.
+        rewrite map_filter_lookup_Some in Hnp'.
+        destruct Hnp' as [Hcontra _]. rewrite HCp' in Hcontra. inversion Hcontra.
+      }
+    - repeat case_match. invert_tuples.
+      simpl in *.
+      rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      { destruct Hcall as [Hp' Hnp']. subst p' np'.
+       constructor. reflexivity.
+      }
+      destruct Hcall as [Hp' Hnp'].
+      rewrite lookup_union_Some in Hnp'.
+      2: { apply remove_disjoint_keep_s. }
+      destruct Hnp' as [Hnp'|Hnp'].
+      {
+        unfold remove_bound_svars in Hnp'.
+        rewrite map_filter_lookup_Some in Hnp'.
+        destruct Hnp' as [Hg0p' Hbep'].
+        pose proof (IH := IHp (<[BoundVarSugar.B0:=npatt_svar (svs_fresh s p)]>
+        (cache_incr_svar C)) evs (s ∪ {[svs_fresh s p]})).
+        rewrite Heqp3 in IH. simpl in IH.
+        specialize (IH p').
+        unfold is_bound_svar_entry in Hbep'. simpl in Hbep'.
+        feed specialize IH.
+        {
+          destruct (decide (p' = BoundVarSugar.B0)).
+          {
+            subst p'. exfalso. apply Hbep'. exists 0. reflexivity.
+          }
+          rewrite lookup_insert_ne.
+          { apply not_eq_sym. assumption. }
+          unfold cache_incr_svar.
+          replace p' with (incr_one_svar p').
+          2: {
+            destruct p'; simpl; try reflexivity.
+            exfalso. apply Hbep'. exists n1. reflexivity.
+          }
+          rewrite lookup_kmap_None.
+          intros p'' Hp''.
+          apply (inj incr_one_svar) in Hp''.
+          subst p''.
+          exact HCp'.
+        }
+        {
+          exists np'. exact Hg0p'.
+        }
+        { apply sub_mu. exact IH. }
+      }
+      {
+        unfold keep_bound_evars in Hnp'.
+        rewrite map_filter_lookup_Some in Hnp'.
+        destruct Hnp' as [Hcontra _]. rewrite HCp' in Hcontra. inversion Hcontra.
+      }
+  Qed.
+
+  Lemma doesNotAddBoundVars (C : Cache) (p : Pattern) (evs : EVarSet) (svs: SVarSet):
+    dangling_vars_cached C p ->
+    forall (p' : Pattern),
+      C !! p' = None ->
+      (exists (np' : NamedPattern),
+          (to_NamedPattern2' p C evs svs).1.1.2 !! p' = Some np') ->
+      ~is_bound_evar p' /\ ~ is_bound_svar p'.
+  Proof.
+    intros HCached.
+    move: C evs svs HCached.
+    induction p; intros C evs svs HCached p' HCp' [np' Hcall]; simpl in Hcall; case_match;
+      simpl in Hcall; try (rewrite HCp' in Hcall; inversion Hcall).
+    - rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        split; intros HContra; inversion HContra; inversion H.
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        rewrite HCp' in Hnp'.
+        inversion Hnp'.
+    - rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        split; intros HContra; inversion HContra; inversion H.
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        rewrite HCp' in Hnp'.
+        inversion Hnp'.
+    - rewrite lookup_insert_Some in Hcall.
+      destruct HCached as [HCachede HCacheds].
+      unfold dangling_evars_cached in HCachede.
+      specialize (HCachede n).
+      feed specialize HCachede.
+      { unfold evar_is_dangling. simpl. case_match; auto. }
+      destruct HCachede as [nphi Hnphi].
+      rewrite Hnphi in Heqo.
+      inversion Heqo.
+    - rewrite lookup_insert_Some in Hcall.
+      destruct HCached as [HCachede HCacheds].
+      unfold dangling_svars_cached in HCacheds.
+      specialize (HCacheds n).
+      feed specialize HCacheds.
+      { unfold svar_is_dangling. simpl. case_match; auto. }
+      destruct HCacheds as [nphi Hnphi].
+      rewrite Hnphi in Heqo.
+      inversion Heqo.
+    - rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        split; intros HContra; inversion HContra; inversion H.
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        rewrite HCp' in Hnp'.
+        inversion Hnp'.
+    - repeat case_match. invert_tuples.
+      simpl in *.
+      pose proof (IH1 := IHp1 C evs svs).
+      feed specialize IH1.
+      { eapply dangling_vars_cached_app_proj1. apply HCached. }
+      specialize (IH1 p').
+      rewrite Heqp1 in IH1. simpl in IH1.
+      pose proof (IH2 := IHp2 g0 e0 s0).
+      pose proof (Hextends := to_NamedPattern2'_extends_cache C p1 evs svs).
+      rewrite Heqp1 in Hextends. simpl in Hextends.
+      feed specialize IH2.
+      { eapply dangling_vars_subcache;[|apply Hextends].
+      eapply dangling_vars_cached_app_proj2. apply HCached.
+      }
+      specialize (IH2 p').
+      rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      {
+        destruct Hcall; subst p' np'.
+        split; intros Hcontra; inversion Hcontra; inversion H.
+      }
+      destruct Hcall as [Hp' Hgp'].
+      rewrite Heqp2 in IH2. simpl in IH2.
+      specialize (IH1 HCp').
+      destruct (g0 !! p') eqn:Hg0p'.
+      {
+        feed specialize IH1.
+        {
+          exists n. reflexivity.
+        }
+        destruct IH1 as [Hbep' Hbsp'].
+        split. apply Hbep'. apply Hbsp'.
+      }
+      specialize (IH2 Hg0p').
+      feed specialize IH2.
+      {
+        exists np'. exact Hgp'.
+      }
+      destruct IH2 as [Hbep' Hbsp'].
+      split. exact Hbep'. exact Hbsp'.
+    - rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        split; intros HContra; inversion HContra; inversion H.
+      + destruct Hcall as [Hp' Hnp'].
+        subst.
+        rewrite HCp' in Hnp'.
+        inversion Hnp'.
+    - repeat case_match. invert_tuples.
+    simpl in *.
+    pose proof (IH1 := IHp1 C evs svs).
+    feed specialize IH1.
+    { eapply dangling_vars_cached_app_proj1. apply HCached. }
+    specialize (IH1 p').
+    rewrite Heqp1 in IH1. simpl in IH1.
+    pose proof (IH2 := IHp2 g0 e0 s0).
+    pose proof (Hextends := to_NamedPattern2'_extends_cache C p1 evs svs).
+    rewrite Heqp1 in Hextends. simpl in Hextends.
+    feed specialize IH2.
+    { eapply dangling_vars_subcache;[|apply Hextends].
+    eapply dangling_vars_cached_app_proj2. apply HCached.
+    }
+    specialize (IH2 p').
+    rewrite lookup_insert_Some in Hcall.
+    destruct Hcall as [Hcall|Hcall].
+    {
+      destruct Hcall; subst p' np'.
+      split; intros Hcontra; inversion Hcontra; inversion H.
+    }
+    destruct Hcall as [Hp' Hgp'].
+    rewrite Heqp2 in IH2. simpl in IH2.
+    specialize (IH1 HCp').
+    destruct (g0 !! p') eqn:Hg0p'.
+    {
+      feed specialize IH1.
+      {
+        exists n. reflexivity.
+      }
+      destruct IH1 as [Hbep' Hbsp'].
+      split. apply Hbep'. apply Hbsp'.
+    }
+    specialize (IH2 Hg0p').
+    feed specialize IH2.
+    {
+      exists np'. exact Hgp'.
+    }
+    destruct IH2 as [Hbep' Hbsp'].
+    
+    split. exact Hbep'. exact Hbsp'.
+    - repeat case_match. invert_tuples.
+      simpl in *.
+      rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      { destruct Hcall as [Hp' Hnp']. subst p' np'.
+        split; intros Hcontra; inversion Hcontra; inversion H.
+      }
+      destruct Hcall as [Hp' Hnp'].
+      rewrite lookup_union_Some in Hnp'.
+      2: { apply remove_disjoint_keep_e. }
+      destruct Hnp' as [Hnp'|Hnp'].
+      {
+        unfold remove_bound_evars in Hnp'.
+        rewrite map_filter_lookup_Some in Hnp'.
+        destruct Hnp' as [Hg0p' Hbep'].
+        pose proof (IH := IHp (<[BoundVarSugar.b0:=npatt_evar (evs_fresh evs p)]>
+        (cache_incr_evar C)) (evs ∪ {[evs_fresh evs p]}) s).
+        rewrite Heqp3 in IH. simpl in IH.
+        feed specialize IH.
+        {
+          unfold dangling_vars_cached. unfold dangling_vars_cached in HCached.
+          destruct HCached as [HCachede HCacheds].
+          split.
+          + unfold dangling_evars_cached.
+            intros b Hpb.
+            destruct b.
+            {
+              exists (npatt_evar (evs_fresh evs p)).
+              apply lookup_insert.
+            }
+            specialize (HCachede b).
+            simpl in HCachede. specialize (HCachede Hpb).
+            destruct HCachede as [nphi Hnphi].
+            exists nphi.
+            rewrite lookup_insert_ne.
+            { discriminate. }
+            unfold cache_incr_evar.
+            replace (patt_bound_evar (S b)) with (incr_one_evar (patt_bound_evar b)) by reflexivity.
+            rewrite lookup_kmap_Some.
+            exists (patt_bound_evar b).
+            split;[reflexivity|].
+            exact Hnphi.
+          + unfold dangling_svars_cached.
+            intros b Hpb.
+            specialize (HCacheds b).
+            simpl in HCacheds. specialize (HCacheds Hpb).
+            destruct HCacheds as [nphi Hnphi].
+            exists nphi.
+            rewrite lookup_insert_ne.
+            { discriminate. }
+            unfold cache_incr_evar.
+            replace (patt_bound_svar b) with (incr_one_evar (patt_bound_svar b)) by reflexivity.
+            rewrite lookup_kmap_Some.
+            exists (patt_bound_svar b).
+            split;[reflexivity|].
+            exact Hnphi.
+        }
+        specialize (IH p').
+        unfold is_bound_evar_entry in Hbep'. simpl in Hbep'.
+        feed specialize IH.
+        {
+          destruct (decide (p' = BoundVarSugar.b0)).
+          {
+            subst p'. exfalso. apply Hbep'. exists 0. reflexivity.
+          }
+          rewrite lookup_insert_ne.
+          { apply not_eq_sym. assumption. }
+          unfold cache_incr_evar.
+          replace p' with (incr_one_evar p').
+          2: {
+            destruct p'; simpl; try reflexivity.
+            exfalso. apply Hbep'. exists n1. reflexivity.
+          }
+          rewrite lookup_kmap_None.
+          intros p'' Hp''.
+          apply (inj incr_one_evar) in Hp''.
+          subst p''.
+          exact HCp'.
+        }
+        {
+          exists np'. exact Hg0p'.
+        }
+        destruct IH as [Hbe Hbs].
+        split. exact Hbe. exact Hbs.
+      }
+      {
+        unfold keep_bound_evars in Hnp'.
+        rewrite map_filter_lookup_Some in Hnp'.
+        destruct Hnp' as [Hcontra _]. rewrite HCp' in Hcontra. inversion Hcontra.
+      }
+    - repeat case_match. invert_tuples.
+      simpl in *.
+      rewrite lookup_insert_Some in Hcall.
+      destruct Hcall as [Hcall|Hcall].
+      { destruct Hcall as [Hp' Hnp']. subst p' np'.
+       split; intros Hcontra; inversion Hcontra; inversion H.
+      }
+      destruct Hcall as [Hp' Hnp'].
+      rewrite lookup_union_Some in Hnp'.
+      2: { apply remove_disjoint_keep_s. }
+      destruct Hnp' as [Hnp'|Hnp'].
+      {
+        unfold remove_bound_svars in Hnp'.
+        rewrite map_filter_lookup_Some in Hnp'.
+        destruct Hnp' as [Hg0p' Hbep'].
+        pose proof (IH := IHp (<[BoundVarSugar.B0:=npatt_svar (svs_fresh s p)]>
+        (cache_incr_svar C)) evs (s ∪ {[svs_fresh s p]})).
+        rewrite Heqp3 in IH. simpl in IH.
+        feed specialize IH.
+        {
+          unfold dangling_vars_cached. unfold dangling_vars_cached in HCached.
+          destruct HCached as [HCachede HCacheds].
+          split.
+          + unfold dangling_evars_cached.
+            intros b Hpb.
+            specialize (HCachede b).
+            simpl in HCachede. specialize (HCachede Hpb).
+            destruct HCachede as [nphi Hnphi].
+            exists nphi.
+            rewrite lookup_insert_ne.
+            { discriminate. }
+            unfold cache_incr_svar.
+            replace (patt_bound_evar b) with (incr_one_svar (patt_bound_evar b)) by reflexivity.
+            rewrite lookup_kmap_Some.
+            exists (patt_bound_evar b).
+            split;[reflexivity|].
+            exact Hnphi.
+          + unfold dangling_svars_cached.
+            intros b Hpb.
+            destruct b.
+            {
+              exists (npatt_svar (svs_fresh s p)).
+              apply lookup_insert.
+            }
+            specialize (HCacheds b).
+            simpl in HCacheds. specialize (HCacheds Hpb).
+            destruct HCacheds as [nphi Hnphi].
+            exists nphi.
+            rewrite lookup_insert_ne.
+            { discriminate. }
+            unfold cache_incr_svar.
+            replace (patt_bound_svar (S b)) with (incr_one_svar (patt_bound_svar b)) by reflexivity.
+            rewrite lookup_kmap_Some.
+            exists (patt_bound_svar b).
+            split;[reflexivity|].
+            exact Hnphi.
+        }
+        specialize (IH p').
+        unfold is_bound_svar_entry in Hbep'. simpl in Hbep'.
+        feed specialize IH.
+        {
+          destruct (decide (p' = BoundVarSugar.B0)).
+          {
+            subst p'. exfalso. apply Hbep'. exists 0. reflexivity.
+          }
+          rewrite lookup_insert_ne.
+          { apply not_eq_sym. assumption. }
+          unfold cache_incr_svar.
+          replace p' with (incr_one_svar p').
+          2: {
+            destruct p'; simpl; try reflexivity.
+            exfalso. apply Hbep'. exists n1. reflexivity.
+          }
+          rewrite lookup_kmap_None.
+          intros p'' Hp''.
+          apply (inj incr_one_svar) in Hp''.
+          subst p''.
+          exact HCp'.
+        }
+        {
+          exists np'. exact Hg0p'.
+        }
+        destruct IH as [Hbe Hbs].
+        split. exact Hbe. exact Hbs.
+      }
+      {
+        unfold keep_bound_evars in Hnp'.
+        rewrite map_filter_lookup_Some in Hnp'.
+        destruct Hnp' as [Hcontra _]. rewrite HCp' in Hcontra. inversion Hcontra.
+      }
+  Qed.
+
   Definition cache_continuous_prop (C : Cache) : Prop :=
     (∃ (k : nat), ∀ (k' : nat),
         (k' < k)
@@ -1645,7 +2202,7 @@ Qed.
     lia.
   Qed.
 
-
+(*
   Lemma app_exist_p_q_neq_p p q:
     ~ patt_app (patt_exists p) q = p.
   Proof. Admitted.
@@ -1657,7 +2214,7 @@ Qed.
   Lemma is_not_subformula_2 p q:
     ~is_subformula_of_ind (patt_app q (patt_exists p)) p.
   Proof. Admitted.
-
+*)
   Lemma bound_evar_is_bound_var p:
     is_bound_evar p ->
     is_bound_var p.
@@ -2554,6 +3111,8 @@ Qed.
         rewrite lookup_empty in Hcached; inversion Hcached).
         - rewrite lookup_insert_ne in Hcached.
           { discriminate. }
+          apply dangling_vars_cached_proj_insert in Hdangling.
+          2: { simpl. auto. }
           (* Contradiction. [g] cannot contain the implication. *)
           (*assert(empty !! patt_imp p q = None).*)
           pose proof (Honly1 := onlyAddsSubpatterns empty p0_1 empty empty).

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -4590,7 +4590,54 @@ Qed.
           }
         }
         {
-          pose proof (Hhistory' := Hhistory).
+          (*pose proof (Hhistory' := Hhistory).*)
+          destruct ih as [[iC ievs] isvs].
+          pose proof (Hhist_prop := Hhistory).
+          eapply hist_prop_strip_2 in Hhist_prop.
+          assert (Hhistory' : History_generator iC ievs isvs).
+          {
+            exists (inr (iC, ievs, isvs) :: history).
+            apply Hhist_prop.
+          }
+
+          simpl in Hhistory.
+          destruct Hhistory as [HC [Hevs [Hsvs [Hrest1 Hrest2]]]]. subst.
+          specialize (Hrest2 0). simpl in Hrest2. destruct Hrest2 as [HCES2 Hrest2].
+          destruct a.
+          {
+            destruct Hrest2 as [p_i Hp_i]. cbn in Hp_i.
+            destruct Hp_i as [HiCp_i [Hconti [Hsubpi [Hdnglp_i Hn]]]].
+            subst. simpl in Hcached. unfold cache_of_nhe in Hcached. simpl in Hcached.
+          
+            specialize (IHhistory p np  ievs isvs iC Hhistory' HCES2 Hnboundp).
+
+            pose proof (Hfnc := find_nested_call p_i iC ievs isvs).
+            specialize (Hfnc ((to_NamedPattern2' p_i iC ievs isvs).1.1.2) p np).
+            specialize (Hfnc HCES2 Hnboundp Hhistory' Hdnglp_i Hconti Hsubpi).
+            exists iC, ievs, isvs, Hhistory'.
+            split.
+            {}
+          }
+
+          specialize (IHhistory p np  ievs isvs iC Hhistory').
+          feed specialize IHhistory.
+          {
+            unfold CES_prop. intros hIC. subst. simpl in Hhistory.
+            destruct_and!. subst. specialize (H4 0). simpl in H4.
+            destruct_and!. apply H. reflexivity.
+          }
+          { exact Hnboundp. }
+          {
+            simpl in Hhistory. destruct_and!. subst.
+            specialize (H4 0). simpl in H4. destruct_and!. simpl in H.
+            destruct a.
+            { cbn in H0.
+              destruct H0.
+              destruct_and?. subst. cbn in Hcached.
+            }
+          }
+          
+          apply IHhistory with (p := p) (np := np) in Hhistory'.
           simpl in Hhistory.
           destruct_and!. subst. specialize (H4 0). simpl in H4.
           destruct_and!.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -2208,19 +2208,6 @@ Qed.
     lia.
   Qed.
 
-(*
-  Lemma app_exist_p_q_neq_p p q:
-    ~ patt_app (patt_exists p) q = p.
-  Proof. Admitted.
-
-  Lemma is_not_subformula_1 p q:
-    ~is_subformula_of_ind (patt_app (patt_exists p) q) p.
-  Proof. Admitted.
-
-  Lemma is_not_subformula_2 p q:
-    ~is_subformula_of_ind (patt_app q (patt_exists p)) p.
-  Proof. Admitted.
-*)
   Lemma bound_evar_is_bound_var p:
     is_bound_evar p ->
     is_bound_var p.
@@ -2939,20 +2926,6 @@ Qed.
           mu2_finish_cached Hnsame Hnsubpattern Hnbound.
         }
   Qed.
-
-  (*
-  Lemma sub_prop_subcache (C C' : Cache) :
-    sub_prop C' -> map_subseteq C C' -> sub_prop C.
-  Proof.
-    intros. induction C.
-    - unfold sub_prop. intros. destruct p; auto.
-      unfold sub_prop in H. specialize (H (patt_imp p1 p2) np).
-      destruct H as [np' [nq' [Hp1 Hp2]]]. eapply subcache_prop; eauto.
-      exists np', nq'. split.
-      (* need induction hypothesis *)
-      admit. admit.
-  Admitted.
-   *)
 
    #[global]
    Instance NamedPattern_eqdec : EqDecision NamedPattern.
@@ -4516,9 +4489,7 @@ Qed.
             destruct IH as [C' [evs' [svs' [IH1 [IH2 IH3]]]]].
             subst.
             (* C came from hiC  *)
-            (*assert ( hiC ⊆ C ).
-            { admit. (* eapply hist_prop_subseteq. exact Hhistory.*) }
-            *)
+
             eapply IHhistory with (C := hiC).
             { shelve. }
             { shelve. }

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3721,6 +3721,22 @@ Qed.
     }
   Qed.
 
+  Lemma hist_prop_subseteq C a hip hinp hiC hievs hisvs history:
+    hist_prop C (a :: (hip, (hinp, hiC, hievs, hisvs)) :: history) ->
+    hiC ⊆ C.
+  Proof.
+    intros Hhist.
+    unfold hist_prop in Hhist.
+    destruct Hhist as [Hhist1 [Hhist2 Hhist3]].
+    subst C.
+    destruct a as [ap [[[anp aC] aevs] asvs]].
+    specialize (Hhist3 0). simpl in Hhist3.
+    destruct Hhist3 as [p_i [H1 [H2 [H3 [H4 H5]]]]].
+    inversion H5; subst; clear H5.
+    rewrite H6.
+    apply to_NamedPattern2'_extends_cache.
+  Qed.
+
   Lemma cached_p_impl_called_with_p
     (C : Cache)
     (hg : History_generator C)
@@ -3763,13 +3779,20 @@ Qed.
         destruct (hiC !! p) eqn:HeqhiCp.
         {
           pose proof (IH := IHhistory p n hiC Hnboundp HeqhiCp).
+          feed specialize IH.
+          { apply hist_prop_strip in Hhistory. exact Hhistory. }
+          destruct IH as [C' [evs' [svs' [IH1 IH2]]]].
+          (* C came from hiC  *)
+          assert ( hiC ⊆ C ).
+          { eapply hist_prop_subseteq. exact Hhistory. }
           eapply IHhistory with (C := hiC).
           { exact Hnboundp. }
-          { exact Hcached. }
-          {
-            simpl.
+          { pose proof (Htmp := HeqhiCp).
+            apply lookup_weaken with (m2 := C) in Htmp.
+            2: { exact H. }
+            rewrite Htmp in Hcached. inversion Hcached. subst. exact HeqhiCp.
           }
-          admit.
+          { apply hist_prop_strip in Hhistory. exact Hhistory. }
         }
         {
           destruct a as [ap [[[anp aC] aievs] aisvs]].

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3600,12 +3600,6 @@ Qed.
       (to_NamedPattern2' q Cfound evsfound svsfound).1.1.1 = nq.
   Proof.
     intros HCES Hnbq Hhist Hdvc Hccp Hsp Hqin Hqout Hcall.
-    (*
-    pose proof (Hsub := onlyAddsSubpatterns2 Cin p evsin svsin q Hqin).
-    feed specialize Hsub.
-    {
-      exists nq. rewrite Hcall. exact Hqout.
-    }*)
     remember (size' p) as sz.
     assert (Hsz: size' p <= sz) by lia.
     clear Heqsz.
@@ -4038,6 +4032,10 @@ Qed.
             ).
             feed specialize IH.
             {
+              apply History_generator_shift_e.
+              exact Hhist.
+            }
+            {
               apply dangling_vars_cached_shift_e with (e := (evs_fresh evsin p)) in Hdvc.
               apply Hdvc.
             }
@@ -4054,7 +4052,7 @@ Qed.
               }
             }
             { exact Hg0q. }
-            { erewrite Heqp3. reflexivity. }
+            { rewrite Heqp3. reflexivity. }
             apply IH.
           }
         }
@@ -4069,7 +4067,7 @@ Qed.
           {
             destruct Heq as [Heq1 Heq2].
             subst.
-            exists Cin, evsin, s.
+            exists Cin, evsin, s, Hhist.
             simpl. rewrite Hqin.
             repeat case_match. invert_tuples. simpl in *.
             split; reflexivity.
@@ -4091,8 +4089,16 @@ Qed.
             rewrite map_filter_lookup_Some in Hnq.
             destruct Hnq as [Hg0q _].
 
-            epose proof (IH := IHsz p ltac:(lia) q nq _ _ _ _ Hnbq).
+            epose proof (IH := IHsz p ltac:(lia) q nq evsin (s ∪ {[svs_fresh s p]})
+              (<[BoundVarSugar.B0:=npatt_svar (svs_fresh s p)]> (cache_incr_svar Cin))
+              (CES_prop_insert _ _ _ _ _)
+              _ Hnbq
+            ).
             feed specialize IH.
+            {
+              apply History_generator_shift_s.
+              exact Hhist.
+            }
             {
               apply dangling_vars_cached_shift_s with (s := (svs_fresh s p)) in Hdvc.
               apply Hdvc.
@@ -4110,8 +4116,26 @@ Qed.
               }
             }
             { exact Hg0q. }
-            { erewrite Heqp3. reflexivity. }
+            { rewrite Heqp3. reflexivity. }
             apply IH.
+          }
+          Unshelve. all: auto.
+          {
+            epose proof (Htmp := CES_prop_step _ _ _ _).
+            repeat case_match. subst. erewrite Heqp1 in Heqp.
+            specialize (Htmp ltac:(assumption)).
+            epose proof (Htmp2 := CES_prop_step _ _ _ _).
+            repeat case_match. subst. erewrite Heqp2 in Heqp0. invert_tuples.
+            exact Htmp.
+          }
+          {
+            Search CES_prop.
+            epose proof (Htmp := CES_prop_step _ _ _ _).
+            repeat case_match. subst. erewrite Heqp1 in Heqp.
+            specialize (Htmp ltac:(assumption)).
+            epose proof (Htmp2 := CES_prop_step _ _ _ _).
+            repeat case_match. subst. erewrite Heqp2 in Heqp0. invert_tuples.
+            exact Htmp.
           }
         }
   Qed.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -4298,6 +4298,27 @@ Qed.
     }
   Qed.
 
+  Lemma hist_prop_strip_2 C evs svs a hiC hievs hisvs history:
+    hist_prop C evs svs (a :: ((inr (hiC, hievs, hisvs)) :: history)) ->
+    hist_prop hiC hievs hisvs ((inr (hiC, hievs, hisvs)) :: history).
+  Proof.
+    intros HC.
+    unfold hist_prop in *.
+    destruct HC as [HC1 [Hevs [Hsvs [HC2 HC3]]]].
+    subst C evs svs.
+    split.
+    { simpl. reflexivity. }
+    split.
+    { simpl. reflexivity. }
+    split.
+    { simpl. reflexivity. }
+    split.
+    { simpl in HC2. apply HC2. }
+    intros i.
+    specialize (HC3 (S i)). simpl in HC3. apply HC3.
+  Qed.
+
+  (* TODO *)
   Lemma hist_prop_subseteq C evs svs a b history:
     hist_prop C evs svs (a :: (inl b) :: history) ->
     cache_of_nhe b ⊆ C.
@@ -4567,6 +4588,13 @@ Qed.
               }
             }
           }
+        }
+        {
+          pose proof (Hhistory' := Hhistory).
+          simpl in Hhistory.
+          destruct_and!. subst. specialize (H4 0). simpl in H4.
+          destruct_and!.
+          Print hist_prop.
         }
       }
     }

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -4536,6 +4536,54 @@ Qed.
                 { exists np. rewrite -H1. simpl. exact Hcached. }
                 exact Hoas.
               }
+              destruct hist'.
+              {
+                simpl in *. destruct i as [[i1 i2] i3].
+                cbn in *.
+                exfalso.
+                destruct H3 as [np' [Hnp'|Hnp']]; subst.
+                {
+                  apply Hnboundp. unfold singletonM,map_singleton in Hcached.
+                  rewrite lookup_insert_Some in Hcached.
+                  destruct Hcached as [HCached|HCached].
+                  {
+                    destruct HCached. subst.
+                    simpl. exact I.
+                  }
+                  {
+                    destruct HCached as [_ HContra].
+                    rewrite lookup_empty in HContra. inversion HContra.
+                  }
+                }
+                {
+                  apply Hnboundp. unfold singletonM,map_singleton in Hcached.
+                  rewrite lookup_insert_Some in Hcached.
+                  destruct Hcached as [HCached|HCached].
+                  {
+                    destruct HCached. subst.
+                    simpl. exact I.
+                  }
+                  {
+                    destruct HCached as [_ HContra].
+                    rewrite lookup_empty in HContra. inversion HContra.
+                  }
+                }
+              }
+              {
+                cbn in *. specialize (H5 0). simpl in H5.
+                rewrite last_cons in H3.
+                destruct (last hist') eqn:?.
+                {
+                  destruct h0.
+                  {
+                    destruct_and!.
+                  }
+                }
+                {
+
+                }
+                
+              }
               
               clear Hhistory2.
               clear H3. clear Hfnc.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -2986,7 +2986,7 @@ Qed.
    Qed.
    
   Definition normal_hist_entry := (@Pattern signature * ((@NamedPattern signature) * Cache * (@EVarSet signature) * (@SVarSet signature)))%type.
-  Definition inner_hist_entry := (@Pattern signature * Cache * (@EVarSet signature) * (@SVarSet signature))%type.
+  Definition inner_hist_entry := (Cache * (@EVarSet signature) * (@SVarSet signature))%type.
   Definition hist_entry := (normal_hist_entry + inner_hist_entry)%type.
   
   Definition pattern_of_nhe (h : normal_hist_entry) : (@Pattern signature) := h.1.
@@ -2996,8 +2996,7 @@ Qed.
   Definition evs_of_nhe (h : normal_hist_entry) : (@EVarSet signature) := h.2.1.2.
   Definition svs_of_nhe (h : normal_hist_entry) : (@SVarSet signature) := h.2.2.
 
-  Definition pattern_of_ihe (e : inner_hist_entry) : (@Pattern signature) := e.1.1.1.
-  Definition cache_of_ihe (e : inner_hist_entry) : Cache := e.1.1.2.
+  Definition cache_of_ihe (e : inner_hist_entry) : Cache := e.1.1.
   Definition evs_of_ihe (e : inner_hist_entry) : (@EVarSet signature) := e.1.2.
   Definition svs_of_ihe (e : inner_hist_entry) : (@SVarSet signature) := e.2.
 
@@ -3018,13 +3017,7 @@ Qed.
     | inl e' => svs_of_nhe e'
     | inr e' => svs_of_ihe e'
     end.
-
-  Definition pattern_of (e : hist_entry) : (@Pattern signature) :=
-    match e with
-    | inl e' => pattern_of_nhe e'
-    | inr e' => pattern_of_ihe e'
-    end.
-
+  
   Definition hist_prop (C : Cache) (evs : EVarSet) (svs : SVarSet) (history : list hist_entry) : Prop :=
     match history with
     | [] => C = ∅
@@ -3038,15 +3031,10 @@ Qed.
               dangling_vars_cached ∅ (pattern_of_nhe nhe) /\
               result_of_nhe nhe = to_NamedPattern2' (pattern_of_nhe nhe) ∅ ∅ ∅
             | inr ihe =>
-              (exists (p : Pattern) (np : NamedPattern),
-                cache_of_ihe ihe = {[ patt_bound_evar 0 := np ]}
-                /\ pattern_of_ihe ihe = (patt_exists p)
-              )
+              exists (np : NamedPattern),
+                (cache_of_ihe ihe = {[ patt_bound_evar 0 := np ]})
                 \/
-              (exists (p : Pattern) (np : NamedPattern),
-                cache_of_ihe ihe = {[ patt_bound_svar 0 := np ]}
-                /\ pattern_of_ihe ihe = (patt_mu p)
-              )
+                (cache_of_ihe ihe = {[ patt_bound_svar 0 := np ]})
             end
            end) /\
           forall (i:nat), 
@@ -3072,12 +3060,8 @@ Qed.
                     )
                   )
                 | inr ihei =>
-                  (remove_bound_evars (cache_of_ihe ihei) = remove_bound_evars (cache_of heSi)
-                   /\ pattern_of_ihe ihei = (patt_exists (pattern_of heSi))
-                  )
-                  \/ (remove_bound_svars (cache_of_ihe ihei) = remove_bound_svars (cache_of heSi)
-                    /\ pattern_of_ihe ihei = (patt_mu (pattern_of heSi))
-                  )
+                  (remove_bound_evars (cache_of_ihe ihei) = remove_bound_evars (cache_of heSi))
+                  \/ (remove_bound_svars (cache_of_ihe ihei) = remove_bound_svars (cache_of heSi))
                 end 
               end
             end
@@ -3383,7 +3367,7 @@ Qed.
 
  
 
-  Lemma History_generator_shift_e Cin evsin svsin e (p : Pattern):
+  Lemma History_generator_shift_e Cin evsin svsin e:
   CES_prop Cin evsin svsin ->
   History_generator Cin evsin svsin ->
   History_generator (<[BoundVarSugar.b0:=npatt_evar e]> (cache_incr_evar Cin))
@@ -3391,7 +3375,7 @@ Qed.
   Proof.
     intros HCES Hhist.
     destruct Hhist as [history Hhistory].
-    exists ((inr (patt_exists p, (<[BoundVarSugar.b0:=npatt_evar e]> (cache_incr_evar Cin)), (evsin ∪ {[e]}), svsin))::history).
+    exists ((inr ((<[BoundVarSugar.b0:=npatt_evar e]> (cache_incr_evar Cin)), (evsin ∪ {[e]}), svsin))::history).
     simpl.
     split.
     { reflexivity. }
@@ -3417,17 +3401,9 @@ Qed.
           split. exact Hdngl. exact Hresult.
         }
         {
-          destruct Hhistory as [Hcache [Hevs [Hsvs Hhistory]]]. subst Cin evsin svsin.
-          destruct Hhistory as [Hentry Hhistory].
-          destruct Hentry as [Hentry|Hentry].
-          {
-            left. destruct Hentry as [p' [np' Hp']].
-            exists p', np'. exact Hp'.
-          }
-          {
-            right. destruct Hentry as [p' [np' Hp']].
-            exists p', np'. exact Hp'.
-          }
+          destruct Hhistory as [Hcache [Hevs [Hsvs Hhistory]]]. subst evsin svsin.
+          destruct Hhistory as [[np Hnp] Hhistory].
+          exists np. exact Hnp.
         }
       }
       {
@@ -3435,8 +3411,7 @@ Qed.
         destruct history.
         2: { rewrite last_cons in Heqlsthist. destruct (last history); simpl in Heqlsthist; inversion Heqlsthist. }
         clear Heqlsthist.
-        left. cbn.
-        exists p,(npatt_evar e). subst Cin. simpl. split; reflexivity.
+        exists (npatt_evar e). left. subst Cin. reflexivity.
       }
     }
     {
@@ -3463,47 +3438,33 @@ Qed.
           {
             intros np. simpl. unfold cache_incr_evar.
             rewrite lookup_kmap_Some.
-            intros [p' [Hp'1 Hp'2]].
-            destruct p'; simpl in Hp'1; inversion Hp'1.
+            intros [p [Hp1 Hp2]].
+            destruct p; simpl in Hp1; inversion Hp1.
           }
           unfold cache_incr_evar.
           rewrite map_filter_strong_ext.
-          split.
+          intros p np. simpl.
+          split; intros H.
           {
-            intros p' np'. simpl.
-            split; intros H.
-            {
-              destruct H as [H1 H2].
-              split;[exact H1|].
-              replace p' with (incr_one_evar p') in H2.
-              2: {
-                destruct p'; simpl; try reflexivity.
-                exfalso. apply H1. exists n. reflexivity.
-              }
-              rewrite lookup_kmap in H2.
-              exact H2.
+            destruct H as [H1 H2].
+            split;[exact H1|].
+            replace p with (incr_one_evar p) in H2.
+            2: {
+              destruct p; simpl; try reflexivity.
+              exfalso. apply H1. exists n. reflexivity.
             }
-            {
-              destruct H as [H1 H2].
-              split;[exact H1|].
-              replace p' with (incr_one_evar p').
-              2: {
-                destruct p'; simpl; try reflexivity.
-                exfalso. apply H1. exists n. reflexivity.
-              }
-              rewrite lookup_kmap. exact H2.
-            }
+            rewrite lookup_kmap in H2.
+            exact H2.
           }
           {
-            cbn.
-            destruct history as [|h1 history].
-            {
-              simpl in Hlast.
-              destruct h.
-              {
-                
-              }
+            destruct H as [H1 H2].
+            split;[exact H1|].
+            replace p with (incr_one_evar p).
+            2: {
+              destruct p; simpl; try reflexivity.
+              exfalso. apply H1. exists n. reflexivity.
             }
+            rewrite lookup_kmap. exact H2.
           }
         }
         {

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -4504,96 +4504,67 @@ Qed.
           }
         }
         {
-          destruct a as [anormal|ain].
-          {
-          destruct anormal as [ap [[[anp aC] aievs] aisvs]].
+          pose proof (Hhistory' := Hhistory).
+          apply hist_prop_strip_1 in Hhistory'.
           simpl in Hhistory.
           destruct Hhistory as [Hhistory1 [Hevs [Hsvs [Hhistory2 Hhistory3]]]].
-          subst.
           specialize (Hhistory3 0). simpl in Hhistory3.
           destruct Hhistory3 as [HCES' Hhistory3].
-          destruct Hhistory3 as [p_i [HhiCp_i [Hcont_i [Hsubp_i [Hdngl Hp_i]]]]].
-          inversion Hp_i. subst ap. clear Hp_i.
-          unfold cache_of_nhe,evs_of_nhe,svs_of_nhe,fst,snd in *.
-          pose proof (Hfnc := find_nested_call p_i hiC hievs hisvs aC p np HCES' Hnboundp).
-          feed specialize Hfnc.
+          destruct a as [anormal|ain].
           {
-            destruct hg' as [hist' Hhist'].
-            destruct hist'.
+            destruct Hhistory3 as [p_i [HhiCp_i [Hcont_i [Hsubp_i [Hdngl Hp_i]]]]].
+            destruct anormal as [ap [[[anp aC] aievs] aisvs]]. subst.
+            inversion Hp_i. subst ap. clear Hp_i.
+            cbn in HCES', HhiCp_i, Hcont_i, Hsubp_i, Hdngl, H1.
+            (*unfold cache_of_nhe,evs_of_nhe,svs_of_nhe,fst,snd in *.*)
+            pose proof (Hfnc := find_nested_call p_i hiC hievs hisvs aC p np HCES' Hnboundp).
+            feed specialize Hfnc.
             {
-              simpl in *. subst. symmetry in H1.
-              pose proof (H := to_NamedPattern2'_ensures_present p_i hiC hievs hisvs).
-              rewrite H1 in H. simpl in H. rewrite lookup_empty in H. inversion H.
+              exists ((inl (hip, (hinp, hiC, hievs, hisvs)))::history).
+              apply Hhistory'.
             }
-            destruct h.
-            2: {
-              simpl in *. destruct_and?. subst.
-              clear IHhistory Hfnc.
-              assert (is_subformula_of_ind p p_i).
-              {
-                epose proof (Hoas := onlyAddsSubpatterns2 hiC p_i hievs hisvs p HeqhiCp).
-                feed specialize Hoas.
-                { exists np. rewrite -H1. simpl. exact Hcached. }
-                exact Hoas.
-              }
-              destruct hist'.
-              {
-                simpl in *. destruct i as [[i1 i2] i3].
-                cbn in *.
-                exfalso.
-                destruct H3 as [np' [Hnp'|Hnp']]; subst.
-                {
-                  apply Hnboundp. unfold singletonM,map_singleton in Hcached.
-                  rewrite lookup_insert_Some in Hcached.
-                  destruct Hcached as [HCached|HCached].
-                  {
-                    destruct HCached. subst.
-                    simpl. exact I.
-                  }
-                  {
-                    destruct HCached as [_ HContra].
-                    rewrite lookup_empty in HContra. inversion HContra.
-                  }
-                }
-                {
-                  apply Hnboundp. unfold singletonM,map_singleton in Hcached.
-                  rewrite lookup_insert_Some in Hcached.
-                  destruct Hcached as [HCached|HCached].
-                  {
-                    destruct HCached. subst.
-                    simpl. exact I.
-                  }
-                  {
-                    destruct HCached as [_ HContra].
-                    rewrite lookup_empty in HContra. inversion HContra.
-                  }
-                }
-              }
-              {
-                cbn in *. specialize (H5 0). simpl in H5.
-                rewrite last_cons in H3.
-                destruct (last hist') eqn:?.
-                {
-                  destruct h0.
-                  {
-                    destruct_and!.
-                  }
-                }
-                {
-
-                }
-                
-              }
-              
-              clear Hhistory2.
-              clear H3. clear Hfnc.
-            }
-            apply hist_prop_strip_1 in Hhist'.
+            { exact Hdngl. }
+            { exact Hcont_i. }
+            { exact Hsubp_i. }
+            { exact HeqhiCp. }
+            { exact Hcached. }
+            { rewrite -H1. reflexivity. }
+            apply Hfnc.
           }
-          Hdngl).
-             Hcont_i Hsubp_i HeqhiCp Hcached).
-          rewrite -H1 in Hfnc. simpl in Hfnc. specialize (Hfnc erefl).
-          apply Hfnc.
+          {
+            destruct ain as [[ainC ainE] ainS].
+            clear Hhistory2.
+            cbn in Hhistory3. cbn in HCES', Hhistory1, Hsvs, Hevs. subst ainC ainE ainS.
+            clear -Hhistory3 HeqhiCp Hcached Hnboundp. exfalso.
+            destruct Hhistory3 as [Hhistory3|Hhistory3].
+            {
+              assert (Hcached': (remove_bound_evars C) !! p = Some np).
+              {
+                unfold remove_bound_evars. rewrite map_filter_lookup_Some.
+                split;[exact Hcached|]. unfold is_bound_evar_entry. simpl.
+                intros Hcontra. apply Hnboundp. apply bound_evar_is_bound_var.
+                exact Hcontra.
+              }
+              rewrite Hhistory3 in Hcached'.
+              unfold remove_bound_evars in Hcached'.
+              rewrite map_filter_lookup_Some in Hcached'.
+              destruct Hcached' as [Hcontra _].
+              rewrite HeqhiCp in Hcontra. inversion Hcontra.
+            }
+            {
+              assert (Hcached': (remove_bound_svars C) !! p = Some np).
+              {
+                unfold remove_bound_svars. rewrite map_filter_lookup_Some.
+                split;[exact Hcached|]. unfold is_bound_svar_entry. simpl.
+                intros Hcontra. apply Hnboundp. apply bound_svar_is_bound_var.
+                exact Hcontra.
+              }
+              rewrite Hhistory3 in Hcached'.
+              unfold remove_bound_svars in Hcached'.
+              rewrite map_filter_lookup_Some in Hcached'.
+              destruct Hcached' as [Hcontra _].
+              rewrite HeqhiCp in Hcontra. inversion Hcontra.
+            }
           }
         }
         }

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3071,14 +3071,97 @@ Qed.
       subst. exists np. exact HCp.
     }
     {
+      pose proof (Hsubp' := Hsubp (patt_app ϕ₂ ϕ₃) np HCp). simpl in Hsubp'.
+      destruct Hsubp' as [Hboc2 Hboc3].
+      destruct Hboc2 as [Hbound2|Hcached2].
+      {
+        destruct ϕ₂; simpl in Hbound2; inversion Hbound2.
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+      }
+      destruct Hcached2 as [nϕ2 Hnϕ2].
+
       eapply IHHsubf.
       { exact Hnbound. }
       { exact Hsubp. }
-      { unfold sub_prop in Hsubp.
-        specialize (Hsubp (patt_app ϕ₂ ϕ₃)).
-      }
+      { exact Hnϕ2. }
     }
+    {
+      pose proof (Hsubp' := Hsubp (patt_app ϕ₂ ϕ₃) np HCp). simpl in Hsubp'.
+      destruct Hsubp' as [Hboc2 Hboc3].
+      destruct Hboc3 as [Hbound3|Hcached3].
+      {
+        destruct ϕ₃; simpl in Hbound3; inversion Hbound3.
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+      }
+      destruct Hcached3 as [nϕ3 Hnϕ3].
 
+      eapply IHHsubf.
+      { exact Hnbound. }
+      { exact Hsubp. }
+      { exact Hnϕ3. }
+    }
+    {
+      pose proof (Hsubp' := Hsubp (patt_imp ϕ₂ ϕ₃) np HCp). simpl in Hsubp'.
+      destruct Hsubp' as [Hboc2 Hboc3].
+      destruct Hboc2 as [Hbound2|Hcached2].
+      {
+        destruct ϕ₂; simpl in Hbound2; inversion Hbound2.
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+      }
+      destruct Hcached2 as [nϕ2 Hnϕ2].
+
+      eapply IHHsubf.
+      { exact Hnbound. }
+      { exact Hsubp. }
+      { exact Hnϕ2. }
+    }
+    {
+      pose proof (Hsubp' := Hsubp (patt_imp ϕ₂ ϕ₃) np HCp). simpl in Hsubp'.
+      destruct Hsubp' as [Hboc2 Hboc3].
+      destruct Hboc3 as [Hbound3|Hcached3].
+      {
+        destruct ϕ₃; simpl in Hbound3; inversion Hbound3.
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+      }
+      destruct Hcached3 as [nϕ3 Hnϕ3].
+
+      eapply IHHsubf.
+      { exact Hnbound. }
+      { exact Hsubp. }
+      { exact Hnϕ3. }
+    }
+    {
+      pose proof (Hsubp' := Hsubp (patt_exists ϕ₂) np HCp). simpl in Hsubp'.
+      destruct Hsubp' as [Hbound|Hcached].
+      {
+        destruct ϕ₂; simpl in Hbound; inversion Hbound.
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+      }
+      destruct Hcached as [nϕ Hnϕ].
+      eapply IHHsubf.
+      { exact Hnbound. }
+      { exact Hsubp. }
+      { exact Hnϕ. }
+    }
+    {
+      pose proof (Hsubp' := Hsubp (patt_mu ϕ₂) np HCp). simpl in Hsubp'.
+      destruct Hsubp' as [Hbound|Hcached].
+      {
+        destruct ϕ₂; simpl in Hbound; inversion Hbound.
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+        { inversion Hsubf. subst. clear Hsubf. exfalso. apply Hnbound. simpl. exact I. }
+      }
+      destruct Hcached as [nϕ Hnϕ].
+      eapply IHHsubf.
+      { exact Hnbound. }
+      { exact Hsubp. }
+      { exact Hnϕ. }
+    }
   Qed.
 
   Lemma actually_adds_subpatterns p C evs svs q:

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3267,10 +3267,16 @@ Qed.
     Cout !! q = Some nq ->
     (to_NamedPattern2' p Cin evsin svsin).1.1.2 = Cout ->
     exists Cfound evsfound svsfound,
-      Cfound ⊆ Cout /\ Cfound !! q = None /\
+      Cfound !! q = None /\
       (to_NamedPattern2' q Cfound evsfound svsfound).1.1.1 = nq.
   Proof.
     intros Hnbq Hdvc Hccp Hsp Hqin Hqout Hcall.
+    (*
+    pose proof (Hsub := onlyAddsSubpatterns2 Cin p evsin svsin q Hqin).
+    feed specialize Hsub.
+    {
+      exists nq. rewrite Hcall. exact Hqout.
+    }*)
     remember (size' p) as sz.
     assert (Hsz: size' p <= sz) by lia.
     clear Heqsz.
@@ -3292,10 +3298,7 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl.
-        split. 2: split;reflexivity.
-        apply insert_subseteq.
-        { exact Hqin. }
+        rewrite Hqin. simpl. split; reflexivity.
       }
       {
         destruct H as [H1 H2].
@@ -3315,10 +3318,7 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl.
-        split. 2: split;reflexivity.
-        apply insert_subseteq.
-        { exact Hqin. }
+        rewrite Hqin. simpl. split; reflexivity.
       }
       {
         destruct H as [H1 H2].
@@ -3338,10 +3338,7 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl.
-        split. 2: split;reflexivity.
-        apply insert_subseteq.
-        { exact Hqin. }
+        rewrite Hqin. simpl. split; reflexivity.
       }
       {
         destruct H as [H1 H2].
@@ -3361,10 +3358,7 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl.
-        split. 2: split;reflexivity.
-        apply insert_subseteq.
-        { exact Hqin. }
+        rewrite Hqin. simpl. split; reflexivity.
       }
       {
         destruct H as [H1 H2].
@@ -3384,10 +3378,7 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl.
-        split. 2: split;reflexivity.
-        apply insert_subseteq.
-        { exact Hqin. }
+        rewrite Hqin. simpl. split; reflexivity.
       }
       {
         destruct H as [H1 H2].
@@ -3408,16 +3399,7 @@ Qed.
         exists Cin, evsin, svsin.
         simpl. rewrite Hqin.
         repeat case_match. invert_tuples. simpl in *.
-        rewrite Heqp2 in Heqp5. inversion Heqp5. subst.
-        split. 2: split;reflexivity.
-        apply insert_subseteq_r.
-        { exact Hqin. }
-        { epose proof (Htmp2 := to_NamedPattern2'_extends_cache _ _ _ _).
-          erewrite Heqp2 in Htmp2. simpl in Htmp2.
-          epose proof (Htmp1 := to_NamedPattern2'_extends_cache _ _ _ _).
-          erewrite Heqp0 in Htmp1. simpl in Htmp1.
-          eapply transitivity; eassumption.
-        }
+        rewrite Heqp2 in Heqp5. inversion Heqp5. subst. split; reflexivity.
       }
       {
         destruct Hneq as [Hneq1 Hnq].
@@ -3448,27 +3430,6 @@ Qed.
             eapply lookup_weaken in Hg0q';[|exact Hext].
             rewrite Hnq in Hg0q'. inversion Hg0q'; subst; clear Hg0q'.
             
-            pose proof (IH := IHsz p1 ltac:(lia) q n evsin svsin Cin g0 Hnbq Hdvcp1 Hccp Hsp Hqin Hg0q).
-            rewrite Heqp1 in IH. specialize (IH erefl).
-            destruct IH as [Cfound [evsfound [svsfound Hfound]]].
-            destruct Hfound as [Hfound1 [Hfound2 Hfound3]].
-            exists Cfound,evsfound,svsfound.
-            split.
-            { eapply transitivity. exact Hfound1.
-              epose proof (Htmp := to_NamedPattern2'_extends_cache _ _ _ _).
-              erewrite Heqp2 in Htmp. simpl in Htmp.
-              apply insert_subseteq_r.
-              { 
-                epose proof (Htmp2 := onlyAddsSubpatterns2 _ _ _ _ (patt_app p1 p2)).
-                erewrite Heqp1 in Htmp2. simpl in Htmp2. specialize (Htmp2 Heqo).
-                destruct (g0 !! (patt_app p1 p2));[|reflexivity].
-                exfalso. Search is_subformula_of.
-                feed specialize Htmp2.
-                { exists n2. reflexivity. }
-                (* HERE *)
-              }
-              { exact Htmp. }
-            }
             eapply IHsz with (p := p1).
             { lia. }
             { exact Hnbq. }
@@ -3476,7 +3437,7 @@ Qed.
             { exact Hccp. }
             { exact Hsp. }
             { exact Hqin. }
-            { rewrite lookup_insert_ne. exact Hneq1. exact Hnq. }
+            { exact Hg0q. }
             { erewrite Heqp1. reflexivity. }
           }
           {
@@ -3784,7 +3745,6 @@ Qed.
     ~ is_bound_var p ->
     C !! p = Some np ->
     exists (C' : Cache) (evs' : EVarSet) (svs' : SVarSet),
-      C' ⊆ C /\
       C' !! p = None /\ (to_NamedPattern2' p C' evs' svs').1.1.1 = np.
   Proof.
     intros Hnboundp Hcached.
@@ -3849,7 +3809,7 @@ Qed.
       }
     }
   Qed.
-(*
+
   Lemma cached_imp_is_nimp
     (C : Cache)
     (hg : History_generator C)
@@ -3928,90 +3888,19 @@ Qed.
       
     }
   Abort.
-*)
+
   Lemma consistency_pqp
         (p q : Pattern)
+        (np' nq' np'' : NamedPattern)
         (cache : Cache)
         (evs : EVarSet)
         (svs : SVarSet):
     History_generator cache ->
-    sub_prop cache ->
-    dangling_vars_cached cache (patt_imp p (patt_imp q p)) ->
-    exists np nq,
     (to_NamedPattern2' (patt_imp p (patt_imp q p)) cache evs svs).1.1.1
-    = npatt_imp np (npatt_imp nq np).
+    = npatt_imp np' (npatt_imp nq' np'') ->
+    np'' = np'.
   Proof.
-    intros Hhist Hsubp Hdngcached.
-    remember ((to_NamedPattern2' (patt_imp p (patt_imp q p)) cache evs svs)) as Call.
-    simpl in HeqCall.
-    destruct (cache !! patt_imp p (patt_imp q p)) eqn:Hcachepqp.
-    {
-      rewrite Hcachepqp in HeqCall. rewrite HeqCall. simpl. rename n into npqp.
 
-      apply cached_p_impl_called_with_p in Hcachepqp.
-      3: { simpl. auto. }
-      2: { exact Hhist. }
-      destruct Hcachepqp as [C' [evs' [svs' [HC'notcached HeqCall1]]]].
-      rewrite -HeqCall1. simpl. rewrite HC'notcached.
-      repeat case_match; invert_tuples; simpl in *.
-      {
-        apply cached_p_impl_called_with_p in Heqo.
-        3: { simpl. auto. }
-        2: {  }
-      }
-
-
-      pose proof (Hnp := Hsubp (patt_imp p (patt_imp q p)) npqp Hcachepqp).
-      simpl in Hnp.
-      destruct Hnp as [Hbocp Hbocqp].
-
-      assert (Hcachedp: exists np, cache !! p = Some np).
-      {
-        destruct Hbocp as [Hboundp|Hcachedp'].
-        {
-          (* p is in cache because it is bound *)
-          pose proof (Hcachedp := Hdngcached).
-          apply dangling_vars_cached_imp_proj1 in Hcachedp.
-          destruct Hcachedp as [Hcachede Hcacheds].
-          unfold dangling_evars_cached,dangling_svars_cached in *.
-          destruct p; simpl in Hboundp; try inversion Hboundp.
-          { apply Hcachede. simpl. case_match. reflexivity. contradiction. }
-          { apply Hcacheds. simpl. case_match. reflexivity. contradiction. }
-        }
-        {
-          exact Hcachedp'.
-        }
-      }
-      destruct Hcachedp as [np Hcachedp].
-      exists np.
-
-      destruct Hbocqp as [Hbqp|Hcqp].
-      { simpl in Hbqp. inversion Hbqp. }
-      destruct Hcqp as [nqp Hcachedqp].
-      pose proof (Hnqp := Hsubp (patt_imp q p) nqp Hcachedqp).
-      simpl in Hnqp.
-      destruct Hnqp as [Hbocq _].
-      assert (Hcachedq: exists nq, cache !! q = Some nq).
-      {
-        destruct Hbocq as [Hboundq|Hcachedq'].
-        {
-          (* p is in cache because it is bound *)
-          pose proof (Hcachedq := Hdngcached).
-          apply dangling_vars_cached_imp_proj2 in Hcachedq.
-          apply dangling_vars_cached_imp_proj1 in Hcachedq.
-          destruct Hcachedq as [Hcachede Hcacheds].
-          unfold dangling_evars_cached,dangling_svars_cached in *.
-          destruct q; simpl in Hboundq; try inversion Hboundq.
-          { apply Hcachede. simpl. case_match. reflexivity. contradiction. }
-          { apply Hcacheds. simpl. case_match. reflexivity. contradiction. }
-        }
-        {
-          exact Hcachedq'.
-        }
-      }
-      destruct Hcachedq as [nq Hcachedq].
-      exists nq.
-    }
   (*
     (to_NamedPattern2' (p ---> (q ---> p)) cache used_evars used_svars).1.1.1
     (1) cache !! (p ---> (q ---> p)) = Some pqp'

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3173,63 +3173,10 @@ Qed.
     exists nq, (to_NamedPattern2' p C evs svs).1.1.2 !! q = Some nq.
   Proof.
     intros Hdgcached Hccont Hsubp Hsubf Hnbound.
-    Check sub_prop_step.
-    pose proof (Hsubp' := sub_prop_step C p evs svs Hdgcached Hccont Hsubp).
-
-
-
-  move: C evs svs q.
-  induction p; intros C evs svs q Hsub Hnbound; simpl.
-  - inversion Hsub; subst; clear Hsub.
-    case_match.
-    {
-      simpl. exists n. exact Heqo.
-    }
-    simpl. exists (npatt_evar x). apply lookup_insert.
-  - inversion Hsub; subst; clear Hsub.
-    case_match.
-    {
-      simpl. exists n. exact Heqo.
-    }
-    simpl. exists (npatt_svar x). apply lookup_insert.
-  - inversion Hsub; subst; clear Hsub.
-    exfalso. apply Hnbound. simpl. exact I.
-  - inversion Hsub; subst; clear Hsub.
-    exfalso. apply Hnbound. simpl. exact I.
-  - inversion Hsub; subst; clear Hsub.
-    case_match.
-    {
-      simpl. exists n. exact Heqo.
-    }
-    simpl. exists (npatt_sym sigma). apply lookup_insert.
-  - inversion Hsub; subst; clear Hsub.
-    {
-      repeat case_match; invert_tuples; simpl in *.
-      { exists n. exact Heqo. }
-      { exists (npatt_app n n0). apply lookup_insert. }
-    }
-    {
-      repeat case_match; invert_tuples; simpl in *. Print sub_prop.
-      (*
-
-      *)
-    }
-
-
-
-    intros Hsub.
-    move: C evs svs.
-    induction Hsub; intros C evs svs Hnbound.
-    - subst.
-      eexists.
-      apply to_NamedPattern2'_ensures_present.
-    - specialize (IHHsub C evs svs Hnbound).
-      destruct IHHsub as [nq Hnq].
-      exists nq. simpl. repeat case_match.
-      + simpl.
-    apply IHHsub.
+    epose proof (to_NamedPattern2'_ensures_present _ _ _ _).
+    eapply sub_prop_trans; eauto.
+    { apply sub_prop_step; assumption. }
   Qed.
-
 
   Lemma find_nested_call
     (p : Pattern)

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3380,9 +3380,101 @@ Qed.
        (evsin ∪ {[e]}) svsin.
   Proof.
     intros Hhist.
-    destruct Hhist as [history Hhistory]. Print hist_prop.
-    
-  Abort. (*Defined. *)
+    destruct Hhist as [history Hhistory].
+    exists ((inr ((<[BoundVarSugar.b0:=npatt_evar e]> (cache_incr_evar Cin)), (evsin ∪ {[e]}), svsin))::history).
+    simpl.
+    split.
+    { reflexivity. }
+    split.
+    { reflexivity. }
+    split.
+    { reflexivity. }
+    split.
+    {
+      rewrite last_cons.
+      destruct (last history) eqn:Heqlsthist.
+      {
+        unfold hist_prop in Hhistory.
+        destruct history.
+        {
+          simpl in Heqlsthist. inversion Heqlsthist.
+        }
+        rewrite Heqlsthist in Hhistory.
+        destruct h as [nhe | ihe].
+        {
+          destruct Hhistory as [Hcache [Hevs [Hsvs Hhistory]]]. subst evsin svsin.
+          destruct Hhistory as [[Hdngl Hresult] Hhistory].
+          split. exact Hdngl. exact Hresult.
+        }
+        {
+          destruct Hhistory as [Hcache [Hevs [Hsvs Hhistory]]]. subst evsin svsin.
+          destruct Hhistory as [[np Hnp] Hhistory].
+          exists np. exact Hnp.
+        }
+      }
+      {
+        unfold hist_prop in Hhistory.
+        destruct history.
+        2: { rewrite last_cons in Heqlsthist. destruct (last history); simpl in Heqlsthist; inversion Heqlsthist. }
+        clear Heqlsthist.
+        exists (npatt_evar e). left. subst Cin. reflexivity.
+      }
+    }
+    {
+      unfold hist_prop in Hhistory.
+      destruct history.
+      {
+        intros i. simpl. exact I.
+      }
+      {
+        destruct Hhistory as [Hcache [Hevs [Hsvs Hhistory]]]. subst Cin evsin svsin.
+        destruct Hhistory as [Hlast Hhistory].
+        intros i.
+        destruct i; simpl.
+        {
+          left. repeat unfold cache_of_ihe,fst.
+          unfold remove_bound_evars.
+          rewrite map_filter_insert.
+          unfold is_bound_evar_entry. simpl.
+          rewrite map_filter_delete_not.
+          {
+            intros np. simpl. unfold cache_incr_evar.
+            rewrite lookup_kmap_Some.
+            intros [p [Hp1 Hp2]].
+            destruct p; simpl in Hp1; inversion Hp1.
+          }
+          unfold cache_incr_evar.
+          rewrite map_filter_strong_ext.
+          intros p np. simpl.
+          split; intros H.
+          {
+            destruct H as [H1 H2].
+            split;[exact H1|].
+            replace p with (incr_one_evar p) in H2.
+            2: {
+              destruct p; simpl; try reflexivity.
+              exfalso. apply H1. exists n. reflexivity.
+            }
+            rewrite lookup_kmap in H2.
+            exact H2.
+          }
+          {
+            destruct H as [H1 H2].
+            split;[exact H1|].
+            replace p with (incr_one_evar p).
+            2: {
+              destruct p; simpl; try reflexivity.
+              exfalso. apply H1. exists n. reflexivity.
+            }
+            rewrite lookup_kmap. exact H2.
+          }
+        }
+        {
+          apply Hhistory.
+        }
+      }
+    }
+  Defined.
 
   Lemma find_nested_call
     (p : Pattern)

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3224,6 +3224,7 @@ Qed.
     Cout !! q = Some nq ->
     (to_NamedPattern2' p Cin evsin svsin).1.1.2 = Cout ->
     exists Cfound evsfound svsfound,
+      Cfound !! q = None /\
       (to_NamedPattern2' q Cfound evsfound svsfound).1.1.1 = nq.
   Proof.
     intros Hnbq Hdvc Hccp Hsp Hqin Hqout Hcall.
@@ -3254,7 +3255,7 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl. reflexivity.
+        rewrite Hqin. simpl. split; reflexivity.
       }
       {
         destruct H as [H1 H2].
@@ -3274,7 +3275,7 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl. reflexivity.
+        rewrite Hqin. simpl. split; reflexivity.
       }
       {
         destruct H as [H1 H2].
@@ -3294,7 +3295,7 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl. reflexivity.
+        rewrite Hqin. simpl. split; reflexivity.
       }
       {
         destruct H as [H1 H2].
@@ -3314,7 +3315,7 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl. reflexivity.
+        rewrite Hqin. simpl. split; reflexivity.
       }
       {
         destruct H as [H1 H2].
@@ -3334,7 +3335,7 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl. reflexivity.
+        rewrite Hqin. simpl. split; reflexivity.
       }
       {
         destruct H as [H1 H2].
@@ -3355,7 +3356,7 @@ Qed.
         exists Cin, evsin, svsin.
         simpl. rewrite Hqin.
         repeat case_match. invert_tuples. simpl in *.
-        rewrite Heqp2 in Heqp5. inversion Heqp5. subst. reflexivity.
+        rewrite Heqp2 in Heqp5. inversion Heqp5. subst. split; reflexivity.
       }
       {
         destruct Hneq as [Hneq1 Hnq].
@@ -3433,7 +3434,7 @@ Qed.
           destruct H as [H1 H2]. subst.
           exists Cin, evsin, svsin.
           simpl.
-          rewrite Hqin. simpl. reflexivity.
+          rewrite Hqin. simpl. split; reflexivity.
         }
         {
           destruct H as [H1 H2].
@@ -3454,7 +3455,7 @@ Qed.
           exists Cin, evsin, svsin.
           simpl. rewrite Hqin.
           repeat case_match. invert_tuples. simpl in *.
-          rewrite Heqp2 in Heqp5. inversion Heqp5. subst. reflexivity.
+          rewrite Heqp2 in Heqp5. inversion Heqp5. subst. split; reflexivity.
         }
         {
           destruct Hneq as [Hneq1 Hnq].
@@ -3533,7 +3534,7 @@ Qed.
             exists Cin, evsin, s.
             simpl. rewrite Hqin.
             repeat case_match. invert_tuples. simpl in *.
-            reflexivity.
+            split; reflexivity.
           }
           {
             destruct Hneq as [Hneq1 Hnq].
@@ -3551,13 +3552,6 @@ Qed.
             unfold remove_bound_evars in Hnq.
             rewrite map_filter_lookup_Some in Hnq.
             destruct Hnq as [Hg0q _].
-
-            (*
-            assert (Hdvcp : dangling_vars_cached Cin p).
-            {
-              apply dangling_vars_cached_ex_proj
-            }
-            *)
 
             epose proof (IH := IHsz p ltac:(lia) q nq _ _ _ _ Hnbq).
             feed specialize IH.
@@ -3596,7 +3590,7 @@ Qed.
             exists Cin, evsin, s.
             simpl. rewrite Hqin.
             repeat case_match. invert_tuples. simpl in *.
-            reflexivity.
+            split; reflexivity.
           }
           {
             destruct Hneq as [Hneq1 Hnq].
@@ -3614,13 +3608,6 @@ Qed.
             unfold remove_bound_evars in Hnq.
             rewrite map_filter_lookup_Some in Hnq.
             destruct Hnq as [Hg0q _].
-
-            (*
-            assert (Hdvcp : dangling_vars_cached Cin p).
-            {
-              apply dangling_vars_cached_ex_proj
-            }
-            *)
 
             epose proof (IH := IHsz p ltac:(lia) q nq _ _ _ _ Hnbq).
             feed specialize IH.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3476,6 +3476,108 @@ Qed.
     }
   Defined.
 
+  Lemma History_generator_shift_s Cin evsin svsin s:
+  History_generator Cin evsin svsin ->
+  History_generator (<[BoundVarSugar.B0:=npatt_svar s]> (cache_incr_svar Cin))
+       evsin (svsin ∪ {[s]}).
+  Proof.
+    intros Hhist.
+    destruct Hhist as [history Hhistory].
+    exists ((inr ((<[BoundVarSugar.B0:=npatt_svar s]> (cache_incr_svar Cin)), evsin, (svsin ∪ {[s]})))::history).
+    simpl.
+    split.
+    { reflexivity. }
+    split.
+    { reflexivity. }
+    split.
+    { reflexivity. }
+    split.
+    {
+      rewrite last_cons.
+      destruct (last history) eqn:Heqlsthist.
+      {
+        unfold hist_prop in Hhistory.
+        destruct history.
+        {
+          simpl in Heqlsthist. inversion Heqlsthist.
+        }
+        rewrite Heqlsthist in Hhistory.
+        destruct h as [nhe | ihe].
+        {
+          destruct Hhistory as [Hcache [Hevs [Hsvs Hhistory]]]. subst evsin svsin.
+          destruct Hhistory as [[Hdngl Hresult] Hhistory].
+          split. exact Hdngl. exact Hresult.
+        }
+        {
+          destruct Hhistory as [Hcache [Hevs [Hsvs Hhistory]]]. subst evsin svsin.
+          destruct Hhistory as [[np Hnp] Hhistory].
+          exists np. exact Hnp.
+        }
+      }
+      {
+        unfold hist_prop in Hhistory.
+        destruct history.
+        2: { rewrite last_cons in Heqlsthist. destruct (last history); simpl in Heqlsthist; inversion Heqlsthist. }
+        clear Heqlsthist.
+        exists (npatt_svar s). right. subst Cin. reflexivity.
+      }
+    }
+    {
+      unfold hist_prop in Hhistory.
+      destruct history.
+      {
+        intros i. simpl. exact I.
+      }
+      {
+        destruct Hhistory as [Hcache [Hevs [Hsvs Hhistory]]]. subst Cin evsin svsin.
+        destruct Hhistory as [Hlast Hhistory].
+        intros i.
+        destruct i; simpl.
+        {
+          right. repeat unfold cache_of_ihe,fst.
+          unfold remove_bound_svars.
+          rewrite map_filter_insert.
+          unfold is_bound_svar_entry. simpl.
+          rewrite map_filter_delete_not.
+          {
+            intros np. simpl. unfold cache_incr_svar.
+            rewrite lookup_kmap_Some.
+            intros [p [Hp1 Hp2]].
+            destruct p; simpl in Hp1; inversion Hp1.
+          }
+          unfold cache_incr_svar.
+          rewrite map_filter_strong_ext.
+          intros p np. simpl.
+          split; intros H.
+          {
+            destruct H as [H1 H2].
+            split;[exact H1|].
+            replace p with (incr_one_svar p) in H2.
+            2: {
+              destruct p; simpl; try reflexivity.
+              exfalso. apply H1. exists n. reflexivity.
+            }
+            rewrite lookup_kmap in H2.
+            exact H2.
+          }
+          {
+            destruct H as [H1 H2].
+            split;[exact H1|].
+            replace p with (incr_one_svar p).
+            2: {
+              destruct p; simpl; try reflexivity.
+              exfalso. apply H1. exists n. reflexivity.
+            }
+            rewrite lookup_kmap. exact H2.
+          }
+        }
+        {
+          apply Hhistory.
+        }
+      }
+    }
+  Defined.
+
   Lemma find_nested_call
     (p : Pattern)
     (Cin : Cache)

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3267,16 +3267,10 @@ Qed.
     Cout !! q = Some nq ->
     (to_NamedPattern2' p Cin evsin svsin).1.1.2 = Cout ->
     exists Cfound evsfound svsfound,
-      Cfound !! q = None /\
+      Cfound ⊆ Cout /\ Cfound !! q = None /\
       (to_NamedPattern2' q Cfound evsfound svsfound).1.1.1 = nq.
   Proof.
     intros Hnbq Hdvc Hccp Hsp Hqin Hqout Hcall.
-    (*
-    pose proof (Hsub := onlyAddsSubpatterns2 Cin p evsin svsin q Hqin).
-    feed specialize Hsub.
-    {
-      exists nq. rewrite Hcall. exact Hqout.
-    }*)
     remember (size' p) as sz.
     assert (Hsz: size' p <= sz) by lia.
     clear Heqsz.
@@ -3298,7 +3292,10 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl. split; reflexivity.
+        rewrite Hqin. simpl.
+        split. 2: split;reflexivity.
+        apply insert_subseteq.
+        { exact Hqin. }
       }
       {
         destruct H as [H1 H2].
@@ -3318,7 +3315,10 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl. split; reflexivity.
+        rewrite Hqin. simpl.
+        split. 2: split;reflexivity.
+        apply insert_subseteq.
+        { exact Hqin. }
       }
       {
         destruct H as [H1 H2].
@@ -3338,7 +3338,10 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl. split; reflexivity.
+        rewrite Hqin. simpl.
+        split. 2: split;reflexivity.
+        apply insert_subseteq.
+        { exact Hqin. }
       }
       {
         destruct H as [H1 H2].
@@ -3358,7 +3361,10 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl. split; reflexivity.
+        rewrite Hqin. simpl.
+        split. 2: split;reflexivity.
+        apply insert_subseteq.
+        { exact Hqin. }
       }
       {
         destruct H as [H1 H2].
@@ -3378,7 +3384,10 @@ Qed.
         destruct H as [H1 H2]. subst.
         exists Cin, evsin, svsin.
         simpl.
-        rewrite Hqin. simpl. split; reflexivity.
+        rewrite Hqin. simpl.
+        split. 2: split;reflexivity.
+        apply insert_subseteq.
+        { exact Hqin. }
       }
       {
         destruct H as [H1 H2].
@@ -3399,7 +3408,16 @@ Qed.
         exists Cin, evsin, svsin.
         simpl. rewrite Hqin.
         repeat case_match. invert_tuples. simpl in *.
-        rewrite Heqp2 in Heqp5. inversion Heqp5. subst. split; reflexivity.
+        rewrite Heqp2 in Heqp5. inversion Heqp5. subst.
+        split. 2: split;reflexivity.
+        apply insert_subseteq_r.
+        { exact Hqin. }
+        { epose proof (Htmp2 := to_NamedPattern2'_extends_cache _ _ _ _).
+          erewrite Heqp2 in Htmp2. simpl in Htmp2.
+          epose proof (Htmp1 := to_NamedPattern2'_extends_cache _ _ _ _).
+          erewrite Heqp0 in Htmp1. simpl in Htmp1.
+          eapply transitivity; eassumption.
+        }
       }
       {
         destruct Hneq as [Hneq1 Hnq].
@@ -3430,6 +3448,27 @@ Qed.
             eapply lookup_weaken in Hg0q';[|exact Hext].
             rewrite Hnq in Hg0q'. inversion Hg0q'; subst; clear Hg0q'.
             
+            pose proof (IH := IHsz p1 ltac:(lia) q n evsin svsin Cin g0 Hnbq Hdvcp1 Hccp Hsp Hqin Hg0q).
+            rewrite Heqp1 in IH. specialize (IH erefl).
+            destruct IH as [Cfound [evsfound [svsfound Hfound]]].
+            destruct Hfound as [Hfound1 [Hfound2 Hfound3]].
+            exists Cfound,evsfound,svsfound.
+            split.
+            { eapply transitivity. exact Hfound1.
+              epose proof (Htmp := to_NamedPattern2'_extends_cache _ _ _ _).
+              erewrite Heqp2 in Htmp. simpl in Htmp.
+              apply insert_subseteq_r.
+              { 
+                epose proof (Htmp2 := onlyAddsSubpatterns2 _ _ _ _ (patt_app p1 p2)).
+                erewrite Heqp1 in Htmp2. simpl in Htmp2. specialize (Htmp2 Heqo).
+                destruct (g0 !! (patt_app p1 p2));[|reflexivity].
+                exfalso. Search is_subformula_of.
+                feed specialize Htmp2.
+                { exists n2. reflexivity. }
+                (* HERE *)
+              }
+              { exact Htmp. }
+            }
             eapply IHsz with (p := p1).
             { lia. }
             { exact Hnbq. }
@@ -3437,7 +3476,7 @@ Qed.
             { exact Hccp. }
             { exact Hsp. }
             { exact Hqin. }
-            { exact Hg0q. }
+            { rewrite lookup_insert_ne. exact Hneq1. exact Hnq. }
             { erewrite Heqp1. reflexivity. }
           }
           {
@@ -3745,6 +3784,7 @@ Qed.
     ~ is_bound_var p ->
     C !! p = Some np ->
     exists (C' : Cache) (evs' : EVarSet) (svs' : SVarSet),
+      C' ⊆ C /\
       C' !! p = None /\ (to_NamedPattern2' p C' evs' svs').1.1.1 = np.
   Proof.
     intros Hnboundp Hcached.
@@ -3809,7 +3849,7 @@ Qed.
       }
     }
   Qed.
-
+(*
   Lemma cached_imp_is_nimp
     (C : Cache)
     (hg : History_generator C)
@@ -3888,19 +3928,90 @@ Qed.
       
     }
   Abort.
-
+*)
   Lemma consistency_pqp
         (p q : Pattern)
-        (np' nq' np'' : NamedPattern)
         (cache : Cache)
         (evs : EVarSet)
         (svs : SVarSet):
     History_generator cache ->
+    sub_prop cache ->
+    dangling_vars_cached cache (patt_imp p (patt_imp q p)) ->
+    exists np nq,
     (to_NamedPattern2' (patt_imp p (patt_imp q p)) cache evs svs).1.1.1
-    = npatt_imp np' (npatt_imp nq' np'') ->
-    np'' = np'.
+    = npatt_imp np (npatt_imp nq np).
   Proof.
+    intros Hhist Hsubp Hdngcached.
+    remember ((to_NamedPattern2' (patt_imp p (patt_imp q p)) cache evs svs)) as Call.
+    simpl in HeqCall.
+    destruct (cache !! patt_imp p (patt_imp q p)) eqn:Hcachepqp.
+    {
+      rewrite Hcachepqp in HeqCall. rewrite HeqCall. simpl. rename n into npqp.
 
+      apply cached_p_impl_called_with_p in Hcachepqp.
+      3: { simpl. auto. }
+      2: { exact Hhist. }
+      destruct Hcachepqp as [C' [evs' [svs' [HC'notcached HeqCall1]]]].
+      rewrite -HeqCall1. simpl. rewrite HC'notcached.
+      repeat case_match; invert_tuples; simpl in *.
+      {
+        apply cached_p_impl_called_with_p in Heqo.
+        3: { simpl. auto. }
+        2: {  }
+      }
+
+
+      pose proof (Hnp := Hsubp (patt_imp p (patt_imp q p)) npqp Hcachepqp).
+      simpl in Hnp.
+      destruct Hnp as [Hbocp Hbocqp].
+
+      assert (Hcachedp: exists np, cache !! p = Some np).
+      {
+        destruct Hbocp as [Hboundp|Hcachedp'].
+        {
+          (* p is in cache because it is bound *)
+          pose proof (Hcachedp := Hdngcached).
+          apply dangling_vars_cached_imp_proj1 in Hcachedp.
+          destruct Hcachedp as [Hcachede Hcacheds].
+          unfold dangling_evars_cached,dangling_svars_cached in *.
+          destruct p; simpl in Hboundp; try inversion Hboundp.
+          { apply Hcachede. simpl. case_match. reflexivity. contradiction. }
+          { apply Hcacheds. simpl. case_match. reflexivity. contradiction. }
+        }
+        {
+          exact Hcachedp'.
+        }
+      }
+      destruct Hcachedp as [np Hcachedp].
+      exists np.
+
+      destruct Hbocqp as [Hbqp|Hcqp].
+      { simpl in Hbqp. inversion Hbqp. }
+      destruct Hcqp as [nqp Hcachedqp].
+      pose proof (Hnqp := Hsubp (patt_imp q p) nqp Hcachedqp).
+      simpl in Hnqp.
+      destruct Hnqp as [Hbocq _].
+      assert (Hcachedq: exists nq, cache !! q = Some nq).
+      {
+        destruct Hbocq as [Hboundq|Hcachedq'].
+        {
+          (* p is in cache because it is bound *)
+          pose proof (Hcachedq := Hdngcached).
+          apply dangling_vars_cached_imp_proj2 in Hcachedq.
+          apply dangling_vars_cached_imp_proj1 in Hcachedq.
+          destruct Hcachedq as [Hcachede Hcacheds].
+          unfold dangling_evars_cached,dangling_svars_cached in *.
+          destruct q; simpl in Hboundq; try inversion Hboundq.
+          { apply Hcachede. simpl. case_match. reflexivity. contradiction. }
+          { apply Hcacheds. simpl. case_match. reflexivity. contradiction. }
+        }
+        {
+          exact Hcachedq'.
+        }
+      }
+      destruct Hcachedq as [nq Hcachedq].
+      exists nq.
+    }
   (*
     (to_NamedPattern2' (p ---> (q ---> p)) cache used_evars used_svars).1.1.1
     (1) cache !! (p ---> (q ---> p)) = Some pqp'

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3057,12 +3057,199 @@ Qed.
       exact Hnphi.
   Qed.
 
+  Lemma find_nested_call
+    (p : Pattern)
+    (Cin : Cache)
+    (evsin : EVarSet)
+    (svsin : SVarSet)
+    (Cout : Cache)
+    (q : Pattern)
+    (nq : NamedPattern):
+    Cin !! q = None ->
+    Cout !! q = Some nq ->
+    (to_NamedPattern2' p Cin evsin svsin).1.1.2 = Cout ->
+    exists Cfound evsfound svsfound,
+      (to_NamedPattern2' q Cfound evsfound svsfound).1.1.1 = nq.
+  Proof.
+    intros Hqin Hqout Hcall.
+    pose proof (Hsub := onlyAddsSubpatterns2 Cin p evsin svsin q Hqin).
+    feed specialize Hsub.
+    {
+      exists nq. rewrite Hcall. exact Hqout.
+    }
+    move: q nq evsin svsin Cin Cout Hqin Hqout Hcall Hsub.
+    induction p; intros q nq evsin svsin Cin Cout Hqin Hqout Hcall Hsub;
+      simpl in Hcall.
+    {
+      case_match_in_hyp Hcall.
+      {
+        simpl in Hcall. rewrite Hcall in Hqin. rewrite Hqout in Hqin. inversion Hqin.
+      }
+      simpl in Hcall.
+      rewrite -Hcall in Hqout.
+      rewrite lookup_insert_Some in Hqout.
+      destruct Hqout as [H|H].
+      {
+        destruct H as [H1 H2]. subst.
+        exists Cin, evsin, svsin.
+        simpl.
+        rewrite Hqin. simpl. reflexivity.
+      }
+      {
+        destruct H as [H1 H2].
+        rewrite H2 in Hqin. inversion Hqin.
+      }
+    }
+    {
+      case_match_in_hyp Hcall.
+      {
+        simpl in Hcall. rewrite Hcall in Hqin. rewrite Hqout in Hqin. inversion Hqin.
+      }
+      simpl in Hcall.
+      rewrite -Hcall in Hqout.
+      rewrite lookup_insert_Some in Hqout.
+      destruct Hqout as [H|H].
+      {
+        destruct H as [H1 H2]. subst.
+        exists Cin, evsin, svsin.
+        simpl.
+        rewrite Hqin. simpl. reflexivity.
+      }
+      {
+        destruct H as [H1 H2].
+        rewrite H2 in Hqin. inversion Hqin.
+      }
+    }
+    {
+      case_match_in_hyp Hcall.
+      {
+        simpl in Hcall. rewrite Hcall in Hqin. rewrite Hqout in Hqin. inversion Hqin.
+      }
+      simpl in Hcall.
+      rewrite -Hcall in Hqout.
+      rewrite lookup_insert_Some in Hqout.
+      destruct Hqout as [H|H].
+      {
+        destruct H as [H1 H2]. subst.
+        exists Cin, evsin, svsin.
+        simpl.
+        rewrite Hqin. simpl. reflexivity.
+      }
+      {
+        destruct H as [H1 H2].
+        rewrite H2 in Hqin. inversion Hqin.
+      }
+    }
+    {
+      case_match_in_hyp Hcall.
+      {
+        simpl in Hcall. rewrite Hcall in Hqin. rewrite Hqout in Hqin. inversion Hqin.
+      }
+      simpl in Hcall.
+      rewrite -Hcall in Hqout.
+      rewrite lookup_insert_Some in Hqout.
+      destruct Hqout as [H|H].
+      {
+        destruct H as [H1 H2]. subst.
+        exists Cin, evsin, svsin.
+        simpl.
+        rewrite Hqin. simpl. reflexivity.
+      }
+      {
+        destruct H as [H1 H2].
+        rewrite H2 in Hqin. inversion Hqin.
+      }
+    }
+    {
+      case_match_in_hyp Hcall.
+      {
+        simpl in Hcall. rewrite Hcall in Hqin. rewrite Hqout in Hqin. inversion Hqin.
+      }
+      simpl in Hcall.
+      rewrite -Hcall in Hqout.
+      rewrite lookup_insert_Some in Hqout.
+      destruct Hqout as [H|H].
+      {
+        destruct H as [H1 H2]. subst.
+        exists Cin, evsin, svsin.
+        simpl.
+        rewrite Hqin. simpl. reflexivity.
+      }
+      {
+        destruct H as [H1 H2].
+        rewrite H2 in Hqin. inversion Hqin.
+      }
+    }
+    {
+      case_match_in_hyp Hcall.
+      {
+        simpl in Hcall. rewrite Hcall in Hqin. rewrite Hqout in Hqin. inversion Hqin.
+      }
+      repeat case_match. invert_tuples. simpl in *.
+      rewrite lookup_insert_Some in Hqout.
+      destruct Hqout as [Heq|Hneq].
+      {
+        destruct Heq as [Heq1 Heq2].
+        subst.
+        exists Cin, evsin, svsin.
+        simpl. rewrite Hqin.
+        repeat case_match. invert_tuples. simpl in *.
+        rewrite Heqp2 in Heqp5. inversion Heqp5. subst. reflexivity.
+      }
+      {
+        destruct Hneq as [Hneq1 Hnq].
+        inversion Hsub; subst; clear Hsub.
+        { contradiction Hneq1. reflexivity. }
+        {
+          specialize (IHp1 q nq evsin svsin Cin g0 Hqin).
+        }
+      }
+    }
+  Qed.
+
+  Lemma cached_p_impl_called_with_p
+    (C : Cache)
+    (hg : History_generator C)
+    (p : Pattern)
+    (np : NamedPattern):
+    C !! p = Some np ->
+    exists (C' : Cache) (evs' : EVarSet) (svs' : SVarSet),
+      C' !! p = None /\ (to_NamedPattern2' p C' evs' svs').1.1.1 = np.
+  Proof.
+    intros Hcached.
+    destruct hg as [history Hhistory].
+    move: p np C Hcached Hhistory.
+    induction history; intros p np C Hcached Hhistory.
+    {
+      simpl in Hhistory. inversion Hhistory.
+    }
+    {
+      simpl in Hhistory.
+      destruct Hhistory as [Hhistory1 [Hhistory2 Hhistory3]].
+      destruct a as [hip [[[hinp hiC] hievs] hisvs]].
+      simpl in Hhistory1. subst hiC.
+      destruct history.
+      {
+        simpl in Hhistory2. clear Hhistory3 IHhistory.
+        pose proof (Hoas := onlyAddsSubpatterns2 empty hip empty empty p).
+        feed specialize Hoas.
+        {
+          apply lookup_empty.
+        }
+        {
+          rewrite -Hhistory2. simpl. exists np. exact Hcached.
+        }
+        exists C, hievs, hisvs.
+      }
+    }
+  Qed.
+
   Lemma cached_imp_is_nimp
     (C : Cache)
     (hg : History_generator C)
     (p q : Pattern)
     (npq : NamedPattern):
-    dangling_vars_cached C (patt_imp p q) ->
+    dangling_vars_cached C (patt_imp p q) -> (* Maybe not needed? *)
     C !! (patt_imp p q) = Some npq ->
     exists (np nq : NamedPattern), npq = npatt_imp np nq.
   Proof.
@@ -3115,11 +3302,21 @@ Qed.
           2: { simpl. auto. }
           (* Contradiction. [g] cannot contain the implication. *)
           (*assert(empty !! patt_imp p q = None).*)
-          pose proof (Honly1 := onlyAddsSubpatterns empty p0_1 empty empty).
-          feed specialize Honly1.
+          assert (g0 !! patt_imp p q = None).
           {
-            Search dangling_vars_cached.
+            assert (~ (exists npq', g0 !! patt_imp p q = npq')).
+            {
+              intros HContra.
+              pose proof (Honly1 := onlyAddsSubpatterns2 empty p0_1 empty empty).
+              specialize (Honly1 (patt_imp p q)).
+              feed specialize Honly1.
+              {
+
+              }
+            }
+            
           }
+          
         
       }
       

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3042,7 +3042,9 @@ Qed.
                     nhei = (p_i, (to_NamedPattern2' p_i c_Si evs_Si svs_Si))
                     )
                   )
-                | inr ihei => True
+                | inr ihei =>
+                  (remove_bound_evars (cache_of_ihe ihei) = remove_bound_evars (cache_of heSi))
+                  \/ (remove_bound_svars (cache_of_ihe ihei) = remove_bound_svars (cache_of heSi))
                 end 
               end
             end
@@ -3093,7 +3095,7 @@ Qed.
       destruct p; simpl in Heqp0; rewrite Hin in Heqp0; simpl;
         destruct hC; simpl in Heqp0; inversion Heqp0; subst; simpl; assumption.
     - repeat case_match. subst.
-      exists ((p, to_NamedPattern2' p C evs svs) :: (Hst_history C evs svs hC)).
+      exists ((inl (p, to_NamedPattern2' p C evs svs)) :: (Hst_history C evs svs hC)).
       simpl. rewrite Heqp0.
       split;[reflexivity|].
       split;[reflexivity|].
@@ -3108,14 +3110,25 @@ Qed.
         destruct Hst_prop0 as [Hcache [H2evs [H2svs [HhistoryC Hinner]]]].
         subst evs svs.
         split.
-        { subst C. destruct h as [p0 [[[np0 C0] evs0] svs0]].
-          simpl in * |-. inversion Hevs. inversion Hsvs. clear Hevs Hsvs. subst.
-          repeat unfold fst,snd,svs_of,evs_of.
-          unfold evs_of, svs_of in *. simpl in *.
-          rewrite last_cons. rewrite last_cons in HhistoryC.
-          destruct (last Hst_history0) eqn:Heqtmp.
-          { exact HhistoryC. }
-          { exact HhistoryC. }
+        { subst C.
+          destruct h as [hnormal|hinner].
+          {
+            destruct hnormal as [p0 [[[np0 C0] evs0] svs0]].
+            simpl in * |-. inversion Hevs. inversion Hsvs. clear Hevs Hsvs. subst.
+            repeat unfold fst,snd,svs_of,evs_of.
+            unfold evs_of, svs_of in *. simpl in *.
+            rewrite last_cons. rewrite last_cons in HhistoryC.
+            destruct (last Hst_history0) eqn:Heqtmp.
+            { exact HhistoryC. }
+            { exact HhistoryC. }
+          }
+          {
+            unfold evs_of, svs_of in *. simpl in *.
+            rewrite last_cons. rewrite last_cons in HhistoryC.
+            destruct (last Hst_history0) eqn:Heqtmp.
+            { exact HhistoryC. }
+            { exact HhistoryC. }
+          }
         }
         destruct i; simpl.
         unfold evs_of, svs_of in *. simpl in *.
@@ -3127,7 +3140,36 @@ Qed.
         + exists p. split. exact Hin. split.
           exact Hcont. split. exact Hsubp. split.
           exact HdcCp. rewrite Heqp0. reflexivity.
-        + apply Hinner.
+        + 
+          clear Hevs Hsvs. exists p. rewrite Heqp0. simpl.
+          split;[exact Hin|].
+          split;[exact Hcont|].
+          split;[exact Hsubp|].
+          split;[exact HdcCp|].
+          reflexivity.
+        +
+        clear Hevs Hsvs. exists p. rewrite Heqp0. simpl.
+        split;[exact Hin|].
+        split;[exact Hcont|].
+        split;[exact Hsubp|].
+        split;[exact HdcCp|].
+        reflexivity.
+        + 
+        clear Hevs Hsvs. exists p. rewrite Heqp0. simpl.
+        split;[exact Hin|].
+        split;[exact Hcont|].
+        split;[exact Hsubp|].
+        split;[exact HdcCp|].
+        reflexivity.
+        +
+        clear Hevs Hsvs. exists p. rewrite Heqp0. simpl.
+        split;[exact Hin|].
+        split;[exact Hcont|].
+        split;[exact Hsubp|].
+        split;[exact HdcCp|].
+        reflexivity.
+        + 
+          apply Hinner.
       }
       {
         destruct Hevssvs as [H1 [H2 [H3 H4]]]. subst.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -4662,54 +4662,51 @@ Qed.
             apply IHhistory.
           }
           {
-            pose proof (Hfnc := find_nested_call).
-          }
-
-          simpl in Hhistory.
-          destruct Hhistory as [HC [Hevs [Hsvs [Hrest1 Hrest2]]]]. subst.
-          specialize (Hrest2 0). simpl in Hrest2. destruct Hrest2 as [HCES2 Hrest2].
-          destruct a.
-          {
-            destruct Hrest2 as [p_i Hp_i]. cbn in Hp_i.
-            destruct Hp_i as [HiCp_i [Hconti [Hsubpi [Hdnglp_i Hn]]]].
-            subst. simpl in Hcached. unfold cache_of_nhe in Hcached. simpl in Hcached.
-          
-            specialize (IHhistory p np  ievs isvs iC Hhistory' HCES2 Hnboundp).
-
-            pose proof (Hfnc := find_nested_call p_i iC ievs isvs).
-            specialize (Hfnc ((to_NamedPattern2' p_i iC ievs isvs).1.1.2) p np).
-            specialize (Hfnc HCES2 Hnboundp Hhistory' Hdnglp_i Hconti Hsubpi).
-            exists iC, ievs, isvs, Hhistory'.
-            split.
-            {}
-          }
-
-          specialize (IHhistory p np  ievs isvs iC Hhistory').
-          feed specialize IHhistory.
-          {
-            unfold CES_prop. intros hIC. subst. simpl in Hhistory.
-            destruct_and!. subst. specialize (H4 0). simpl in H4.
-            destruct_and!. apply H. reflexivity.
-          }
-          { exact Hnboundp. }
-          {
-            simpl in Hhistory. destruct_and!. subst.
-            specialize (H4 0). simpl in H4. destruct_and!. simpl in H.
+            simpl in Hhistory.
+            destruct Hhistory as [HC [Hevs [Hsvs [Hhistory1 Hhistory2]]]]. subst.
+            specialize (Hhistory2 0). simpl in Hhistory2.
+            destruct Hhistory2 as [HCES' Hhistory2].
             destruct a.
-            { cbn in H0.
-              destruct H0.
-              destruct_and?. subst. cbn in Hcached.
+            {
+              admit.
+            }
+            {
+              destruct i as [[iC' ievs'] isvs']. cbn in Hhistory2.
+              destruct Hhistory2 as [Hhistory2|Hhistory2].
+              {
+                cbn in Hcached.
+                assert (Hcached2: remove_bound_evars iC' !! p = Some np).
+                {
+                  unfold remove_bound_evars. rewrite map_filter_lookup_Some.
+                  split. exact Hcached. unfold is_bound_evar_entry. simpl.
+                  intros Hcontra. apply Hnboundp. apply bound_evar_is_bound_var.
+                  apply Hcontra.
+                }
+                rewrite Hhistory2 in Hcached2.
+                unfold remove_bound_evars in Hcached2.
+                rewrite map_filter_lookup_Some in Hcached2.
+                destruct Hcached2 as [Hcached2 _]. rewrite HiCp in Hcached2.
+                inversion Hcached2.
+              }
+              {
+                cbn in Hcached.
+                assert (Hcached2: remove_bound_svars iC' !! p = Some np).
+                {
+                  unfold remove_bound_svars. rewrite map_filter_lookup_Some.
+                  split. exact Hcached. unfold is_bound_svar_entry. simpl.
+                  intros Hcontra. apply Hnboundp. apply bound_svar_is_bound_var.
+                  apply Hcontra.
+                }
+                rewrite Hhistory2 in Hcached2.
+                unfold remove_bound_svars in Hcached2.
+                rewrite map_filter_lookup_Some in Hcached2.
+                destruct Hcached2 as [Hcached2 _]. rewrite HiCp in Hcached2.
+                inversion Hcached2.
+              }
             }
           }
-          
-          apply IHhistory with (p := p) (np := np) in Hhistory'.
-          simpl in Hhistory.
-          destruct_and!. subst. specialize (H4 0). simpl in H4.
-          destruct_and!.
-          Print hist_prop.
         }
       }
-    }
   Qed.
 (*
   Lemma cached_imp_is_nimp

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -4668,7 +4668,14 @@ Qed.
             destruct Hhistory2 as [HCES' Hhistory2].
             destruct a.
             {
-              admit.
+              destruct Hhistory2 as [p_i [Hhistory21 [Hhistory22 [Hhistory23 [Hhistory24 Hhistory25]]]]].
+              subst. cbn in Hhistory21,Hhistory22,Hhistory23,Hhistory24, Hcached.
+              unfold cache_of_nhe in Hcached. cbn in Hcached.
+              pose proof (Hfnc := find_nested_call p_i iC ievs isvs).
+              specialize (Hfnc (to_NamedPattern2' p_i iC ievs isvs).1.1.2 p np HCES').
+              specialize (Hfnc Hnboundp Hhistory' Hhistory24 Hhistory22 Hhistory23 HiCp).
+              specialize (Hfnc Hcached erefl).
+              apply Hfnc.
             }
             {
               destruct i as [[iC' ievs'] isvs']. cbn in Hhistory2.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -4600,6 +4600,71 @@ Qed.
             apply Hhist_prop.
           }
 
+          destruct (iC !! p) eqn:HiCp.
+          {
+            assert (n = np).
+            {
+              simpl in Hhistory. destruct Hhistory as [HC [Hevs [Hsvs [Hhistory1 Hhistory2]]]].
+              subst. specialize (Hhistory2 0). simpl in Hhistory2.
+              destruct Hhistory2 as [HCES' Hhistory2].
+              destruct a.
+              {
+                destruct Hhistory2 as [p_i [Hhistory21 [Hhistory22 [Hhistory23 [Hhistory24 Hhistory25]]]]].
+                subst. cbn in Hcached. unfold cache_of_nhe in Hcached. simpl in Hcached.
+                pose proof (Hextends := to_NamedPattern2'_extends_cache iC p_i ievs isvs).
+                eapply lookup_weaken in HiCp;[|apply Hextends].
+                rewrite HiCp in Hcached. inversion Hcached.
+                subst. reflexivity.
+              }
+              {
+                destruct i. destruct p0. cbn in Hcached.
+                cbn in Hhistory2.
+                destruct Hhistory2 as [Hhistory2|Hhistory2].
+                {
+                  assert (HiCp': remove_bound_evars iC !! p = Some n).
+                  {
+                    unfold remove_bound_evars. rewrite map_filter_lookup_Some.
+                    split. exact HiCp. unfold is_bound_evar_entry. simpl.
+                    intros Hcontra. apply Hnboundp. apply bound_evar_is_bound_var.
+                    apply Hcontra.
+                  }
+                  rewrite -Hhistory2 in HiCp'.
+                  unfold remove_bound_evars in HiCp'.
+                  rewrite map_filter_lookup_Some in HiCp'.
+                  destruct HiCp' as [HiCp' _].
+                  rewrite Hcached in HiCp'. inversion HiCp'. subst. reflexivity.
+                }
+                {
+                  assert (HiCp': remove_bound_svars iC !! p = Some n).
+                  {
+                    unfold remove_bound_svars. rewrite map_filter_lookup_Some.
+                    split. exact HiCp. unfold is_bound_svar_entry. simpl.
+                    intros Hcontra. apply Hnboundp. apply bound_svar_is_bound_var.
+                    apply Hcontra.
+                  }
+                  rewrite -Hhistory2 in HiCp'.
+                  unfold remove_bound_svars in HiCp'.
+                  rewrite map_filter_lookup_Some in HiCp'.
+                  destruct HiCp' as [HiCp' _].
+                  rewrite Hcached in HiCp'. inversion HiCp'. subst. reflexivity.
+                }
+              }
+            }
+            subst n.
+            specialize (IHhistory p np  ievs isvs iC Hhistory').
+            feed specialize IHhistory.
+            {
+              intros Hempty. subst iC. rewrite lookup_empty in HiCp. inversion HiCp.
+            }
+            { exact Hnboundp. }
+            { exact HiCp. }
+            { exact Hhist_prop. }
+            apply IHhistory.
+          }
+          {
+            pose proof (Hfnc := find_nested_call).
+          }
+
           simpl in Hhistory.
           destruct Hhistory as [HC [Hevs [Hsvs [Hrest1 Hrest2]]]]. subst.
           specialize (Hrest2 0). simpl in Hrest2. destruct Hrest2 as [HCES2 Hrest2].

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -2991,6 +2991,8 @@ Qed.
             | Some (p_Si, (np_Si, c_Si, evs_Si, svs_Si)) =>
                 exists p_i,
                 c_Si !! p_i = None /\
+                cache_continuous_prop c_Si /\
+                sub_prop c_Si /\
                 dangling_vars_cached c_Si p_i /\
                   ((x::xs)!!i) = Some (p_i,(to_NamedPattern2' p_i c_Si evs_Si svs_Si))
             end
@@ -3028,10 +3030,12 @@ Qed.
     ((fmap evs_of (head (Hst_history C hC)) = Some evs /\
      fmap svs_of (head (Hst_history C hC)) = Some svs)
      \/ ( (Hst_history C hC = []) /\ C = ∅ /\ evs = ∅ /\ svs = ∅)) ->
+    cache_continuous_prop C ->
+    sub_prop C ->
     dangling_vars_cached C p ->
     History_generator (to_NamedPattern2' p C evs svs).1.1.2.
   Proof.
-    intros Hevssvs HdcCp.
+    intros Hevssvs Hcont Hsubp HdcCp.
     destruct (C !! p) eqn:Hin.
     - exists (Hst_history C hC).
       unfold to_NamedPattern2'.
@@ -3061,8 +3065,12 @@ Qed.
         unfold evs_of, svs_of in *. simpl in *.
         inversion Hevs; inversion Hsvs; subst.
         repeat case_match; simpl in *; subst.
-        + exists p. split. exact Hin. split. exact HdcCp. reflexivity.
-        + exists p. split. exact Hin. split. exact HdcCp. reflexivity.
+        + exists p. split. exact Hin. split.
+          exact Hcont. split. exact Hsubp. split.
+          exact HdcCp. reflexivity.
+        + exists p. split. exact Hin. split.
+          exact Hcont. split. exact Hsubp. split.
+          exact HdcCp. reflexivity.
         + apply Hinner.
       }
       {
@@ -3714,9 +3722,7 @@ Qed.
           admit.
         }
         {
-          exists hiC, hievs, hisvs.
           destruct a as [ap [[[anp aC] aievs] aisvs]].
-          split;[exact HeqhiCp|].
           simpl in Hhistory.
           destruct Hhistory as [Hhistory1 [Hhistory2 Hhistory3]].
           subst aC.
@@ -3726,6 +3732,8 @@ Qed.
           Check find_nested_call.
           pose proof (Hfnc := find_nested_call p_i hiC hievs hisvs C p np Hnboundp Hdngl).
           feed specialize Hfnc.
+          exists hiC, hievs, hisvs.
+          split;[exact HeqhiCp|].
           eapply find_nested_call.
         }
         Print hist_prop.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -2975,7 +2975,7 @@ Qed.
   
   Definition hist_prop (C : Cache) (history : list hist_entry) : Prop :=
     match history with
-    | [] => False
+    | [] => C = ∅
     | (x::xs) =>
         x.2.1.1.2 = C /\
           (match (last (x::xs)) with
@@ -3014,6 +3014,13 @@ Qed.
   Abort.
 *)
 
+  Lemma history_generator_empty:
+    History_generator empty.
+  Proof.
+    apply mkHistory with (Hst_history := []).
+    simpl. reflexivity.
+  Qed.
+
   Lemma history_generator_step (C : Cache) (p : Pattern) (evs : EVarSet) (svs : SVarSet)
     (hC : History_generator C) :
     fmap evs_of (head (Hst_history C hC)) = Some evs ->
@@ -3031,9 +3038,18 @@ Qed.
       split;[reflexivity|].
       destruct hC. simpl in *.
       unfold hist_prop in Hst_prop0.
-      destruct Hst_history0; [contradiction|].
+      destruct Hst_history0.
+      { subst C. simpl in *. inversion Hevs. }
       destruct Hst_prop0 as [Hcache [HhistoryC Hinner]].
-      split; auto.
+      split.
+      { subst C. destruct h as [p0 [[[np0 C0] evs0] svs0]].
+        simpl in *. inversion Hevs. inversion Hsvs. clear Hevs Hsvs. subst.
+        unfold evs_of, svs_of in *. simpl in *.
+        rewrite last_cons. rewrite last_cons in HhistoryC.
+        destruct (last Hst_history0) eqn:Heqtmp.
+        { exact HhistoryC. }
+        { exact HhistoryC. }
+      }
       destruct i; simpl.
       unfold evs_of, svs_of in *. simpl in *.
       inversion Hevs; inversion Hsvs; subst.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -3689,24 +3689,52 @@ Qed.
       rewrite lookup_empty in Hcached. inversion Hcached.
     }
     {
-      simpl in Hhistory.
-      destruct Hhistory as [Hhistory1 [Hhistory2 Hhistory3]].
-      destruct a as [hip [[[hinp hiC] hievs] hisvs]].
-      simpl in Hhistory1. subst hiC.
       destruct history.
       {
-        simpl in Hhistory2. clear Hhistory3 IHhistory.
-        pose proof (Hfnc := find_nested_call hip empty empty empty C p np Hnboundp).
-        rewrite -Hhistory2 in Hfnc. simpl in Hfnc.
-        pose proof (Hoas := onlyAddsSubpatterns2 empty hip empty empty p).
-        feed specialize Hoas.
+        simpl in Hhistory.
+        destruct Hhistory as [Hhistory1 [Hhistory2 Hhistory3]].
+        destruct a as [hip [[[hinp hiC] hievs] hisvs]].
+        simpl in Hhistory1. subst hiC.
+        clear Hhistory3 IHhistory.
+        simpl in Hhistory2.
+        destruct Hhistory2 as [Hhistory2a Hhistory2b].
+        pose proof (Hfnc := find_nested_call hip empty empty empty C p np Hnboundp Hhistory2a).
+        feed specialize Hfnc.
+        { apply cache_continuous_empty. }
+        { apply sub_prop_empty. }
+        { apply lookup_empty. }
+        { exact Hcached. }
+        { rewrite -Hhistory2b. reflexivity. }
+        apply Hfnc.
+      }
+      {
+        destruct h as [hip [[[hinp hiC] hievs] hisvs]].
+        destruct (hiC !! p) eqn:HeqhiCp.
         {
-          apply lookup_empty.
+          admit.
         }
         {
-          rewrite -Hhistory2. simpl. exists np. exact Hcached.
+          exists hiC, hievs, hisvs.
+          destruct a as [ap [[[anp aC] aievs] aisvs]].
+          split;[exact HeqhiCp|].
+          simpl in Hhistory.
+          destruct Hhistory as [Hhistory1 [Hhistory2 Hhistory3]].
+          subst aC.
+          specialize (Hhistory3 0). simpl in Hhistory3.
+          destruct Hhistory3 as [p_i [HhiCp_i [Hdngl Hp_i]]].
+          inversion Hp_i. subst ap. clear Hp_i.
+          Check find_nested_call.
+          pose proof (Hfnc := find_nested_call p_i hiC hievs hisvs C p np Hnboundp Hdngl).
+          feed specialize Hfnc.
+          eapply find_nested_call.
         }
-        exists C, hievs, hisvs.
+        Print hist_prop.
+        eapply IHhistory with (C := hiC).
+        { exact Hnboundp. }
+        { exact Hcached. }
+        {
+          simpl.
+        }
       }
     }
   Qed.

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -4141,14 +4141,18 @@ Qed.
   Qed.
 
 
-  Lemma hist_prop_strip C a hip hinp hiC hievs hisvs history:
-    hist_prop C (a :: (hip, (hinp, hiC, hievs, hisvs)) :: history) ->
-    hist_prop hiC ((hip, (hinp, hiC, hievs, hisvs)) :: history).
+  Lemma hist_prop_strip_1 C evs svs a hip hinp hiC hievs hisvs history:
+    hist_prop C evs svs (a :: (inl (hip, (hinp, hiC, hievs, hisvs))) :: history) ->
+    hist_prop hiC hievs hisvs ((inl (hip, (hinp, hiC, hievs, hisvs))) :: history).
   Proof.
     intros HC.
     unfold hist_prop in *.
-    destruct HC as [HC1 [HC2 HC3]].
-    subst C.
+    destruct HC as [HC1 [Hevs [Hsvs [HC2 HC3]]]].
+    subst C evs svs.
+    split.
+    { simpl. reflexivity. }
+    split.
+    { simpl. reflexivity. }
     split.
     { simpl. reflexivity. }
     split.
@@ -4156,11 +4160,10 @@ Qed.
     clear HC2.
     intros i.
     specialize (HC3 (S i)).
-    repeat case_match; subst; try exact I.
+    repeat case_match; subst; try exact I; try contradiction.
     {
-      Search list lookup S.
       destruct HC3 as [p_i Hp_i].
-      rewrite lookup_cons_Some in Hp_i. simpl in Hp_i.
+      rewrite lookup_cons_Some in Heqo0. simpl in Heqo0.
       rewrite lookup_cons_Some in Heqo. simpl in Heqo.
       destruct Heqo as [Heqo|Heqo].
       {
@@ -4168,19 +4171,111 @@ Qed.
       }
       destruct Heqo as [_ Heqo].
       replace (i - 0) with i in Heqo by lia.
-      rewrite Heqo in Heqo0. inversion Heqo0. subst. clear Heqo0.
-      exists p_i. destruct Hp_i as [Hcpi [Hccpc [Hsubc [Hdngl Hrest]]]].
-      split; [exact Hcpi|]. split; [exact Hccpc|]. split; [exact Hsubc|]. split; [exact Hdngl|].
-      destruct Hrest as [Hrest|Hrest].
-      {
-        destruct Hrest as [Hcontra _]. inversion Hcontra.
-      }
-      destruct Hrest as [_ Hrest].
-      replace (i - 0) with i in Hrest by lia.
-      exact Hrest.
+      replace (i - 0) with i in Heqo0 by lia.
+      rewrite Heqo2 in Heqo0. inversion Heqo0; subst; clear Heqo0.
+      { destruct H as [HContra _]. inversion HContra. }
+      destruct H as [_ H]. inversion H. subst. clear H.
+      rewrite Heqo in Heqo1. inversion Heqo1. subst. clear Heqo1.
+      exists p_i.
+      destruct_and!. split_and!; assumption.
     }
     {
-      simpl in Heqo. rewrite Heqo in Heqo0. inversion Heqo0.
+      destruct HC3 as [p_i Hp_i].
+      rewrite lookup_cons_Some in Heqo0. simpl in Heqo0.
+      rewrite lookup_cons_Some in Heqo. simpl in Heqo.
+      destruct Heqo as [Heqo|Heqo].
+      {
+        destruct Heqo as [Hcontra _]. inversion Hcontra.
+      }
+      destruct Heqo as [_ Heqo].
+      replace (i - 0) with i in Heqo by lia.
+      replace (i - 0) with i in Heqo0 by lia.
+      rewrite Heqo2 in Heqo0. inversion Heqo0; subst; clear Heqo0.
+      { destruct H as [HContra _]. inversion HContra. }
+      destruct H as [_ H]. inversion H.
+    }
+    {
+      (* An ugly contradiction that we may extract into a lemma *)
+      remember (inl (hip, (hinp, hiC, hievs, hisvs))) as b.
+      clear -Heqo1 Heqo2.
+      move: b history Heqo1 Heqo2.
+      induction i; intros b history Heqo1 Heqo2.
+      {
+        simpl in *. inversion Heqo2.
+      }
+      {
+        destruct history.
+        { simpl in Heqo1. inversion Heqo1. }
+        {
+          simpl in *. eapply IHi. apply Heqo1. apply Heqo2.
+        }
+      }
+    }
+    {
+      rewrite lookup_cons_Some in Heqo0. simpl in Heqo0.
+      rewrite lookup_cons_Some in Heqo. simpl in Heqo.
+      replace (i - 0) with i in Heqo by lia.
+      replace (i - 0) with i in Heqo0 by lia.
+      destruct Heqo as [Hcontra|Heqo].
+      {
+        destruct Hcontra as [Hcontra _]. inversion Hcontra.
+      }
+      destruct Heqo as [_ Heqo].
+      destruct Heqo0 as [Hcontra|Heqo0].
+      {
+        destruct Hcontra as [Hcontra _]. inversion Hcontra.
+      }
+      destruct Heqo0 as [_ Heqo0].
+      rewrite Heqo2 in Heqo0. inversion Heqo0.
+    }
+    {
+      rewrite lookup_cons_Some in Heqo0. simpl in Heqo0.
+      rewrite lookup_cons_Some in Heqo. simpl in Heqo.
+      replace (i - 0) with i in Heqo by lia.
+      replace (i - 0) with i in Heqo0 by lia.
+      destruct Heqo as [Hcontra|Heqo].
+      {
+        destruct Hcontra as [Hcontra _]. inversion Hcontra.
+      }
+      destruct Heqo as [_ Heqo].
+      destruct Heqo0 as [Hcontra|Heqo0].
+      {
+        destruct Hcontra as [Hcontra _]. inversion Hcontra.
+      }
+      destruct Heqo0 as [_ Heqo0].
+      rewrite Heqo2 in Heqo0. inversion Heqo0.
+      subst. clear Heqo0.
+      rewrite Heqo in Heqo1. inversion Heqo1. subst. clear Heqo1.
+      exact HC3.
+    }
+    {
+      rewrite lookup_cons_Some in Heqo0. simpl in Heqo0.
+      rewrite lookup_cons_Some in Heqo. simpl in Heqo.
+      replace (i - 0) with i in Heqo by lia.
+      replace (i - 0) with i in Heqo0 by lia.
+      destruct Heqo as [Hcontra|Heqo].
+      {
+        destruct Hcontra as [Hcontra _]. inversion Hcontra.
+      }
+      destruct Heqo as [_ Heqo].
+      destruct Heqo0 as [Hcontra|Heqo0].
+      {
+        destruct Hcontra as [Hcontra _]. inversion Hcontra.
+      }
+      destruct Heqo0 as [_ Heqo0].
+      rewrite Heqo2 in Heqo0. inversion Heqo0.
+    }
+    {
+      rewrite lookup_cons in Heqo. 
+      rewrite Heqo0 in Heqo. inversion Heqo.
+    }
+    {
+      rewrite lookup_cons in Heqo. 
+      rewrite Heqo0 in Heqo. inversion Heqo.
+    }
+    {
+      rewrite lookup_cons in Heqo. 
+      rewrite Heqo0 in Heqo. inversion Heqo.
     }
   Qed.
 

--- a/prover/theories/ProofSystemTranslation.v
+++ b/prover/theories/ProofSystemTranslation.v
@@ -4417,156 +4417,156 @@ Qed.
       {
         destruct h as [nh|ih].
         {
-        destruct nh as [hip [[[hinp hiC] hievs] hisvs]].
-        destruct (hiC !! p) eqn:HeqhiCp.
-        {
-          epose proof (IH := IHhistory p n _ _ hiC _ _ Hnboundp HeqhiCp).
-          feed specialize IH.
-          { apply hist_prop_strip_1 in Hhistory. exact Hhistory. }
-          Unshelve.
-          3: {
-            simpl in Hhistory.
-            destruct Hhistory as [HC [Hevs [Hsvs Hhistory]]].
+          destruct nh as [hip [[[hinp hiC] hievs] hisvs]].
+          destruct (hiC !! p) eqn:HeqhiCp.
+          {
+            epose proof (IH := IHhistory p n _ _ hiC _ _ Hnboundp HeqhiCp).
+            feed specialize IH.
+            { apply hist_prop_strip_1 in Hhistory. exact Hhistory. }
+            Unshelve.
+            3: {
+              simpl in Hhistory.
+              destruct Hhistory as [HC [Hevs [Hsvs Hhistory]]].
+              subst.
+              destruct Hhistory as [Hhistory1 Hhistory2].
+              specialize (Hhistory2 0).
+              simpl in Hhistory2.
+              destruct Hhistory2 as [HCES' Hhistory2].
+              apply HCES'.
+            }
+            2: {
+              apply hist_prop_strip_1 in Hhistory.
+              eexists. apply Hhistory.
+            }
+            destruct IH as [C' [evs' [svs' [IH1 [IH2 IH3]]]]].
             subst.
-            destruct Hhistory as [Hhistory1 Hhistory2].
-            specialize (Hhistory2 0).
-            simpl in Hhistory2.
-            destruct Hhistory2 as [HCES' Hhistory2].
-            apply HCES'.
-          }
-          2: {
-            apply hist_prop_strip_1 in Hhistory.
-            eexists. apply Hhistory.
-          }
-          destruct IH as [C' [evs' [svs' [IH1 [IH2 IH3]]]]].
-          subst.
-          (* C came from hiC  *)
-          (*assert ( hiC ⊆ C ).
-          { admit. (* eapply hist_prop_subseteq. exact Hhistory.*) }
-          *)
-          eapply IHhistory with (C := hiC).
-          { shelve. }
-          { shelve. }
-          { exact Hnboundp. }
-          { pose proof (Htmp := HeqhiCp).
-            assert(H: remove_bound_evars (remove_bound_svars hiC) ⊆ remove_bound_evars (remove_bound_svars C)).
-            { admit. (*hist_prop_subseteq. exact Hhistory*) }
-            assert (Htmp2: (remove_bound_evars (remove_bound_svars hiC)) !! p = Some (to_NamedPattern2' p C' evs' svs').1.1.1).
-            {
-              unfold remove_bound_evars.
-              rewrite map_filter_lookup_Some.
-              split.
-              2: { unfold is_bound_evar_entry. simpl. intros HContra. apply Hnboundp.
-                apply bound_evar_is_bound_var. exact HContra.
+            (* C came from hiC  *)
+            (*assert ( hiC ⊆ C ).
+            { admit. (* eapply hist_prop_subseteq. exact Hhistory.*) }
+            *)
+            eapply IHhistory with (C := hiC).
+            { shelve. }
+            { shelve. }
+            { exact Hnboundp. }
+            { pose proof (Htmp := HeqhiCp).
+              assert(H: remove_bound_evars (remove_bound_svars hiC) ⊆ remove_bound_evars (remove_bound_svars C)).
+              { admit. (*hist_prop_subseteq. exact Hhistory*) }
+              assert (Htmp2: (remove_bound_evars (remove_bound_svars hiC)) !! p = Some (to_NamedPattern2' p C' evs' svs').1.1.1).
+              {
+                unfold remove_bound_evars.
+                rewrite map_filter_lookup_Some.
+                split.
+                2: { unfold is_bound_evar_entry. simpl. intros HContra. apply Hnboundp.
+                  apply bound_evar_is_bound_var. exact HContra.
+                }
+                unfold remove_bound_svars.
+                rewrite map_filter_lookup_Some.
+                split.
+                2: { unfold is_bound_svar_entry. simpl. intros HContra. apply Hnboundp.
+                  apply bound_svar_is_bound_var. exact HContra.
+                }
+                exact Htmp.
               }
-              unfold remove_bound_svars.
-              rewrite map_filter_lookup_Some.
-              split.
-              2: { unfold is_bound_svar_entry. simpl. intros HContra. apply Hnboundp.
-                apply bound_svar_is_bound_var. exact HContra.
+              apply lookup_weaken with (m2 := (remove_bound_evars (remove_bound_svars C))) in Htmp2.
+              2: { exact H. }
+              assert (Hcached2: (remove_bound_evars (remove_bound_svars C)) !! p = Some np ).
+              {
+                unfold remove_bound_evars.
+                rewrite map_filter_lookup_Some.
+                split.
+                2: { unfold is_bound_evar_entry. simpl. intros HContra. apply Hnboundp.
+                  apply bound_evar_is_bound_var. exact HContra.
+                }
+                unfold remove_bound_svars.
+                rewrite map_filter_lookup_Some.
+                split.
+                2: { unfold is_bound_svar_entry. simpl. intros HContra. apply Hnboundp.
+                  apply bound_svar_is_bound_var. exact HContra.
+                }
+                exact Hcached.
               }
-              exact Htmp.
+              rewrite Htmp2 in Hcached2. inversion Hcached2. subst. exact HeqhiCp.
             }
-            apply lookup_weaken with (m2 := (remove_bound_evars (remove_bound_svars C))) in Htmp2.
-            2: { exact H. }
-            assert (Hcached2: (remove_bound_evars (remove_bound_svars C)) !! p = Some np ).
+            { apply hist_prop_strip_1 in Hhistory. exact Hhistory. }
+            Unshelve.
             {
-              unfold remove_bound_evars.
-              rewrite map_filter_lookup_Some.
-              split.
-              2: { unfold is_bound_evar_entry. simpl. intros HContra. apply Hnboundp.
-                apply bound_evar_is_bound_var. exact HContra.
-              }
-              unfold remove_bound_svars.
-              rewrite map_filter_lookup_Some.
-              split.
-              2: { unfold is_bound_svar_entry. simpl. intros HContra. apply Hnboundp.
-                apply bound_svar_is_bound_var. exact HContra.
-              }
-              exact Hcached.
+              apply hist_prop_strip_1 in Hhistory. eexists. apply Hhistory.
             }
-            rewrite Htmp2 in Hcached2. inversion Hcached2. subst. exact HeqhiCp.
+            {
+              simpl in Hhistory.
+              destruct Hhistory as [HC [Hevs [Hsvs Hhistory]]].
+              subst.
+              destruct Hhistory as [Hhistory1 Hhistory2].
+              specialize (Hhistory2 0).
+              simpl in Hhistory2.
+              destruct Hhistory2 as [HCES' Hhistory2].
+              apply HCES'.
+            }
           }
-          { apply hist_prop_strip_1 in Hhistory. exact Hhistory. }
-          Unshelve.
           {
-            apply hist_prop_strip_1 in Hhistory. eexists. apply Hhistory.
-          }
-          {
+            pose proof (Hhistory' := Hhistory).
+            apply hist_prop_strip_1 in Hhistory'.
             simpl in Hhistory.
-            destruct Hhistory as [HC [Hevs [Hsvs Hhistory]]].
-            subst.
-            destruct Hhistory as [Hhistory1 Hhistory2].
-            specialize (Hhistory2 0).
-            simpl in Hhistory2.
-            destruct Hhistory2 as [HCES' Hhistory2].
-            apply HCES'.
-          }
-        }
-        {
-          pose proof (Hhistory' := Hhistory).
-          apply hist_prop_strip_1 in Hhistory'.
-          simpl in Hhistory.
-          destruct Hhistory as [Hhistory1 [Hevs [Hsvs [Hhistory2 Hhistory3]]]].
-          specialize (Hhistory3 0). simpl in Hhistory3.
-          destruct Hhistory3 as [HCES' Hhistory3].
-          destruct a as [anormal|ain].
-          {
-            destruct Hhistory3 as [p_i [HhiCp_i [Hcont_i [Hsubp_i [Hdngl Hp_i]]]]].
-            destruct anormal as [ap [[[anp aC] aievs] aisvs]]. subst.
-            inversion Hp_i. subst ap. clear Hp_i.
-            cbn in HCES', HhiCp_i, Hcont_i, Hsubp_i, Hdngl, H1.
-            (*unfold cache_of_nhe,evs_of_nhe,svs_of_nhe,fst,snd in *.*)
-            pose proof (Hfnc := find_nested_call p_i hiC hievs hisvs aC p np HCES' Hnboundp).
-            feed specialize Hfnc.
+            destruct Hhistory as [Hhistory1 [Hevs [Hsvs [Hhistory2 Hhistory3]]]].
+            specialize (Hhistory3 0). simpl in Hhistory3.
+            destruct Hhistory3 as [HCES' Hhistory3].
+            destruct a as [anormal|ain].
             {
-              exists ((inl (hip, (hinp, hiC, hievs, hisvs)))::history).
-              apply Hhistory'.
-            }
-            { exact Hdngl. }
-            { exact Hcont_i. }
-            { exact Hsubp_i. }
-            { exact HeqhiCp. }
-            { exact Hcached. }
-            { rewrite -H1. reflexivity. }
-            apply Hfnc.
-          }
-          {
-            destruct ain as [[ainC ainE] ainS].
-            clear Hhistory2.
-            cbn in Hhistory3. cbn in HCES', Hhistory1, Hsvs, Hevs. subst ainC ainE ainS.
-            clear -Hhistory3 HeqhiCp Hcached Hnboundp. exfalso.
-            destruct Hhistory3 as [Hhistory3|Hhistory3].
-            {
-              assert (Hcached': (remove_bound_evars C) !! p = Some np).
+              destruct Hhistory3 as [p_i [HhiCp_i [Hcont_i [Hsubp_i [Hdngl Hp_i]]]]].
+              destruct anormal as [ap [[[anp aC] aievs] aisvs]]. subst.
+              inversion Hp_i. subst ap. clear Hp_i.
+              cbn in HCES', HhiCp_i, Hcont_i, Hsubp_i, Hdngl, H1.
+              (*unfold cache_of_nhe,evs_of_nhe,svs_of_nhe,fst,snd in *.*)
+              pose proof (Hfnc := find_nested_call p_i hiC hievs hisvs aC p np HCES' Hnboundp).
+              feed specialize Hfnc.
               {
-                unfold remove_bound_evars. rewrite map_filter_lookup_Some.
-                split;[exact Hcached|]. unfold is_bound_evar_entry. simpl.
-                intros Hcontra. apply Hnboundp. apply bound_evar_is_bound_var.
-                exact Hcontra.
+                exists ((inl (hip, (hinp, hiC, hievs, hisvs)))::history).
+                apply Hhistory'.
               }
-              rewrite Hhistory3 in Hcached'.
-              unfold remove_bound_evars in Hcached'.
-              rewrite map_filter_lookup_Some in Hcached'.
-              destruct Hcached' as [Hcontra _].
-              rewrite HeqhiCp in Hcontra. inversion Hcontra.
+              { exact Hdngl. }
+              { exact Hcont_i. }
+              { exact Hsubp_i. }
+              { exact HeqhiCp. }
+              { exact Hcached. }
+              { rewrite -H1. reflexivity. }
+              apply Hfnc.
             }
             {
-              assert (Hcached': (remove_bound_svars C) !! p = Some np).
+              destruct ain as [[ainC ainE] ainS].
+              clear Hhistory2.
+              cbn in Hhistory3. cbn in HCES', Hhistory1, Hsvs, Hevs. subst ainC ainE ainS.
+              clear -Hhistory3 HeqhiCp Hcached Hnboundp. exfalso.
+              destruct Hhistory3 as [Hhistory3|Hhistory3].
               {
-                unfold remove_bound_svars. rewrite map_filter_lookup_Some.
-                split;[exact Hcached|]. unfold is_bound_svar_entry. simpl.
-                intros Hcontra. apply Hnboundp. apply bound_svar_is_bound_var.
-                exact Hcontra.
+                assert (Hcached': (remove_bound_evars C) !! p = Some np).
+                {
+                  unfold remove_bound_evars. rewrite map_filter_lookup_Some.
+                  split;[exact Hcached|]. unfold is_bound_evar_entry. simpl.
+                  intros Hcontra. apply Hnboundp. apply bound_evar_is_bound_var.
+                  exact Hcontra.
+                }
+                rewrite Hhistory3 in Hcached'.
+                unfold remove_bound_evars in Hcached'.
+                rewrite map_filter_lookup_Some in Hcached'.
+                destruct Hcached' as [Hcontra _].
+                rewrite HeqhiCp in Hcontra. inversion Hcontra.
               }
-              rewrite Hhistory3 in Hcached'.
-              unfold remove_bound_svars in Hcached'.
-              rewrite map_filter_lookup_Some in Hcached'.
-              destruct Hcached' as [Hcontra _].
-              rewrite HeqhiCp in Hcontra. inversion Hcontra.
+              {
+                assert (Hcached': (remove_bound_svars C) !! p = Some np).
+                {
+                  unfold remove_bound_svars. rewrite map_filter_lookup_Some.
+                  split;[exact Hcached|]. unfold is_bound_svar_entry. simpl.
+                  intros Hcontra. apply Hnboundp. apply bound_svar_is_bound_var.
+                  exact Hcontra.
+                }
+                rewrite Hhistory3 in Hcached'.
+                unfold remove_bound_svars in Hcached'.
+                rewrite map_filter_lookup_Some in Hcached'.
+                destruct Hcached' as [Hcontra _].
+                rewrite HeqhiCp in Hcontra. inversion Hcontra.
+              }
             }
           }
-        }
         }
       }
     }


### PR DESCRIPTION
In this PR we prove the lemma
```
  Lemma cached_p_impl_called_with_p
    (C : Cache) (evs : EVarSet) (svs : SVarSet)
    (hg : History_generator C evs svs)
    (p : Pattern)
    (np : NamedPattern):
    CES_prop C evs svs ->
    ~ is_bound_var p ->
    C !! p = Some np ->
    exists (C' : Cache) (evs' : EVarSet) (svs' : SVarSet) (hgC' : History_generator C' evs' svs'),
      C' !! p = None /\ (to_NamedPattern2' p C' evs' svs').1.1.1 = np.
```
saying that if we have history of a cache, then every cached pattern ultimately came from a call to the pattern translation function (the exception are bound variables).