### PR TITLE
Model Extension Theorem: support equality and subseteq as predicates

### DIFF
--- a/matching-logic/src/Theories/Definedness_Semantics.v
+++ b/matching-logic/src/Theories/Definedness_Semantics.v
@@ -669,6 +669,36 @@ Section definedness.
     split; assumption.
   Qed.
 
+  Lemma not_equal_iff_not_interpr_same_1 : forall (M : @Model (Σ)),
+    M ⊨ᵀ theory ->
+    forall (phi1 phi2 : Pattern) (evar_val : @EVarVal (Σ) M) (svar_val : @SVarVal (Σ) M),
+      @pattern_interpretation (Σ) M evar_val svar_val (patt_equal phi1 phi2) = ∅ <->
+      @pattern_interpretation (Σ) M evar_val svar_val phi1
+      <> @pattern_interpretation (Σ) M evar_val svar_val phi2.
+  Proof.
+    intros M H phi1 phi2 evar_val svar_val.
+    rewrite -predicate_not_full_iff_empty.
+    2: { apply T_predicate_equals. apply H. }
+    rewrite equal_iff_interpr_same.
+    2: { apply H. }
+    split; intros H'; exact H'.
+  Qed.
+
+  Lemma not_subseteq_iff_not_interpr_subseteq_1 : forall (M : @Model (Σ)),
+    M ⊨ᵀ theory ->
+    forall (phi1 phi2 : Pattern) (evar_val : @EVarVal (Σ) M) (svar_val : @SVarVal (Σ) M),
+      @pattern_interpretation (Σ) M evar_val svar_val (patt_subseteq phi1 phi2) = ∅ <->
+      ~(@pattern_interpretation (Σ) M evar_val svar_val phi1)
+        ⊆ (@pattern_interpretation (Σ) M evar_val svar_val phi2).
+  Proof.
+    intros M H phi1 phi2 evar_val svar_val.
+    rewrite -predicate_not_full_iff_empty.
+    2: { apply T_predicate_subseteq. apply H. }
+    rewrite subseteq_iff_interpr_subseteq.
+    2: { apply H. }
+    split; intros H'; exact H'.
+  Qed.
+
 End definedness.
 
 

--- a/matching-logic/src/Theories/Definedness_Semantics.v
+++ b/matching-logic/src/Theories/Definedness_Semantics.v
@@ -429,6 +429,15 @@ Section definedness.
     apply T_predicate_defined.
   Qed.
 
+  Lemma T_pre_predicate_total : forall ϕ, T_pre_predicate theory (patt_total ϕ).
+  Proof.
+    intros ϕ. unfold patt_total.
+    unfold T_pre_predicate. intros M HM.
+    apply M_pre_predicate_not.
+    apply T_pre_predicate_defined.
+    exact HM.
+  Qed.
+
   Hint Resolve T_predicate_total : core.
 
   Lemma T_predicate_subseteq : forall ϕ₁ ϕ₂, T_predicate theory (patt_subseteq ϕ₁ ϕ₂).
@@ -436,11 +445,21 @@ Section definedness.
     intros ϕ₁ ϕ₂. unfold patt_subseteq. apply T_predicate_total.
   Qed.
 
+  Lemma T_pre_predicate_subseteq : forall ϕ₁ ϕ₂, T_pre_predicate theory (patt_subseteq ϕ₁ ϕ₂).
+  Proof.
+    intros ϕ₁ ϕ₂. apply T_pre_predicate_total.
+  Qed.
+
   Hint Resolve T_predicate_subseteq : core.
   
   Lemma T_predicate_equals : forall ϕ₁ ϕ₂, T_predicate theory (patt_equal ϕ₁ ϕ₂).
   Proof.
     intros ϕ₁ ϕ₂. unfold patt_equal. apply T_predicate_total.
+  Qed.
+
+  Lemma T_pre_predicate_equal : forall ϕ₁ ϕ₂, T_pre_predicate theory (patt_equal ϕ₁ ϕ₂).
+  Proof.
+    intros ϕ₁ ϕ₂. apply T_pre_predicate_total.
   Qed.
 
   Hint Resolve T_predicate_equals : core.

--- a/matching-logic/src/Theories/ModelExtension.v
+++ b/matching-logic/src/Theories/ModelExtension.v
@@ -1742,21 +1742,8 @@ Section with_syntax.
                         { lia. }
                         { assumption. }
                         { wf_auto2. }
-                        unfold lift_set.
-                        split.
-                        {
-                            split.
-                            {
-                                intros H'.
-                                congruence.
-                            }
-                            {
-                                intros H' HContra.
-                                apply H'. clear H'.
-                                inversion HContra.
-                                congruence.
-                            }
-                        }
+                        rewrite lift_set_injective.
+                        tauto.
                     }
                     {
                         (* patt_impl ψ₁ ψ₂*)

--- a/matching-logic/src/Theories/ModelExtension.v
+++ b/matching-logic/src/Theories/ModelExtension.v
@@ -339,6 +339,64 @@ Section with_syntax.
         clear -H. set_solver.
     Qed.
 
+    Lemma lift_set_injective (xs ys : propset (Domain M)) :
+        xs = ys <-> lift_set xs = lift_set ys.
+    Proof.
+        split;[congruence|].
+        intros H.
+        unfold lift_set,fmap in H.
+        with_strategy transparent [propset_fmap] unfold propset_fmap in H.
+        unfold_leibniz.
+        rewrite set_equiv_subseteq in H.
+        do 2 rewrite elem_of_subseteq in H.
+        destruct H as [H1 H2].
+        rewrite set_equiv_subseteq.
+        do 2 rewrite elem_of_subseteq.
+        split; intros x Hx.
+        {
+            specialize (H1 (lift_value x)).
+            do 2 rewrite elem_of_PropSet in H1.
+            feed specialize H1.
+            {
+                unfold lift_value.
+                exists (inl x).
+                split;[reflexivity|].
+                rewrite elem_of_PropSet.
+                exists x.
+                split;[reflexivity|].
+                apply Hx.
+            }
+            destruct H1 as [a [Ha H1]].
+            unfold lift_value in Ha.
+            inversion Ha. clear Ha. subst. 
+            rewrite elem_of_PropSet in H1.
+            destruct H1 as [a [Ha H1]].
+            inversion Ha. clear Ha. subst.
+            exact H1.
+        }
+        {
+            specialize (H2 (lift_value x)).
+            do 2 rewrite elem_of_PropSet in H2.
+            feed specialize H2.
+            {
+                unfold lift_value.
+                exists (inl x).
+                split;[reflexivity|].
+                rewrite elem_of_PropSet.
+                exists x.
+                split;[reflexivity|].
+                apply Hx.
+            }
+            destruct H2 as [a [Ha H2]].
+            unfold lift_value in Ha.
+            inversion Ha. clear Ha. subst. 
+            rewrite elem_of_PropSet in H2.
+            destruct H2 as [a [Ha H2]].
+            inversion Ha. clear Ha. subst.
+            exact H2.
+        }
+    Qed.
+
     Lemma Mext_indec :
         forall (s : symbols),
             is_not_core_symbol s ->
@@ -1672,6 +1730,33 @@ Section with_syntax.
                         2: { apply Mext_satisfies_definedness. }
                         rewrite equal_iff_interpr_same.
                         2: { apply M_def. }
+                        rewrite not_equal_iff_not_interpr_same_1.
+                        2: { apply Mext_satisfies_definedness. }
+                        rewrite not_equal_iff_not_interpr_same_1.
+                        2: { apply M_def. }
+                        rewrite IHszdata.
+                        { lia. }
+                        { assumption. }
+                        { wf_auto2. }
+                        rewrite IHszdata.
+                        { lia. }
+                        { assumption. }
+                        { wf_auto2. }
+                        unfold lift_set.
+                        split.
+                        {
+                            split.
+                            {
+                                intros H'.
+                                congruence.
+                            }
+                            {
+                                intros H' HContra.
+                                apply H'. clear H'.
+                                inversion HContra.
+                                congruence.
+                            }
+                        }
                     }
                     {
                         (* patt_impl ψ₁ ψ₂*)

--- a/matching-logic/src/Theories/ModelExtension.v
+++ b/matching-logic/src/Theories/ModelExtension.v
@@ -63,6 +63,12 @@ Section with_syntax.
         : is_SPredicate patt_bott
     | spred_def (ϕ : Pattern)
         : is_SData ϕ -> is_SPredicate (patt_defined ϕ)
+    (* note that we have to add equality and subseteq manually,
+       since they are usually defined using totality,
+       and we do not have totality in the fragment!
+     *)
+    | spred_eq (ϕ₁ ϕ₂ : Pattern)
+        : is_SData ϕ₁ -> is_SData ϕ₂ -> is_SPredicate (patt_equal ϕ₁ ϕ₂)
     | spred_imp (ϕ₁ ϕ₂ : Pattern)
         : is_SPredicate ϕ₁ -> is_SPredicate ϕ₂ -> is_SPredicate (patt_imp ϕ₁ ϕ₂)
     | spred_ex (ϕ : Pattern) (s : symbols)
@@ -477,6 +483,7 @@ Section with_syntax.
             induction HSPred.
             { apply (@M_pre_pre_predicate_impl_M_pre_predicate _ 0). apply M_pre_pre_predicate_bott. }
             { apply (@M_pre_pre_predicate_impl_M_pre_predicate _ 0). apply T_pre_predicate_defined. exact M_def. }
+            { apply (@M_pre_pre_predicate_impl_M_pre_predicate _ 0). apply T_pre_predicate_equal. exact M_def. }
             { apply M_pre_predicate_imp; assumption. }
             { 
                 unfold patt_exists_of_sort.
@@ -1336,6 +1343,7 @@ Section with_syntax.
                         }
                     }
                     {
+                        (* patt_defined ϕ *)
                         unfold patt_defined.
                         do 2 rewrite pattern_interpretation_app_simpl.
                         do 2 rewrite pattern_interpretation_sym_simpl.
@@ -1660,6 +1668,13 @@ Section with_syntax.
                         }
                     }
                     {
+                        rewrite equal_iff_interpr_same.
+                        2: { apply Mext_satisfies_definedness. }
+                        rewrite equal_iff_interpr_same.
+                        2: { apply M_def. }
+                    }
+                    {
+                        (* patt_impl ψ₁ ψ₂*)
                         do 2 rewrite pattern_interpretation_imp_simpl.
                         pose proof (IH1 := IHszpred ϕ₁ ρₑ ρₛ).
                         feed specialize IH1.


### PR DESCRIPTION
Originally I thought they were supported by the inclusion of the definedness symbol, but I was wrong.
Eq and subseteq are defined using totality, and totality is not preserved.