### PR TITLE
Refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,6 @@
 # AML-Formalization
 
 In this project we attempt to fully implement the "Applicative Matching Logic" framework in Coq, with example intances.
-The project has two parts:
-1.  A matching logic library for Coq, in which various Matching Logic theories can be defined and reasoned about.
-    (see the directory `matching-logic`)
-2.  An interactive prover / proof mode for matching logic, built inside Coq (see `prover`). This prover uses the matching logic library, and additionally provides some other features, like proof extraction into Metamath (WIP).
-
-
-
-## For users
-
-TODO lets have an example project here in this repository
 
 ## For developers
 
@@ -38,19 +28,18 @@ $ nix-shell
 $ make
 ```
 
+We currently depend on Stdpp and Equations.
+
 ### IDE setup
+
 If you have ProofGeneral or CoqIde installed, just run them inside the `nix-shell`.
 It will detect the nix-provided coq and libraries automatically.
 
 ### Structure
 
-- `MatchingLogic.Utils` - A collection of generally usefull definitions and lemmas, independent of Matching Logic.
-- `MatchingLogic.Syntax`, `MatchingLogic.Semantics`, `MatchingLogic.ProofSystem` -
-  define syntax, semantics, proof system, respectively, and its properties.
-  The user of the library is supposed to import these three.
-- `MatchingLogic.ProofMode` - a proof mode for matching logic, together with a collection with results about the proof system
-
-
+- `matching-logic` library contains a locally-nameless encoding of matching logic in Coq.
+- `examples` folder contain a set of examples about using the matching logic embedding.
+- `prover` defines a proof of concept about extracting matching logic proofs to Metamath.
 
 
 ## References

--- a/matching-logic/README.md
+++ b/matching-logic/README.md
@@ -1,0 +1,11 @@
+# A Locally-Nameless Formalization of Matching logic 
+
+This library includes an embedding of matching logic in the Coq proof system.
+
+## Structure of the source files
+
+- `utils` - A collection of generally useful definitions and lemmas, independent of matching logic:
+  - `Lattice.v` - formalization of complete lattices and Knaster-Tarski theorem.
+  - `stdpp_ext.v` - an extension to the stdpp library.
+  - 
+- `Signature.v` - describes

--- a/matching-logic/README.md
+++ b/matching-logic/README.md
@@ -10,49 +10,49 @@ All Coq source files are in the directory `src/`.
 The structure is as follows:
 
 First, we have some general utilities.
-- `Utils/` - A collection of generally useful definitions and lemmas, independent of matching logic:
-  - `Lattice.v` - formalization of complete lattices and Knaster-Tarski theorem.
-  - `stdpp_ext.v` - an extension to the stdpp library.
-  - `extralibrary.v` - generally useful lemmas and tactics
+- [`Utils/`](src/Utils/) - A collection of generally useful definitions and lemmas, independent of matching logic:
+  - [`Lattice.v`](src/Utils/Lattice.v) - formalization of complete lattices and Knaster-Tarski theorem.
+  - [`stdpp_ext.v`](src/Utils/stdpp_ext.v) - an extension to the stdpp library.
+  - [`extralibrary.v`](src/Utils/extralibrary.v) - generally useful lemmas and tactics
 
 Second, we have things related to matching logic syntax.
-- `Signature.v` - type classes representing matching logic signatures
-- `StringSignature.v` - a particular, string-based, implementation of a signature
-- `Pattern.v` - matching logic patterns and their well-formedness constraints
-- `Freshness.v` - fresh variable generation and related lemmas and tactics
-- `Substitution.v` - all kinds of substitutions and related lemmas
-- `ApplicationContext.v` - application contexts
-- `PatternContext.v` - generic, pattern-based contexts
-- `SyntacticConstruct.v` - type classes for extending the syntax and defining syntactic sugar
-- `NamedAxioms` a way how to give (parameterized) names to axioms of matching logic theories
-- `SyntaxLemmas/` - various lemmas about syntax that require reasoning about more then one component:
-  - `ApplicationCtxSubstitution.v` - lemmas combining application contexts and substitution
-  - `FreshnessApplicationCtx.v` - lemmas combining application contexts and freshness
-  - `FreshnessSubstitution.v` - lemmas combining freshness and substitutions
-  - `PatternCtxApplicationCtx.v` - lemmas about conversion between generic pattern contexts and application contexts
-- `Syntax.v` - remaining stuff about syntax
-- `DerivedOperators_Syntax.v` - syntax of basic derived operators (e.g., `and`, `nu`, ...)
-- `wftactics.v` - tactics for reasoning about well-formedness of patterns
+- [`Signature.v`](src/Signature.v) - type classes representing matching logic signatures
+- [`StringSignature.v`](src/StringSignature.v) - a particular, string-based, implementation of a signature
+- [`Pattern.v`](src/Pattern.v) - matching logic patterns and their well-formedness constraints
+- [`Freshness.v`](src/Freshness.v) - fresh variable generation and related lemmas and tactics
+- [`Substitution.v`](src/Substitution.v) - all kinds of substitutions and related lemmas
+- [`ApplicationContext.v`](src/ApplicationContext.v) - application contexts (contexts consisting only of applications)
+- [`PatternContext.v`](src/PatternContext.v) - generic, pattern-based contexts
+- [`SyntacticConstruct.v`](src/SyntacticConstruct.v) - type classes for extending the syntax and defining syntactic sugar
+- [`NamedAxioms.v`](src/NamedAxioms.v) a way how to give (parameterized) names to axioms of matching logic theories
+- [`SyntaxLemmas/`](src/SyntaxLemmas/) - various lemmas about syntax that require reasoning about more then one component:
+  - [`ApplicationCtxSubstitution.v`](src/SyntaxLemmas/ApplicationCtxSubstitution.v) - lemmas combining application contexts and substitution
+  - [`FreshnessApplicationCtx.v`](src/SyntaxLemmas/FreshnessApplicationCtx.v) - lemmas combining application contexts and freshness
+  - [`FreshnessSubstitution.v`](src/SyntaxLemmas/FreshnessSubstitution.v) - lemmas combining freshness and substitutions
+  - [`PatternCtxApplicationCtx.v`](src/SyntaxLemmas/PatternCtxApplicationCtx.v) - lemmas about conversion between generic pattern contexts and application contexts
+- [`Syntax.v`](src/Syntax.v) - remaining stuff about syntax
+- [`DerivedOperators_Syntax.v`](src/DerivedOperators_Syntax.v) - syntax of basic derived operators (e.g., `and`, `nu`, ...)
+- [`wftactics.v`](src/wftactics.v) - tactics for reasoning about well-formedness of patterns
 
 Third, we have things related to matching logic semantics.
-- `Semantics.v` - definitions of models and semantics
-- `PrePredicate` - helper definitions and lemmas for reasoning about predicate patterns
-- `monotonic.v` - a proof that well-formed patterns give rise to monotonic functions; important for `mu`
-- `FixpointReasoning.v` - additional content on reasoning about the semantics of fixpoint patterns
-- `ModelIsomorphism.v` - definition of model isomorphisms; proof that model isomorphism preserves the semantics of patterns
-
+- [`Semantics.v`](src/Semantics.v) - definitions of models and semantics
+- [`DerivedOperators_Semantics.v`](src/DerivedOperators_Semantics.v) - semantics of derived operators
+- [`PrePredicate.v`](src/PrePredicate.v) - helper definitions and lemmas for reasoning about predicate patterns
+- [`monotonic.v`](src/monotonic.v) - a proof that well-formed patterns give rise to monotonic functions; important for `mu`
+- [`FixpointReasoning.v`](src/FixpointReasoning.v) - additional content on reasoning about the semantics of fixpoint patterns
+- [`ModelIsomorphism.v`](src/ModelIsomorphism.v) - definition of model isomorphisms; proof that model isomorphism preserves the semantics of patterns
 
 Fourth, things related to matching logic proof system.
-- `ProofSystem.v` - the definition of the proof system and its basic properties
-- `ProofSystemSoundness.v` - soundness of the proof system, connecting it with the semantics
-- `ProofMode.v` - support for formal reasoning using the proof system
+- [`ProofSystem.v`](src/ProofSystem.v) - the definition of the proof system and its basic properties
+- [`ProofSystemSoundness.v`](src/ProofSystemSoundness.v) - soundness of the proof system, connecting it with the semantics
+- [`ProofMode.v`](src/ProofMode.v) - support for formal reasoning using the proof system
 
 Fifth, matching logic theories.
-- `theories/`
-  - `Definedness_Syntax.v` - theory of definedness, totality, equality, inclusion, membership - syntax and axioms
-  - `Definedness_Semantics.v` - lemmas about semantics of the above
-  - `Definedness_ProofSystem.v` - proofs using the matching logic proof system about definedness and related notions
-  - `Sorts_Syntax.v` - definition of syntax for sorts and many-sorted functions and related notions
-  - `Sorts_Semantics.v` - the semantics of sorts, many-sorted functions, and related notions
-  - `Sorts_ProofSystem.v` - proof using the matching logic proof system about sorts
-  - `ModelExtension.v` - definition of the "open fragment" of matching logic; semantics of formulas from this fragment is preserved when extending the model with new elements
+- [`Theories/`](src/Theories/)
+  - [`Definedness_Syntax.v`](src/Theories/Definedness_Syntax.v) - theory of definedness, totality, equality, inclusion, membership - syntax and axioms
+  - [`Definedness_Semantics.v`](src/Theories/Definedness_Semantics.v) - lemmas about semantics of the above
+  - [`Definedness_ProofSystem.v`](src/Theories/Definedness_ProofSystem.v) - proofs using the matching logic proof system about definedness and related notions
+  - [`Sorts_Syntax.v`](src/Theories/Sorts_Syntax.v) - definition of syntax for sorts and many-sorted functions and related notions
+  - [`Sorts_Semantics.v`](src/Theories/Sorts_Semantics.v) - the semantics of sorts, many-sorted functions, and related notions
+  - [`Sorts_ProofSystem.v`](src/Theories/Sorts_ProofSystem.v) - proof using the matching logic proof system about sorts
+  - [`ModelExtension.v`](src/Theories/ModelExtension.v) - definition of the "open fragment" of matching logic; semantics of formulas from this fragment is preserved when extending the model with new elements

--- a/matching-logic/README.md
+++ b/matching-logic/README.md
@@ -1,6 +1,8 @@
-# A Locally-Nameless Formalization of Matching logic 
+# A Coq Formalization of Matching logic 
 
-This library includes an embedding of matching logic in the Coq proof system.
+This library contains an embedding of matching logic in the Coq proof system, using the locally-nameless representation.
+
+[Generated html files of the latest version.](https://harp-project.github.io/AML-Formalization/toc.html)
 
 ## Structure of the source files
 

--- a/matching-logic/README.md
+++ b/matching-logic/README.md
@@ -4,8 +4,53 @@ This library includes an embedding of matching logic in the Coq proof system.
 
 ## Structure of the source files
 
-- `utils` - A collection of generally useful definitions and lemmas, independent of matching logic:
+All Coq source files are in the directory `src/`.
+The structure is as follows:
+
+First, we have some general utilities.
+- `Utils/` - A collection of generally useful definitions and lemmas, independent of matching logic:
   - `Lattice.v` - formalization of complete lattices and Knaster-Tarski theorem.
   - `stdpp_ext.v` - an extension to the stdpp library.
-  - 
-- `Signature.v` - describes
+  - `extralibrary.v` - generally useful lemmas and tactics
+
+Second, we have things related to matching logic syntax.
+- `Signature.v` - type classes representing matching logic signatures
+- `StringSignature.v` - a particular, string-based, implementation of a signature
+- `Pattern.v` - matching logic patterns and their well-formedness constraints
+- `Freshness.v` - fresh variable generation and related lemmas and tactics
+- `Substitution.v` - all kinds of substitutions and related lemmas
+- `ApplicationContext.v` - application contexts
+- `PatternContext.v` - generic, pattern-based contexts
+- `SyntacticConstruct.v` - type classes for extending the syntax and defining syntactic sugar
+- `NamedAxioms` a way how to give (parameterized) names to axioms of matching logic theories
+- `SyntaxLemmas/` - various lemmas about syntax that require reasoning about more then one component:
+  - `ApplicationCtxSubstitution.v` - lemmas combining application contexts and substitution
+  - `FreshnessApplicationCtx.v` - lemmas combining application contexts and freshness
+  - `FreshnessSubstitution.v` - lemmas combining freshness and substitutions
+  - `PatternCtxApplicationCtx.v` - lemmas about conversion between generic pattern contexts and application contexts
+- `Syntax.v` - remaining stuff about syntax
+- `DerivedOperators_Syntax.v` - syntax of basic derived operators (e.g., `and`, `nu`, ...)
+- `wftactics.v` - tactics for reasoning about well-formedness of patterns
+
+Third, we have things related to matching logic semantics.
+- `Semantics.v` - definitions of models and semantics
+- `PrePredicate` - helper definitions and lemmas for reasoning about predicate patterns
+- `monotonic.v` - a proof that well-formed patterns give rise to monotonic functions; important for `mu`
+- `FixpointReasoning.v` - additional content on reasoning about the semantics of fixpoint patterns
+- `ModelIsomorphism.v` - definition of model isomorphisms; proof that model isomorphism preserves the semantics of patterns
+
+
+Fourth, things related to matching logic proof system.
+- `ProofSystem.v` - the definition of the proof system and its basic properties
+- `ProofSystemSoundness.v` - soundness of the proof system, connecting it with the semantics
+- `ProofMode.v` - support for formal reasoning using the proof system
+
+Fifth, matching logic theories.
+- `theories/`
+  - `Definedness_Syntax.v` - theory of definedness, totality, equality, inclusion, membership - syntax and axioms
+  - `Definedness_Semantics.v` - lemmas about semantics of the above
+  - `Definedness_ProofSystem.v` - proofs using the matching logic proof system about definedness and related notions
+  - `Sorts_Syntax.v` - definition of syntax for sorts and many-sorted functions and related notions
+  - `Sorts_Semantics.v` - the semantics of sorts, many-sorted functions, and related notions
+  - `Sorts_ProofSystem.v` - proof using the matching logic proof system about sorts
+  - `ModelExtension.v` - definition of the "open fragment" of matching logic; semantics of formulas from this fragment is preserved when extending the model with new elements

--- a/matching-logic/src/DerivedOperators_Semantics.v
+++ b/matching-logic/src/DerivedOperators_Semantics.v
@@ -25,86 +25,86 @@ Section with_signature.
   Section with_model.
     Context {M : Model}.
     
-    Lemma pattern_interpretation_not_simpl : forall (evar_val : EVarVal) (svar_val : SVarVal) (phi : Pattern),
-        @pattern_interpretation Σ M evar_val svar_val (patt_not phi) = ⊤ ∖ (pattern_interpretation evar_val svar_val phi).
+    Lemma eval_not_simpl : forall (evar_val : EVarVal) (svar_val : SVarVal) (phi : Pattern),
+        @eval Σ M evar_val svar_val (patt_not phi) = ⊤ ∖ (eval evar_val svar_val phi).
     Proof.
       intros. unfold patt_not.
-      rewrite -> pattern_interpretation_imp_simpl.
-      rewrite -> pattern_interpretation_bott_simpl.
+      rewrite -> eval_imp_simpl.
+      rewrite -> eval_bott_simpl.
       set_solver by fail.
     Qed.
 
-    Lemma pattern_interpretation_or_simpl : forall (evar_val : EVarVal) (svar_val : SVarVal)
+    Lemma eval_or_simpl : forall (evar_val : EVarVal) (svar_val : SVarVal)
                                                    (phi1 phi2 : Pattern),
-        pattern_interpretation evar_val svar_val (patt_or phi1 phi2)
-        = (pattern_interpretation evar_val svar_val phi1) ∪ (@pattern_interpretation _ M evar_val svar_val phi2).
+        eval evar_val svar_val (patt_or phi1 phi2)
+        = (eval evar_val svar_val phi1) ∪ (@eval _ M evar_val svar_val phi2).
     Proof.
       intros. unfold patt_or.
-      rewrite -> pattern_interpretation_imp_simpl.
-      rewrite -> pattern_interpretation_not_simpl.
-      assert (H: ⊤ ∖ (⊤ ∖ (pattern_interpretation evar_val svar_val phi1)) = pattern_interpretation evar_val svar_val phi1).
+      rewrite -> eval_imp_simpl.
+      rewrite -> eval_not_simpl.
+      assert (H: ⊤ ∖ (⊤ ∖ (eval evar_val svar_val phi1)) = eval evar_val svar_val phi1).
       { apply Compl_Compl_propset. }
       rewrite -> H. reflexivity.
     Qed.
 
-    Lemma pattern_interpretation_or_comm : forall (evar_val : EVarVal) (svar_val : SVarVal)
+    Lemma eval_or_comm : forall (evar_val : EVarVal) (svar_val : SVarVal)
                                                   (phi1 phi2 : Pattern),
-        @pattern_interpretation Σ M evar_val svar_val (patt_or phi1 phi2)
-        = pattern_interpretation evar_val svar_val (patt_or phi2 phi1).
+        @eval Σ M evar_val svar_val (patt_or phi1 phi2)
+        = eval evar_val svar_val (patt_or phi2 phi1).
     Proof.
       intros.
-      repeat rewrite -> pattern_interpretation_or_simpl.
+      repeat rewrite -> eval_or_simpl.
       set_solver by fail.
     Qed.
 
-    Lemma pattern_interpretation_and_simpl : forall (evar_val : EVarVal) (svar_val : SVarVal)
+    Lemma eval_and_simpl : forall (evar_val : EVarVal) (svar_val : SVarVal)
                                                     (phi1 phi2 : Pattern),
-        pattern_interpretation evar_val svar_val (patt_and phi1 phi2)
-        = (pattern_interpretation evar_val svar_val phi1) ∩ (@pattern_interpretation _ M evar_val svar_val phi2).
+        eval evar_val svar_val (patt_and phi1 phi2)
+        = (eval evar_val svar_val phi1) ∩ (@eval _ M evar_val svar_val phi2).
     Proof.
       intros. unfold patt_and.
-      rewrite -> pattern_interpretation_not_simpl.
-      rewrite -> pattern_interpretation_or_simpl.
-      repeat rewrite -> pattern_interpretation_not_simpl.
+      rewrite -> eval_not_simpl.
+      rewrite -> eval_or_simpl.
+      repeat rewrite -> eval_not_simpl.
       apply Compl_Union_Compl_Inters_propset_alt.
     Qed.
 
-    Lemma pattern_interpretation_and_comm : forall (evar_val : EVarVal) (svar_val : SVarVal)
+    Lemma eval_and_comm : forall (evar_val : EVarVal) (svar_val : SVarVal)
                                                    (phi1 phi2 : Pattern),
-        @pattern_interpretation Σ M evar_val svar_val (patt_and phi1 phi2)
-        = pattern_interpretation evar_val svar_val (patt_and phi2 phi1).
+        @eval Σ M evar_val svar_val (patt_and phi1 phi2)
+        = eval evar_val svar_val (patt_and phi2 phi1).
     Proof.
       intros.
-      repeat rewrite -> pattern_interpretation_and_simpl.
+      repeat rewrite -> eval_and_simpl.
       set_solver by fail.
     Qed.
 
-    Lemma pattern_interpretation_top_simpl : forall (evar_val : EVarVal) (svar_val : SVarVal),
-        @pattern_interpretation Σ M evar_val svar_val patt_top = ⊤.
+    Lemma eval_top_simpl : forall (evar_val : EVarVal) (svar_val : SVarVal),
+        @eval Σ M evar_val svar_val patt_top = ⊤.
     Proof.
       intros. unfold patt_top.
-      rewrite -> pattern_interpretation_not_simpl.
-      rewrite -> pattern_interpretation_bott_simpl.
+      rewrite -> eval_not_simpl.
+      rewrite -> eval_bott_simpl.
       set_solver by fail.
     Qed.
 
     (* TODO prove. Maybe some de-morgan laws could be helpful in proving this? *)
-    Lemma pattern_interpretation_iff_or : forall (evar_val : EVarVal) (svar_val : SVarVal)
+    Lemma eval_iff_or : forall (evar_val : EVarVal) (svar_val : SVarVal)
                                                  (phi1 phi2 : Pattern),
-        @pattern_interpretation Σ M evar_val svar_val (patt_iff phi1 phi2)
-        = pattern_interpretation evar_val svar_val (patt_or (patt_and phi1 phi2) (patt_and (patt_not phi1) (patt_not phi2))).
+        @eval Σ M evar_val svar_val (patt_iff phi1 phi2)
+        = eval evar_val svar_val (patt_or (patt_and phi1 phi2) (patt_and (patt_not phi1) (patt_not phi2))).
     Proof.
 
     Abort.
 
-    Lemma pattern_interpretation_iff_comm : forall (evar_val : EVarVal) (svar_val : SVarVal)
+    Lemma eval_iff_comm : forall (evar_val : EVarVal) (svar_val : SVarVal)
                                                    (phi1 phi2 : Pattern),
-        @pattern_interpretation Σ M evar_val svar_val (patt_iff phi1 phi2)
-        = pattern_interpretation evar_val svar_val (patt_iff phi2 phi1).
+        @eval Σ M evar_val svar_val (patt_iff phi1 phi2)
+        = eval evar_val svar_val (patt_iff phi2 phi1).
     Proof.
       intros.
       unfold patt_iff.
-      rewrite -> pattern_interpretation_and_comm.
+      rewrite -> eval_and_comm.
       reflexivity.
     Qed.
 
@@ -112,19 +112,19 @@ Section with_signature.
 
 
 
-        (* if pattern_interpretation (phi1 ---> phi2) = Full_set,
-           then pattern_interpretation phi1 subset pattern_interpretation phi2
+        (* if eval (phi1 ---> phi2) = Full_set,
+           then eval phi1 subset eval phi2
         *)
-    Lemma pattern_interpretation_iff_subset (evar_val : EVarVal) (svar_val : SVarVal)
+    Lemma eval_iff_subset (evar_val : EVarVal) (svar_val : SVarVal)
           (phi1 : Pattern) (phi2 : Pattern) :
-      pattern_interpretation evar_val svar_val (phi1 ---> phi2)%ml = ⊤ <->
-      (pattern_interpretation evar_val svar_val phi1) ⊆
-               (@pattern_interpretation _ M evar_val svar_val phi2).
+      eval evar_val svar_val (phi1 ---> phi2)%ml = ⊤ <->
+      (eval evar_val svar_val phi1) ⊆
+               (@eval _ M evar_val svar_val phi2).
     Proof.
       rewrite -> elem_of_subseteq.
-      rewrite -> pattern_interpretation_imp_simpl.
-      remember (pattern_interpretation evar_val svar_val phi1) as Xphi1.
-      remember (pattern_interpretation evar_val svar_val phi2) as Xphi2.
+      rewrite -> eval_imp_simpl.
+      remember (eval evar_val svar_val phi1) as Xphi1.
+      remember (eval evar_val svar_val phi2) as Xphi2.
       split; intros.
       - assert (x ∈ ((⊤ ∖ Xphi1) ∪ Xphi2)).
         { rewrite H. apply elem_of_top'. }
@@ -244,16 +244,16 @@ Section with_signature.
      *)
     (* ϕ is expected to have dangling evar indices *)
 
-    Lemma pattern_interpretation_set_builder ϕ ρₑ ρₛ :
+    Lemma eval_set_builder ϕ ρₑ ρₛ :
       let x := fresh_evar ϕ in
       M_predicate M (evar_open 0 x ϕ) ->
-      (pattern_interpretation ρₑ ρₛ (patt_exists (patt_and (patt_bound_evar 0) ϕ)))
+      (eval ρₑ ρₛ (patt_exists (patt_and (patt_bound_evar 0) ϕ)))
       = PropSet
-          (fun m : (Domain M) => pattern_interpretation (update_evar_val x m ρₑ) ρₛ (evar_open 0 x ϕ) = ⊤).
+          (fun m : (Domain M) => eval (update_evar_val x m ρₑ) ρₛ (evar_open 0 x ϕ) = ⊤).
     
     Proof.
       simpl. intros Hmp.
-      rewrite -> pattern_interpretation_ex_simpl.
+      rewrite -> eval_ex_simpl.
       unfold fresh_evar. simpl free_evars.
       repeat rewrite -> union_empty_r_L.
       rewrite -> union_empty_l_L.
@@ -265,7 +265,7 @@ Section with_signature.
       - unfold propset_fa_union in H.
         rewrite -> elem_of_PropSet in H.
         destruct H as [m' H].
-        rewrite -> pattern_interpretation_and_simpl in H.
+        rewrite -> eval_and_simpl in H.
         set_unfold in H.
         destruct H as [Hbound Hϕ].
         assert (Heqmm' : m = m').
@@ -273,7 +273,7 @@ Section with_signature.
           simpl in Hbound.
           rewrite -> evar_open_bound_evar in Hbound.
           case_match; try lia.
-          rewrite -> pattern_interpretation_free_evar_simpl in Hbound.
+          rewrite -> eval_free_evar_simpl in Hbound.
           apply elem_of_singleton in Hbound. subst m.
           rewrite update_evar_val_same. reflexivity.
         }
@@ -288,11 +288,11 @@ Section with_signature.
       - unfold propset_fa_union.
         apply elem_of_PropSet.
         exists m.
-        rewrite -> pattern_interpretation_and_simpl. constructor.
+        rewrite -> eval_and_simpl. constructor.
         +
           rewrite -> evar_open_bound_evar.
           case_match; try lia.
-          rewrite -> pattern_interpretation_free_evar_simpl.
+          rewrite -> eval_free_evar_simpl.
           rewrite -> update_evar_val_same. constructor.
         + rewrite -> elem_of_PropSet in H.
           rewrite -> set_eq_subseteq in H. destruct H as [H1 H2].
@@ -300,19 +300,19 @@ Section with_signature.
           specialize (H2 m). apply H2. apply elem_of_top'.
     Qed.
     
-    Lemma pattern_interpretation_forall_predicate ϕ ρₑ ρₛ :
+    Lemma eval_forall_predicate ϕ ρₑ ρₛ :
       let x := fresh_evar ϕ in
       M_predicate M (evar_open 0 x ϕ) ->
-      pattern_interpretation ρₑ ρₛ (patt_forall ϕ) = ⊤ <->
-      ∀ (m : Domain M), pattern_interpretation (update_evar_val x m ρₑ) ρₛ (evar_open 0 x ϕ) = ⊤.
+      eval ρₑ ρₛ (patt_forall ϕ) = ⊤ <->
+      ∀ (m : Domain M), eval (update_evar_val x m ρₑ) ρₛ (evar_open 0 x ϕ) = ⊤.
     Proof.
       intros x H.
       unfold patt_forall.
-      rewrite -> pattern_interpretation_not_simpl.
+      rewrite -> eval_not_simpl.
       
       assert (Hscfie : ⊤ ∖ ⊤ = @empty (propset (Domain M)) _) by apply difference_diag_L.
       rewrite -> complement_full_iff_empty.
-      rewrite -> pattern_interpretation_exists_empty.
+      rewrite -> eval_exists_empty.
       
       assert (Hfr: fresh_evar (! ϕ)%ml = fresh_evar ϕ).
       { unfold fresh_evar. apply f_equal. apply f_equal. simpl.
@@ -325,25 +325,25 @@ Section with_signature.
       split; intros H'.
       - intros m.
         specialize (H' m).
-        rewrite -> pattern_interpretation_not_simpl in H'.
+        rewrite -> eval_not_simpl in H'.
         rewrite -> complement_empty_iff_full in H'.
         exact H'.
       - intros m.
         specialize (H' m).
-        rewrite -> pattern_interpretation_not_simpl.
+        rewrite -> eval_not_simpl.
         rewrite -> H'.
         rewrite Hscfie.
         reflexivity.
     Qed.
 
 
-    Lemma pattern_interpretation_and_full ρₑ ρₛ ϕ₁ ϕ₂:
-      @pattern_interpretation Σ M ρₑ ρₛ (patt_and ϕ₁ ϕ₂) = ⊤
-      <-> (@pattern_interpretation Σ M ρₑ ρₛ ϕ₁ = ⊤
-           /\ @pattern_interpretation Σ M ρₑ ρₛ ϕ₂ = ⊤).
+    Lemma eval_and_full ρₑ ρₛ ϕ₁ ϕ₂:
+      @eval Σ M ρₑ ρₛ (patt_and ϕ₁ ϕ₂) = ⊤
+      <-> (@eval Σ M ρₑ ρₛ ϕ₁ = ⊤
+           /\ @eval Σ M ρₑ ρₛ ϕ₂ = ⊤).
     Proof.
       unfold Full.
-      rewrite -> pattern_interpretation_and_simpl.
+      rewrite -> eval_and_simpl.
       split.
       - intros H.
         apply intersection_full_iff_both_full in H.
@@ -352,13 +352,13 @@ Section with_signature.
         rewrite H1. rewrite H2. set_solver.
     Qed.
 
-    Lemma pattern_interpretation_predicate_not ρₑ ρₛ ϕ :
+    Lemma eval_predicate_not ρₑ ρₛ ϕ :
       M_predicate M ϕ ->
-      pattern_interpretation ρₑ ρₛ (patt_not ϕ) = ⊤
-      <-> @pattern_interpretation Σ M ρₑ ρₛ ϕ <> ⊤.
+      eval ρₑ ρₛ (patt_not ϕ) = ⊤
+      <-> @eval Σ M ρₑ ρₛ ϕ <> ⊤.
     Proof.
       intros Hpred.
-      rewrite pattern_interpretation_not_simpl.
+      rewrite eval_not_simpl.
       split; intros H.
       - apply predicate_not_full_iff_empty.
         { apply Hpred. }
@@ -469,28 +469,28 @@ Proof.
   apply H.
 Qed.
 
-Lemma pattern_interpretation_all_simpl
+Lemma eval_all_simpl
   {Σ : Signature}
   (M : Model)
   (ρₑ : EVarVal)
   (ρₛ : SVarVal)
   (ϕ : Pattern)
   :
-  pattern_interpretation ρₑ ρₛ (patt_forall ϕ) =
+  eval ρₑ ρₛ (patt_forall ϕ) =
   (let x := fresh_evar ϕ in
    propset_fa_intersection (λ e : Domain M,
-    @pattern_interpretation _ M (update_evar_val x e ρₑ) ρₛ (evar_open 0 x ϕ)
+    @eval _ M (update_evar_val x e ρₑ) ρₛ (evar_open 0 x ϕ)
    )
   ).
 Proof.
   unfold patt_forall.
-  rewrite pattern_interpretation_not_simpl.
-  rewrite pattern_interpretation_ex_simpl.
+  rewrite eval_not_simpl.
+  rewrite eval_ex_simpl.
   simpl.
   unfold evar_open.
   simpl_bevar_subst.
   under [fun e => _]functional_extensionality => e
-  do rewrite pattern_interpretation_not_simpl.
+  do rewrite eval_not_simpl.
   unfold propset_fa_union,propset_fa_intersection.
   remember (fresh_evar (! ϕ)%ml) as x.
   remember (fresh_evar ϕ) as x'.
@@ -500,7 +500,7 @@ Proof.
   {
     under [λ c, _]functional_extensionality => c.
     {
-      rewrite (@interpretation_fresh_evar_open Σ M ϕ x x').
+      rewrite (@eval_fresh_evar_open Σ M ϕ x x').
       {
         subst x. eapply evar_is_fresh_in_richer.
         2: { apply set_evar_fresh_is_fresh. }

--- a/matching-logic/src/FixpointReasoning.v
+++ b/matching-logic/src/FixpointReasoning.v
@@ -28,17 +28,17 @@ Import MatchingLogic.DerivedOperators_Syntax.Notations.
 Section with_signature.
   Context {Σ : Signature}.
 
-  Lemma pattern_interpretation_mu_lfp_fixpoint M ρₑ ρₛ ϕ :
+  Lemma eval_mu_lfp_fixpoint M ρₑ ρₛ ϕ :
     well_formed_positive (patt_mu ϕ) ->
     let X := fresh_svar ϕ in
     let F := Fassoc ρₑ ρₛ (svar_open 0 X ϕ) X in
-    let Sfix := @pattern_interpretation Σ M ρₑ ρₛ (patt_mu ϕ) in
+    let Sfix := @eval Σ M ρₑ ρₛ (patt_mu ϕ) in
     F Sfix = Sfix.
   Proof.
     simpl.
     remember (fresh_svar ϕ) as X.
     remember (Fassoc ρₑ ρₛ (svar_open 0 X ϕ) X) as F.
-    remember (@pattern_interpretation Σ M ρₑ ρₛ (patt_mu ϕ)) as Sfix.
+    remember (@eval Σ M ρₑ ρₛ (patt_mu ϕ)) as Sfix.
     pose (OS := PropsetOrderedSet (Domain M)).
     pose (L := PowersetLattice (Domain M)).
     intros Hwfp.
@@ -53,7 +53,7 @@ Section with_signature.
     }
 
     unfold isFixpoint in Ffix.
-    rewrite pattern_interpretation_mu_simpl in HeqSfix.
+    rewrite eval_mu_simpl in HeqSfix.
     simpl in HeqSfix.
     unfold Fassoc in HeqF.
     rewrite HeqX in HeqF.
@@ -63,18 +63,18 @@ Section with_signature.
   Qed.
 
 
-  Lemma pattern_interpretation_mu_lfp_least M ρₑ ρₛ ϕ S:
+  Lemma eval_mu_lfp_least M ρₑ ρₛ ϕ S:
     well_formed_positive (patt_mu ϕ) ->
     let X := fresh_svar ϕ in
     let F := Fassoc ρₑ ρₛ (svar_open 0 X ϕ) X in
-    let Sfix := @pattern_interpretation Σ M ρₑ ρₛ (patt_mu ϕ) in
+    let Sfix := @eval Σ M ρₑ ρₛ (patt_mu ϕ) in
     (F S) ⊆ S ->
     Sfix ⊆ S.
   Proof.
     simpl.
     remember (fresh_svar ϕ) as X.
     remember (Fassoc ρₑ ρₛ (svar_open 0 X ϕ) X) as F.
-    remember (@pattern_interpretation Σ M ρₑ ρₛ (patt_mu ϕ)) as Sfix.
+    remember (@eval Σ M ρₑ ρₛ (patt_mu ϕ)) as Sfix.
     pose (OS := PropsetOrderedSet (Domain M)).
     pose (L := PowersetLattice (Domain M)).
     intros Hwfp.
@@ -85,7 +85,7 @@ Section with_signature.
     }
 
     assert (Hlfp: LeastFixpointOf F = Sfix).
-    { subst. rewrite pattern_interpretation_mu_simpl. simpl. unfold Fassoc. reflexivity. }
+    { subst. rewrite eval_mu_simpl. simpl. unfold Fassoc. reflexivity. }
 
     intros Hincl.
 
@@ -94,47 +94,47 @@ Section with_signature.
     rewrite Hlfp in Hleast. apply Hleast.
   Qed.
 
-  Lemma pattern_interpretation_mu_if_lfp M ρₑ ρₛ ϕ Sfix :
+  Lemma eval_mu_if_lfp M ρₑ ρₛ ϕ Sfix :
     well_formed_positive (patt_mu ϕ) ->
     let X := fresh_svar ϕ in
     let F := Fassoc ρₑ ρₛ (svar_open 0 X ϕ) X in
     (F Sfix) ⊆ Sfix ->
     (∀ S, (F S) ⊆ S -> Sfix ⊆ S) ->
-    Sfix = @pattern_interpretation Σ M ρₑ ρₛ (patt_mu ϕ).
+    Sfix = @eval Σ M ρₑ ρₛ (patt_mu ϕ).
   Proof.
     intros Hwfp. simpl.
     remember (fresh_svar ϕ) as X.
     remember (Fassoc ρₑ ρₛ (svar_open 0 X ϕ) X) as F.
     intros Hprefix Hleast.
-    rewrite pattern_interpretation_mu_simpl. simpl.
+    rewrite eval_mu_simpl. simpl.
     unfold Fassoc in HeqF. rewrite HeqX in HeqF. rewrite -HeqF.
     apply LeastFixpoint_unique. { apply Hprefix. } apply Hleast.
   Qed.
 
-  Lemma pattern_interpretation_mu_lfp_iff M ρₑ ρₛ ϕ Sfix :
+  Lemma eval_mu_lfp_iff M ρₑ ρₛ ϕ Sfix :
     well_formed_positive (patt_mu ϕ) ->
     let X := fresh_svar ϕ in
     let F := Fassoc ρₑ ρₛ (svar_open 0 X ϕ) X in
     (
     (F Sfix) ⊆ Sfix /\
     (∀ S, (F S) ⊆ S -> Sfix ⊆ S)
-    ) <-> Sfix = @pattern_interpretation Σ M ρₑ ρₛ (patt_mu ϕ).
+    ) <-> Sfix = @eval Σ M ρₑ ρₛ (patt_mu ϕ).
   Proof.
     intros Hwfp. simpl.
     remember (fresh_svar ϕ) as X.
     remember (Fassoc ρₑ ρₛ (svar_open 0 X ϕ) X) as F.
-    remember (@pattern_interpretation Σ M ρₑ ρₛ (patt_mu ϕ)) as Sfix'.
+    remember (@eval Σ M ρₑ ρₛ (patt_mu ϕ)) as Sfix'.
     split.
     - intros [H1 H2]. subst.
-      auto using pattern_interpretation_mu_if_lfp.
+      auto using eval_mu_if_lfp.
     - intros H. split.
       + subst.
         match goal with
         | |- ?L ⊆ ?R => assert (H: L = R)
         end.
-        apply pattern_interpretation_mu_lfp_fixpoint. apply Hwfp.
+        apply eval_mu_lfp_fixpoint. apply Hwfp.
         rewrite H. apply reflexivity.
-      + intros S. subst. apply pattern_interpretation_mu_lfp_least. apply Hwfp.
+      + intros S. subst. apply eval_mu_lfp_least. apply Hwfp.
   Qed.
 
   (* mu X. base \/ step X *)
@@ -170,8 +170,8 @@ Section with_signature.
 
     Lemma svar_open_patt_ind_gen_body_simpl M ρₑ ρₛ X:
       svar_is_fresh_in X patt_ind_gen_body ->
-      @pattern_interpretation Σ M ρₑ ρₛ (svar_open 0 X patt_ind_gen_body)
-      = @pattern_interpretation Σ M ρₑ ρₛ (patt_or base (patt_app step (patt_free_svar X))).
+      @eval Σ M ρₑ ρₛ (svar_open 0 X patt_ind_gen_body)
+      = @eval Σ M ρₑ ρₛ (patt_or base (patt_app step (patt_free_svar X))).
     Proof.
       intros Hfr.
       unfold svar_is_fresh_in in Hfr. simpl in Hfr.
@@ -182,13 +182,13 @@ Section with_signature.
       rewrite /patt_ind_gen_body.
       unfold svar_open.
       simpl_bsvar_subst. simpl.
-      rewrite 2!pattern_interpretation_or_simpl.
+      rewrite 2!eval_or_simpl.
       unfold nest_mu. rewrite 2!nest_mu_same.
       reflexivity.
     Qed.
     
     
-    Section with_interpretation.
+    Section with_eval.
       Context (M : @Model Σ).
       Context (ρₑ : @EVarVal Σ M).
       Context (ρₛ : @SVarVal Σ M).
@@ -199,7 +199,7 @@ Section with_signature.
       (*
       Lemma svar_open_patt_ind_gen_body_assoc S:
         let X := fresh_svar patt_ind_gen_body in
-        pattern_interpretation ρₑ (update_svar_val X S ρₛ) (svar_open 0 X patt_ind_gen_body)
+        eval ρₑ (update_svar_val X S ρₛ) (svar_open 0 X patt_ind_gen_body)
         = F S.
       Proof. reflexivity.
              (*
@@ -214,24 +214,24 @@ Section with_signature.
        *)
 
       (* I can imagine this lemma to be proven automatically. *)
-      Lemma F_interp: F = λ A, (pattern_interpretation ρₑ ρₛ base)
-                                 ∪ (app_ext (pattern_interpretation ρₑ ρₛ step) A).
+      Lemma F_interp: F = λ A, (eval ρₑ ρₛ base)
+                                 ∪ (app_ext (eval ρₑ ρₛ step) A).
       Proof.
         unfold F. unfold Fassoc. apply functional_extensionality.
         intros A. rewrite svar_open_patt_ind_gen_body_simpl.
         { apply set_svar_fresh_is_fresh. }
 
-        rewrite pattern_interpretation_or_simpl.
-        rewrite pattern_interpretation_app_simpl.
-        rewrite pattern_interpretation_free_svar_simpl.
+        rewrite eval_or_simpl.
+        rewrite eval_app_simpl.
+        rewrite eval_free_svar_simpl.
         rewrite update_svar_val_same.
-        rewrite pattern_interpretation_free_svar_independent.
+        rewrite eval_free_svar_independent.
         {
           eapply svar_is_fresh_in_richer.
           2: { apply set_svar_fresh_is_fresh. }
           solve_free_svars_inclusion 5.
         }
-        rewrite pattern_interpretation_free_svar_independent.
+        rewrite eval_free_svar_independent.
         {
           eapply svar_is_fresh_in_richer.
           2: { apply set_svar_fresh_is_fresh. }
@@ -244,13 +244,13 @@ Section with_signature.
         (last l = Some m) /\
         (match l with
          | [] => False
-         | m₀::ms => (m₀ ∈ @pattern_interpretation Σ M ρₑ ρₛ base)
+         | m₀::ms => (m₀ ∈ @eval Σ M ρₑ ρₛ base)
                      /\  (@Forall _
                                   (λ (x : (Domain M) * (Domain M)),
                                    let (old, new) := x in
                                    new ∈ 
                                   app_ext
-                                    (@pattern_interpretation Σ M ρₑ ρₛ step)
+                                    (@eval Σ M ρₑ ρₛ step)
                                     {[ old ]}
                                  )
                                  (zip (m₀::ms) ms)
@@ -259,14 +259,14 @@ Section with_signature.
          end).
 
       Definition is_witnessing_sequence (m : Domain M) (l : list (Domain M)) :=
-        (∃ lst, last l = Some lst /\ lst ∈ @pattern_interpretation Σ M ρₑ ρₛ base)
+        (∃ lst, last l = Some lst /\ lst ∈ @eval Σ M ρₑ ρₛ base)
           /\
           hd_error l = Some m
           /\
           ((@Forall _ (uncurry (λ new old,
                               new ∈
                      app_ext
-                       (@pattern_interpretation Σ M ρₑ ρₛ step)
+                       (@eval Σ M ρₑ ρₛ step)
                        {[old]}
                     ))
                     (zip l (tail l))
@@ -278,7 +278,7 @@ Section with_signature.
       Lemma witnessing_sequence_middle (m : Domain M) (l : list (Domain M)) (n : nat) (m' : Domain M) :
         is_witnessing_sequence m l ->
         l !! n = Some m' ->
-        m' ∈ @pattern_interpretation Σ M ρₑ ρₛ base ->
+        m' ∈ @eval Σ M ρₑ ρₛ base ->
         is_witnessing_sequence m' (drop n l).
       Proof.
         intros [[lst [Hlst Hbase] ] [Hhd Hfa] ] Hm' Hbase'.
@@ -332,14 +332,14 @@ Section with_signature.
                            (λ new old : Domain M,
                                         new ∈
                                         app_ext
-                                          (pattern_interpretation ρₑ ρₛ step)
+                                          (eval ρₑ ρₛ step)
                                           {[old]})
                      ))
                      =  (λ x : Domain M * Domain M,
                                let (old, new) := x in
                                new ∈
                                app_ext
-                                 (pattern_interpretation ρₑ ρₛ step)
+                                 (eval ρₑ ρₛ step)
                                  {[old]})).
         
         { apply functional_extensionality. intros [x₁ x₂].
@@ -421,7 +421,7 @@ Section with_signature.
             apply Hlast.
           }
 
-          assert (Hfeq': (λ new old : Domain M, new ∈ app_ext (pattern_interpretation ρₑ ρₛ step) {[old]}) = flip (flip (λ new old : Domain M, new ∈ app_ext (pattern_interpretation ρₑ ρₛ step) {[old]}))).
+          assert (Hfeq': (λ new old : Domain M, new ∈ app_ext (eval ρₑ ρₛ step) {[old]}) = flip (flip (λ new old : Domain M, new ∈ app_ext (eval ρₑ ρₛ step) {[old]}))).
           { apply functional_extensionality. intros x0.
             apply functional_extensionality. intros x1.
             reflexivity.
@@ -435,7 +435,7 @@ Section with_signature.
 
       Lemma witnessing_sequence_extend (m m' : Domain M) (l : list (Domain M)) :
         (is_witnessing_sequence m l
-         /\ (∃ step', step' ∈ pattern_interpretation ρₑ ρₛ step /\ m' ∈ app_interp step' m)
+         /\ (∃ step', step' ∈ eval ρₑ ρₛ step /\ m' ∈ app_interp step' m)
         ) <-> (is_witnessing_sequence m' (m'::l) /\ l ≠ []).
       Proof.
         split.
@@ -488,7 +488,7 @@ Section with_signature.
       Lemma witnessing_sequence_old_extend
             (m x m' : Domain M) (l : list (Domain M)):
         (is_witnessing_sequence_old m (x::l) /\
-        ∃ step', (step' ∈ pattern_interpretation ρₑ ρₛ step /\
+        ∃ step', (step' ∈ eval ρₑ ρₛ step /\
         m' ∈ app_interp step' m)) <->
         (last (x::l) = Some m /\ is_witnessing_sequence_old m' ((x::l) ++ [m'])).
       Proof.
@@ -606,7 +606,7 @@ Section with_signature.
       Proof.
         rewrite elem_of_subseteq. intros x Hx.
         unfold F in Hx. unfold Fassoc in Hx. unfold svar_open in Hx. simpl in Hx.
-        rewrite pattern_interpretation_or_simpl in Hx.
+        rewrite eval_or_simpl in Hx.
         fold (svar_open 0 (fresh_svar patt_ind_gen_body) (nest_mu base)) in Hx.
         fold (svar_open 0 (fresh_svar patt_ind_gen_body) (nest_mu step)) in Hx.
         destruct Hx.
@@ -618,7 +618,7 @@ Section with_signature.
           { reflexivity. }
           split.
           2: { constructor. }
-          rewrite pattern_interpretation_free_svar_independent in H.
+          rewrite eval_free_svar_independent in H.
           {
             eapply svar_is_fresh_in_richer. 2: { subst. auto. }
             unfold svar_open.
@@ -627,8 +627,8 @@ Section with_signature.
           simpl. unfold svar_open in H.
           rewrite nest_mu_same in H. auto.
         - unfold Ensembles.In in H.
-          rewrite pattern_interpretation_app_simpl in H.
-          rewrite pattern_interpretation_free_svar_simpl in H.
+          rewrite eval_app_simpl in H.
+          rewrite eval_free_svar_simpl in H.
           rewrite update_svar_val_same in H.
           unfold app_ext in H.
           destruct H as [step' [m [H1 [H2 Happ] ] ] ].
@@ -643,7 +643,7 @@ Section with_signature.
           { unfold is_witnessing_sequence in Hl. destruct Hl. simpl in H. inversion H. }
 
           unfold svar_open in H1. rewrite nest_mu_same in H1.
-          rewrite pattern_interpretation_free_svar_independent in H1.
+          rewrite eval_free_svar_independent in H1.
           {
             eapply svar_is_fresh_in_richer.
             2: { apply set_svar_fresh_is_fresh. }
@@ -657,18 +657,18 @@ Section with_signature.
       Qed.
 
       Lemma interp_included_in_witnessed_elements_old:
-        (@pattern_interpretation Σ M ρₑ ρₛ patt_ind_gen) ⊆ witnessed_elements_old.
+        (@eval Σ M ρₑ ρₛ patt_ind_gen) ⊆ witnessed_elements_old.
       Proof.
-        apply pattern_interpretation_mu_lfp_least.
+        apply eval_mu_lfp_least.
         { apply patt_ind_gen_wfp. }
         apply witnessed_elements_old_prefixpoint.
       Qed.
 
-      Lemma pattern_interpretation_patt_ind_gen_fix :
-        let Sfix := pattern_interpretation ρₑ ρₛ patt_ind_gen in
+      Lemma eval_patt_ind_gen_fix :
+        let Sfix := eval ρₑ ρₛ patt_ind_gen in
         F Sfix = Sfix.
       Proof.
-        apply pattern_interpretation_mu_lfp_fixpoint.
+        apply eval_mu_lfp_fixpoint.
         apply patt_ind_gen_wfp.
       Qed.
       
@@ -677,11 +677,11 @@ Section with_signature.
         PropSet (λ m, ∃ l, is_witnessing_sequence_old m l /\ length l <= len).
 
       Lemma witnessed_elements_old_of_max_len_included_in_interp len:
-        (witnessed_elements_old_of_max_len (S len)) ⊆ (@pattern_interpretation Σ M ρₑ ρₛ patt_ind_gen).
+        (witnessed_elements_old_of_max_len (S len)) ⊆ (@eval Σ M ρₑ ρₛ patt_ind_gen).
       Proof.
         induction len.
         - unfold Included. intros m.
-          rewrite -pattern_interpretation_patt_ind_gen_fix.
+          rewrite -eval_patt_ind_gen_fix.
           unfold Ensembles.In.
           intros H.
           unfold witnessed_elements_old_of_max_len.
@@ -697,7 +697,7 @@ Section with_signature.
           destruct Hm as [Hm _].
           left. unfold Ensembles.In. apply Hm.
         - unfold Included. intros m.
-          rewrite -pattern_interpretation_patt_ind_gen_fix.
+          rewrite -eval_patt_ind_gen_fix.
           unfold Ensembles.In. intros H.
           destruct H as [l [Hwit Hlen] ].
           unfold Included in IHlen. unfold Ensembles.In in IHlen.
@@ -842,7 +842,7 @@ Section with_signature.
       Qed.
 
       Lemma witnessed_elements_old_included_in_interp:
-        witnessed_elements_old ⊆ (@pattern_interpretation Σ M ρₑ ρₛ patt_ind_gen).
+        witnessed_elements_old ⊆ (@eval Σ M ρₑ ρₛ patt_ind_gen).
       Proof.
         intros x H.
         unfold Ensembles.In in H. unfold witnessed_elements_old in H.
@@ -876,7 +876,7 @@ Section with_signature.
       Qed.
       
       Lemma patt_ind_gen_simpl:
-        @pattern_interpretation Σ M ρₑ ρₛ patt_ind_gen = witnessed_elements.
+        @eval Σ M ρₑ ρₛ patt_ind_gen = witnessed_elements.
       Proof.
         rewrite -witnessed_elements_old_eq_witnessed_elements.
         rewrite -> set_eq_subseteq.
@@ -891,8 +891,8 @@ Section with_signature.
         Hypothesis (Hstep_injective : @total_function_is_injective _ M step witnessed_elements ρₑ ρₛ).
 
         Hypothesis (Hbase_step_no_confusion
-                    : (pattern_interpretation ρₑ ρₛ base)
-                        ∩ (app_ext (pattern_interpretation ρₑ ρₛ step) witnessed_elements) = ∅).
+                    : (eval ρₑ ρₛ base)
+                        ∩ (app_ext (eval ρₑ ρₛ step) witnessed_elements) = ∅).
 
         Lemma witnessed_elements_unique_seq :
           ∀ m l₁ l₂, is_witnessing_sequence m l₁ -> is_witnessing_sequence m l₂ -> l₁ = l₂.
@@ -985,7 +985,7 @@ Section with_signature.
               
               simpl in Hma. simpl in Hmb.
 
-              assert (Ham: app_ext (pattern_interpretation ρₑ ρₛ step) {[a]} = {[m]}).
+              assert (Ham: app_ext (eval ρₑ ρₛ step) {[a]} = {[m]}).
               {
                 unfold is_total_function in Hstep_total_function.
                 pose proof (Hstep_total_function Hwita).
@@ -995,7 +995,7 @@ Section with_signature.
                 apply Ha'.
               }
 
-              assert (Hbm: app_ext (pattern_interpretation ρₑ ρₛ step) {[b]} = {[m]}).
+              assert (Hbm: app_ext (eval ρₑ ρₛ step) {[b]} = {[m]}).
               {
                 unfold is_total_function in Hstep_total_function.
                 pose proof (Hstep_total_function Hwitb).
@@ -1048,7 +1048,7 @@ Section with_signature.
             lia.
           }
 
-          (*assert (Hbasem': pattern_interpretation ρₑ ρₛ base lst).*)          
+          (*assert (Hbasem': eval ρₑ ρₛ base lst).*)          
           
           assert (~ (length l₁ > length l₂)).
           {
@@ -1110,9 +1110,9 @@ Section with_signature.
             }
             subst m'.
 
-            (* `m'=d` matches `app_ext (pattern_interpretation ρₑ ρₛ step) d0` *)
+            (* `m'=d` matches `app_ext (eval ρₑ ρₛ step) d0` *)
             assert (d ∈ app_ext
-                      (pattern_interpretation ρₑ ρₛ step)
+                      (eval ρₑ ρₛ step)
                       {[d0]}).
             {
               unfold is_witnessing_sequence in Hwsm.
@@ -1150,7 +1150,7 @@ Section with_signature.
         
       End injective.
       
-    End with_interpretation.
+    End with_eval.
 
   End inductive_generation.
 

--- a/matching-logic/src/ModelIsomorphism.v
+++ b/matching-logic/src/ModelIsomorphism.v
@@ -325,8 +325,8 @@ Theorem isomorphism_preserves_semantics
     (i : ModelIsomorphism M₁ M₂)
     :
     forall (ϕ : Pattern) (ρₑ : @EVarVal _ M₁) (ρₛ : @SVarVal _ M₁),
-        ((mi_f i) <$> (@pattern_interpretation Σ M₁ ρₑ ρₛ ϕ))
-        ≡@{propset (Domain M₂)} (@pattern_interpretation Σ M₂ ((mi_f i) ∘ ρₑ) (λ X, (mi_f i) <$> (ρₛ X)) ϕ).
+        ((mi_f i) <$> (@eval Σ M₁ ρₑ ρₛ ϕ))
+        ≡@{propset (Domain M₂)} (@eval Σ M₂ ((mi_f i) ∘ ρₑ) (λ X, (mi_f i) <$> (ρₛ X)) ϕ).
 Proof.
     intros ϕ.
     remember (size' ϕ) as sz.
@@ -341,7 +341,7 @@ Proof.
         destruct ϕ; intros ρₑ ρₛ.
         {
             (* patt_free_evar x *)
-            do 2 rewrite pattern_interpretation_free_evar_simpl.
+            do 2 rewrite eval_free_evar_simpl.
             simpl.
             unfold fmap.
             with_strategy transparent [propset_fmap] unfold propset_fmap.
@@ -349,7 +349,7 @@ Proof.
         }
         {
             (* patt_free_svar X *)
-            do 2 rewrite pattern_interpretation_free_svar_simpl.
+            do 2 rewrite eval_free_svar_simpl.
             simpl.
             unfold fmap.
             with_strategy transparent [propset_fmap] unfold propset_fmap.
@@ -357,7 +357,7 @@ Proof.
         }
         {
             (* patt_bound_evar n *)
-            do 2 rewrite pattern_interpretation_bound_evar_simpl.
+            do 2 rewrite eval_bound_evar_simpl.
             simpl.
             unfold fmap.
             with_strategy transparent [propset_fmap] unfold propset_fmap.
@@ -365,7 +365,7 @@ Proof.
         }
         {
             (* patt_bound_svar n *)
-            do 2 rewrite pattern_interpretation_bound_svar_simpl.
+            do 2 rewrite eval_bound_svar_simpl.
             simpl.
             unfold fmap.
             with_strategy transparent [propset_fmap] unfold propset_fmap.
@@ -373,12 +373,12 @@ Proof.
         }
         {
             (* patt_sym s *)
-            do 2 rewrite pattern_interpretation_sym_simpl.
+            do 2 rewrite eval_sym_simpl.
             apply mi_sym.
         }
         {
             (* patt_app ϕ1 ϕ2 *)
-            do 2 rewrite pattern_interpretation_app_simpl.
+            do 2 rewrite eval_app_simpl.
             rewrite fmap_app_ext.
             
             simpl in Hsz.
@@ -424,7 +424,7 @@ Proof.
         }
         {
             (* patt_bott *)
-            do 2 rewrite pattern_interpretation_bott_simpl.
+            do 2 rewrite eval_bott_simpl.
             unfold fmap.
             with_strategy transparent [propset_fmap] unfold propset_fmap.
             clear.
@@ -432,14 +432,14 @@ Proof.
         }
         {
             (* patt_imp ϕ1 ϕ2 *)
-            do 2 rewrite pattern_interpretation_imp_simpl.
+            do 2 rewrite eval_imp_simpl.
             simpl in Hsz.
             rewrite -IHsz.
             2: { lia. }
             rewrite -IHsz.
             2: { lia. }
-            remember (pattern_interpretation ρₑ ρₛ ϕ1) as X1.
-            remember (pattern_interpretation ρₑ ρₛ ϕ2) as X2.
+            remember (eval ρₑ ρₛ ϕ1) as X1.
+            remember (eval ρₑ ρₛ ϕ2) as X2.
             unfold fmap.
             with_strategy transparent [propset_fmap] unfold propset_fmap.
             rewrite set_equiv_subseteq.
@@ -507,7 +507,7 @@ Proof.
             }
         }
         {
-            do 2 rewrite pattern_interpretation_ex_simpl.
+            do 2 rewrite eval_ex_simpl.
             simpl.
             rewrite set_equiv_subseteq.
             split.
@@ -575,7 +575,7 @@ Proof.
         {
             (* patt_mu ϕ *)
             simpl in Hsz.
-            do 2 rewrite pattern_interpretation_mu_simpl. simpl.
+            do 2 rewrite eval_mu_simpl. simpl.
             unfold Lattice.LeastFixpointOf,Lattice.meet,Lattice.PrefixpointsOf.
             simpl.
             unfold Lattice.propset_Meet.
@@ -623,7 +623,7 @@ Proof.
                     rewrite elem_of_subseteq.
                     intros x.
                     specialize (He (mi_f i x)).
-                    remember (pattern_interpretation ρₑ
+                    remember (eval ρₑ
                     (update_svar_val (fresh_svar ϕ) (surj'_inv <$> e) ρₛ)
                     (svar_open 0 (fresh_svar ϕ) ϕ)) as PI.
                     intros Hx.

--- a/matching-logic/src/ProofSystemSoundness.v
+++ b/matching-logic/src/ProofSystemSoundness.v
@@ -26,13 +26,13 @@ Section soundness.
     (∀ axiom : Pattern,
         axiom ∈ theory
         → ∀ (evar_val : evar → Domain m) (svar_val : svar → propset (Domain m)),
-          pattern_interpretation evar_val svar_val axiom = ⊤) ->
-    pattern_interpretation evar_val svar_val ((ex , phi) $ psi ---> ex , phi $ psi)%ml = ⊤.
+          eval evar_val svar_val axiom = ⊤) ->
+    eval evar_val svar_val ((ex , phi) $ psi ---> ex , phi $ psi)%ml = ⊤.
   Proof.
     intros Hwf H H0 Hv.
-    rewrite -> pattern_interpretation_imp_simpl.
+    rewrite -> eval_imp_simpl.
 
-    remember (pattern_interpretation evar_val svar_val (patt_app (patt_exists phi) psi)) as Xex.
+    remember (eval evar_val svar_val (patt_app (patt_exists phi) psi)) as Xex.
     assert (Huxex: (⊤ ∖ Xex) ∪ Xex = ⊤).
     { clear.
       set_unfold. intros x. split; intros H. exact I.
@@ -45,7 +45,7 @@ Section soundness.
       inversion H1.
       + left. rewrite -> Huxex in H2. exact H2.
       + rewrite Huxex. apply elem_of_top'.
-    - rewrite -> pattern_interpretation_ex_simpl. simpl.
+    - rewrite -> eval_ex_simpl. simpl.
       rewrite -> elem_of_subseteq.
       intros x _.
       destruct (classic (x ∈ Xex)).
@@ -53,7 +53,7 @@ Section soundness.
       right. unfold stdpp_ext.propset_fa_union.
       rewrite -> elem_of_PropSet.
       rewrite -> HeqXex in H1.
-      rewrite -> pattern_interpretation_app_simpl, pattern_interpretation_ex_simpl in H1.
+      rewrite -> eval_app_simpl, eval_ex_simpl in H1.
       simpl in H1.
       unfold stdpp_ext.propset_fa_union in H1.
       unfold app_ext in H1.
@@ -61,11 +61,11 @@ Section soundness.
       destruct H1 as [le [re [Hunion [Hext_le Happ] ] ] ].
       rewrite -> elem_of_PropSet in Hunion.
       destruct Hunion as [c Hext_re].
-      exists c. rewrite -> evar_open_app, -> pattern_interpretation_app_simpl. unfold app_ext.
+      exists c. rewrite -> evar_open_app, -> eval_app_simpl. unfold app_ext.
       rewrite -> elem_of_PropSet.
       exists le, re.
       split.
-      + erewrite -> (@interpretation_fresh_evar_open Σ m) in Hext_re. exact Hext_re.
+      + erewrite -> (@eval_fresh_evar_open Σ m) in Hext_re. exact Hext_re.
         apply set_evar_fresh_is_fresh.
         {
           unfold fresh_evar. simpl. 
@@ -74,7 +74,7 @@ Section soundness.
         }
       + unfold well_formed,well_formed_closed in *. simpl in *.
         destruct_and!.
-        erewrite -> pattern_interpretation_free_evar_independent.
+        erewrite -> eval_free_evar_independent.
         erewrite -> evar_open_closed.
         split.
         2: { exact Happ. }
@@ -97,13 +97,13 @@ Section soundness.
     (∀ axiom : Pattern,
         axiom ∈ theory
         → ∀ (evar_val : evar → Domain m) (svar_val : svar → propset (Domain m)),
-          pattern_interpretation evar_val svar_val axiom = ⊤) ->
-    pattern_interpretation evar_val svar_val (psi $ (ex , phi) ---> ex , psi $ phi)%ml = ⊤.
+          eval evar_val svar_val axiom = ⊤) ->
+    eval evar_val svar_val (psi $ (ex , phi) ---> ex , psi $ phi)%ml = ⊤.
   Proof.
     intros Hwf H H0 Hv.
-    rewrite -> pattern_interpretation_imp_simpl.
+    rewrite -> eval_imp_simpl.
 
-    remember (pattern_interpretation evar_val svar_val (patt_app psi (patt_exists phi))) as Xex.
+    remember (eval evar_val svar_val (patt_app psi (patt_exists phi))) as Xex.
     assert (Huxex: (⊤ ∖ Xex) ∪ Xex = ⊤).
     { clear.
       set_unfold. intros x. split; intros H. exact I.
@@ -114,7 +114,7 @@ Section soundness.
     - rewrite <- Huxex.
       rewrite -> elem_of_subseteq. intros x H1.
       rewrite Huxex. apply elem_of_top'.
-    - rewrite -> pattern_interpretation_ex_simpl. simpl.
+    - rewrite -> eval_ex_simpl. simpl.
       rewrite -> elem_of_subseteq.
       intros x _.
       destruct (classic (x ∈ Xex)).
@@ -122,7 +122,7 @@ Section soundness.
       right. unfold stdpp_ext.propset_fa_union.
       rewrite -> elem_of_PropSet.
       rewrite -> HeqXex in H1.
-      rewrite -> pattern_interpretation_app_simpl, pattern_interpretation_ex_simpl in H1.
+      rewrite -> eval_app_simpl, eval_ex_simpl in H1.
       simpl in H1.
       unfold stdpp_ext.propset_fa_union in H1.
       unfold app_ext in H1.
@@ -131,11 +131,11 @@ Section soundness.
       rewrite -> elem_of_PropSet in Hunion.
       destruct Hunion as [c Hext_re].
 
-      exists c. rewrite -> evar_open_app, -> pattern_interpretation_app_simpl. unfold app_ext.
+      exists c. rewrite -> evar_open_app, -> eval_app_simpl. unfold app_ext.
       exists le, re.
       split.
       + erewrite -> evar_open_closed.
-        erewrite -> pattern_interpretation_free_evar_independent. exact Hext_le.
+        erewrite -> eval_free_evar_independent. exact Hext_le.
         unfold well_formed in H0.
         apply andb_true_iff in H0.
         destruct H0. 
@@ -148,7 +148,7 @@ Section soundness.
         destruct_and!.
         assumption.
       + split; try assumption.
-        erewrite -> (@interpretation_fresh_evar_open Σ m) in Hext_re. exact Hext_re.
+        erewrite -> (@eval_fresh_evar_open Σ m) in Hext_re. exact Hext_re.
         apply set_evar_fresh_is_fresh.
         {
           pose(@set_evar_fresh_is_fresh' Σ (free_evars psi ∪ free_evars phi)).
@@ -160,13 +160,13 @@ Section soundness.
 Lemma proof_rule_set_var_subst_sound {m : Model}: ∀ phi psi,
   well_formed_closed phi → well_formed psi →
   (∀ (evar_val : evar → Domain m) (svar_val : svar → propset (Domain m)),
-      pattern_interpretation evar_val svar_val phi = Full)
+      eval evar_val svar_val phi = Full)
   →
   ∀ X evar_val svar_val,
-    @pattern_interpretation Σ m evar_val svar_val (free_svar_subst phi psi X) = Full.
+    @eval Σ m evar_val svar_val (free_svar_subst phi psi X) = Full.
 Proof.
   intros. pose (H1 evar_val (update_svar_val X 
-                                  (pattern_interpretation evar_val svar_val psi) svar_val)).
+                                  (eval evar_val svar_val psi) svar_val)).
   erewrite <- free_svar_subst_update_exchange in e. exact e. assumption. unfold well_formed in H. assumption.
 Qed.
 
@@ -186,9 +186,9 @@ Proof.
 
   (* FOL reasoning - P1 *)
   - intros Hv evar_val svar_val.
-    repeat rewrite -> pattern_interpretation_imp_simpl.
-    remember (pattern_interpretation evar_val svar_val phi) as Xphi.
-    remember (pattern_interpretation evar_val svar_val psi) as Xpsi.
+    repeat rewrite -> eval_imp_simpl.
+    remember (eval evar_val svar_val phi) as Xphi.
+    remember (eval evar_val svar_val psi) as Xpsi.
     rewrite -> set_eq_subseteq.
     split.
     { apply top_subseteq. }
@@ -208,10 +208,10 @@ Proof.
 
   (* FOL reasoning - P2 *)
   - intros Hv evar_val svar_val.
-    repeat rewrite -> pattern_interpretation_imp_simpl.
-    remember (pattern_interpretation evar_val svar_val phi) as Xphi.
-    remember (pattern_interpretation evar_val svar_val psi) as Xpsi.
-    remember (pattern_interpretation evar_val svar_val xi) as Xxi.
+    repeat rewrite -> eval_imp_simpl.
+    remember (eval evar_val svar_val phi) as Xphi.
+    remember (eval evar_val svar_val psi) as Xpsi.
+    remember (eval evar_val svar_val xi) as Xxi.
     clear.
     apply set_eq_subseteq. split.
     { apply top_subseteq. }
@@ -221,8 +221,8 @@ Proof.
 
   (* FOL reasoning - P3 *)
   - intros Hv evar_val svar_val. 
-    repeat rewrite -> pattern_interpretation_imp_simpl; rewrite -> pattern_interpretation_bott_simpl.
-    remember (pattern_interpretation evar_val svar_val phi) as Xphi.
+    repeat rewrite -> eval_imp_simpl; rewrite -> eval_bott_simpl.
+    remember (eval evar_val svar_val phi) as Xphi.
     clear.
     apply set_eq_subseteq. split.
     { apply top_subseteq. }
@@ -233,7 +233,7 @@ Proof.
   - intros Hv evar_val svar_val.
     rename i into wfphi1. rename i0 into wfphi1impphi2.
     pose (IHHp2 wfphi1impphi2 Hv evar_val svar_val) as e.
-    rewrite -> pattern_interpretation_iff_subset in e.
+    rewrite -> eval_iff_subset in e.
     unfold Full.
     pose proof (H1 := (IHHp1 wfphi1 Hv evar_val svar_val)).
     unfold Full in H1.
@@ -243,8 +243,8 @@ Proof.
   (* Existential quantifier *)
   - intros Hv evar_val svar_val.
     simpl.
-    rewrite -> pattern_interpretation_imp_simpl.
-    rewrite -> pattern_interpretation_ex_simpl.
+    rewrite -> eval_imp_simpl.
+    rewrite -> eval_ex_simpl.
     simpl.
 
     rewrite -> element_substitution_lemma with (x := fresh_evar phi).
@@ -253,7 +253,7 @@ Proof.
     { apply top_subseteq. }
     rewrite -> elem_of_subseteq. intros x _.
     destruct (classic (x ∈ (⊤ ∖
-                              (pattern_interpretation
+                              (eval
                                  (update_evar_val (fresh_evar phi) (evar_val y) evar_val)
                                  svar_val
                                  (evar_open 0 (fresh_evar phi) phi))))).
@@ -264,7 +264,7 @@ Proof.
        rewrite -> elem_of_PropSet.
        exists (evar_val y).
        assert (x
-                 ∉ pattern_interpretation (update_evar_val (fresh_evar phi) (evar_val y) evar_val) svar_val
+                 ∉ eval (update_evar_val (fresh_evar phi) (evar_val y) evar_val) svar_val
                  (evar_open 0 (fresh_evar phi) phi) → False).
        { intros Hcontra. apply H. split. apply elem_of_top'. apply Hcontra. }
        apply NNPP in H0. exact H0.
@@ -273,7 +273,7 @@ Proof.
   (* Existential generalization *)
   - intros Hv evar_val svar_val.
     rename i into H. rename i0 into H0.
-    rewrite pattern_interpretation_iff_subset.
+    rewrite eval_iff_subset.
     assert (Hwf_imp: well_formed (phi1 ---> phi2)).
     { unfold well_formed. simpl. unfold well_formed in H, H0.
       unfold well_formed_closed. unfold well_formed_closed in H, H0.
@@ -286,28 +286,28 @@ Proof.
     }
     specialize (IHHp Hwf_imp Hv). clear Hv. clear Hwf_imp.
     assert (H2: forall evar_val svar_val,
-               (@pattern_interpretation _ m evar_val svar_val phi1)
+               (@eval _ m evar_val svar_val phi1)
                  ⊆
-                 (pattern_interpretation evar_val svar_val phi2)
+                 (eval evar_val svar_val phi2)
            ).
-    { intros. apply pattern_interpretation_iff_subset. apply IHHp. }
-    apply pattern_interpretation_subset_union
+    { intros. apply eval_iff_subset. apply IHHp. }
+    apply eval_subset_union
       with (evar_val0 := evar_val) (svar_val0 := svar_val) (x0 := x) in H2.
     rewrite -> elem_of_subseteq. intros x0 Hphi1.
     rewrite -> elem_of_subseteq in H2.
     destruct H2 with (x0 := x0).
     -- assert (Hinc:
-                              (pattern_interpretation evar_val svar_val (exists_quantify x phi1))
+                              (eval evar_val svar_val (exists_quantify x phi1))
                               ⊆
                               (propset_fa_union
-                                 (λ e : Domain m, pattern_interpretation
+                                 (λ e : Domain m, eval
                                                     (update_evar_val x e evar_val) svar_val phi1))).
-       { unfold exists_quantify. rewrite pattern_interpretation_ex_simpl. simpl.
+       { unfold exists_quantify. rewrite eval_ex_simpl. simpl.
          apply propset_fa_union_included.
          setoid_rewrite -> elem_of_subseteq.
          intros c x1 H3.
          remember (fresh_evar (evar_quantify x 0 phi1)) as x2.
-         erewrite interpretation_fresh_evar_open with (y := x) in H3.
+         erewrite eval_fresh_evar_open with (y := x) in H3.
          3: { apply evar_is_fresh_in_evar_quantify. }
          2: { subst x2. apply set_evar_fresh_is_fresh. }
          unfold well_formed in H.
@@ -324,13 +324,13 @@ Proof.
        apply Hinc. apply Hphi1.
 
     -- simpl.
-       rewrite pattern_interpretation_free_evar_independent in H1.
+       rewrite eval_free_evar_independent in H1.
        { auto. }
        apply H1.
 
   (* Propagation bottom - left *)
   - intros Hv evar_val svar_val. 
-    rewrite -> pattern_interpretation_imp_simpl, pattern_interpretation_app_simpl, pattern_interpretation_bott_simpl.
+    rewrite -> eval_imp_simpl, eval_app_simpl, eval_bott_simpl.
     unfold Full.
     rewrite right_id_L.
     rewrite -> complement_full_iff_empty.
@@ -338,19 +338,19 @@ Proof.
     
   (* Propagation bottom - right *)
   - intros Hv evar_val svar_val. 
-    rewrite -> pattern_interpretation_imp_simpl, pattern_interpretation_app_simpl, pattern_interpretation_bott_simpl.
+    rewrite -> eval_imp_simpl, eval_app_simpl, eval_bott_simpl.
     rewrite right_id_L.
     rewrite -> complement_full_iff_empty.
     apply app_ext_bot_r.
 
   (* Propagation disjunction - left *)
   - intros Hv evar_val svar_val. 
-    unfold patt_or, patt_not. repeat rewrite -> pattern_interpretation_imp_simpl.
-    repeat rewrite -> pattern_interpretation_app_simpl, pattern_interpretation_imp_simpl.
-    rewrite -> pattern_interpretation_app_simpl, pattern_interpretation_bott_simpl.
-    remember (pattern_interpretation evar_val svar_val phi1) as Xphi1.
-    remember (pattern_interpretation evar_val svar_val phi2) as Xphi2.
-    remember (pattern_interpretation evar_val svar_val psi) as Xpsi.
+    unfold patt_or, patt_not. repeat rewrite -> eval_imp_simpl.
+    repeat rewrite -> eval_app_simpl, eval_imp_simpl.
+    rewrite -> eval_app_simpl, eval_bott_simpl.
+    remember (eval evar_val svar_val phi1) as Xphi1.
+    remember (eval evar_val svar_val phi2) as Xphi2.
+    remember (eval evar_val svar_val psi) as Xpsi.
     unfold Full.
     rewrite [_ ∪ ∅]right_id_L.
     rewrite [_ ∪ ∅]right_id_L.
@@ -373,12 +373,12 @@ Proof.
 
   (* Propagation disjunction - right *)
   - intros Hv evar_val svar_val. 
-    unfold patt_or, patt_not. repeat rewrite -> pattern_interpretation_imp_simpl.
-    repeat rewrite -> pattern_interpretation_app_simpl, pattern_interpretation_imp_simpl.
-    rewrite -> pattern_interpretation_app_simpl, pattern_interpretation_bott_simpl.
-    remember (pattern_interpretation evar_val svar_val phi1) as Xphi1.
-    remember (pattern_interpretation evar_val svar_val phi2) as Xphi2.
-    remember (pattern_interpretation evar_val svar_val psi) as Xpsi.
+    unfold patt_or, patt_not. repeat rewrite -> eval_imp_simpl.
+    repeat rewrite -> eval_app_simpl, eval_imp_simpl.
+    rewrite -> eval_app_simpl, eval_bott_simpl.
+    remember (eval evar_val svar_val phi1) as Xphi1.
+    remember (eval evar_val svar_val phi2) as Xphi2.
+    remember (eval evar_val svar_val psi) as Xpsi.
     unfold Full.
     rewrite [_ ∪ ∅]right_id_L.
     rewrite [_ ∪ ∅]right_id_L.
@@ -409,10 +409,10 @@ Proof.
 
   (* Framing - left *)
   - intros Hv evar_val svar_val. 
-    rewrite -> pattern_interpretation_iff_subset.
+    rewrite -> eval_iff_subset.
     epose (IHHp _ Hv evar_val svar_val) as e.
-    rewrite -> pattern_interpretation_iff_subset in e.
-    repeat rewrite -> pattern_interpretation_app_simpl.
+    rewrite -> eval_iff_subset in e.
+    repeat rewrite -> eval_app_simpl.
     rewrite -> elem_of_subseteq. intros.
     destruct H as [le [re [Hphi1 [Hpsi Happ] ] ] ].
     unfold app_ext.
@@ -442,10 +442,10 @@ Proof.
 
   (* Framing - right *)
   - intros Hv evar_val svar_val.
-    rewrite -> pattern_interpretation_iff_subset.
+    rewrite -> eval_iff_subset.
     epose (IHHp _ Hv evar_val svar_val) as e.
-    rewrite -> pattern_interpretation_iff_subset in e.
-    repeat rewrite -> pattern_interpretation_app_simpl.
+    rewrite -> eval_iff_subset in e.
+    repeat rewrite -> eval_app_simpl.
     rewrite -> elem_of_subseteq. intros.
     destruct H as [le [re [Hphi1 [Hpsi Happ] ] ] ].
     unfold app_ext.
@@ -479,11 +479,11 @@ Proof.
 
   (* Pre-Fixpoint *)
   - intros Hv evar_val svar_val.
-    apply pattern_interpretation_iff_subset. simpl.
-    rewrite -> pattern_interpretation_mu_simpl.
+    apply eval_iff_subset. simpl.
+    rewrite -> eval_mu_simpl.
     simpl.
     remember (fun S : propset (Domain m) =>
-                pattern_interpretation evar_val
+                eval evar_val
                                        (update_svar_val (fresh_svar phi) S svar_val)
                                        (svar_open 0 (fresh_svar phi) phi)) as F.
     pose (OS := Lattice.PropsetOrderedSet (@Domain Σ m)).
@@ -508,7 +508,7 @@ Proof.
     eapply transitivity.
     2: { apply H. }
     rewrite -> HeqF.
-    epose proof (Hsimpl := pattern_interpretation_mu_simpl).
+    epose proof (Hsimpl := eval_mu_simpl).
     specialize (Hsimpl evar_val svar_val phi).
     simpl in Hsimpl. subst OS. subst L.
     rewrite <- Hsimpl.
@@ -521,10 +521,10 @@ Proof.
 
   (* Knaster-Tarski *)
   - intros Hv evar_val svar_val.
-    rewrite -> pattern_interpretation_imp_simpl. rewrite -> pattern_interpretation_mu_simpl.
+    rewrite -> eval_imp_simpl. rewrite -> eval_mu_simpl.
     simpl.
     remember (fun S : propset (Domain m) =>
-                pattern_interpretation evar_val
+                eval evar_val
                                        (update_svar_val (fresh_svar phi) S svar_val)
                                        (svar_open 0 (fresh_svar phi) phi)) as F.
 
@@ -592,7 +592,7 @@ Proof.
 
     unfold instantiate in Hp.
     apply IHHp with (evar_val:=evar_val) (svar_val:=svar_val) in Hv.
-    apply pattern_interpretation_iff_subset in Hv.
+    apply eval_iff_subset in Hv.
     
     subst F.
     rewrite <- set_substitution_lemma.
@@ -606,12 +606,12 @@ Proof.
 
   (* Existence *)
   - intros Hv evar_val svar_val.
-    assert (pattern_interpretation evar_val svar_val (ex , BoundVarSugar.b0)
-            = pattern_interpretation evar_val svar_val (ex , (BoundVarSugar.b0 and Top))).
-    { repeat rewrite pattern_interpretation_ex_simpl. simpl.
+    assert (eval evar_val svar_val (ex , BoundVarSugar.b0)
+            = eval evar_val svar_val (ex , (BoundVarSugar.b0 and Top))).
+    { repeat rewrite eval_ex_simpl. simpl.
       apply propset_fa_union_same. intros.
-      repeat rewrite pattern_interpretation_imp_simpl.
-      repeat rewrite pattern_interpretation_bott_simpl.
+      repeat rewrite eval_imp_simpl.
+      repeat rewrite eval_bott_simpl.
       rewrite [_ ∪ ∅]right_id_L.
       rewrite [_ ∪ ∅]right_id_L.
       rewrite [_ ∪ ∅]right_id_L.
@@ -626,9 +626,9 @@ Proof.
     }
     unfold Full.
     rewrite H.
-    rewrite pattern_interpretation_set_builder.
-    { unfold M_predicate. left. simpl. rewrite pattern_interpretation_imp_simpl.
-      rewrite pattern_interpretation_bott_simpl.
+    rewrite eval_set_builder.
+    { unfold M_predicate. left. simpl. rewrite eval_imp_simpl.
+      rewrite eval_bott_simpl.
       clear. set_solver.
     }
     simpl.
@@ -637,39 +637,39 @@ Proof.
     { apply top_subseteq. }
     rewrite -> elem_of_subseteq. intros x _.
     rewrite -> elem_of_PropSet.
-    rewrite pattern_interpretation_imp_simpl.
+    rewrite eval_imp_simpl.
     clear. set_solver.
     
   (* Singleton *)
   - assert (Hemp: forall (evar_val : evar -> Domain m) svar_val,
-               pattern_interpretation
+               eval
                  evar_val svar_val
                  (subst_ctx C1 (patt_free_evar x and phi)
                             and subst_ctx C2 (patt_free_evar x and (phi ---> Bot)))
                = ∅).
     { intros evar_val svar_val.
-      rewrite -> pattern_interpretation_and_simpl.
-      destruct (classic (evar_val x ∈ pattern_interpretation evar_val svar_val phi)).
-      - rewrite [(pattern_interpretation
+      rewrite -> eval_and_simpl.
+      destruct (classic (evar_val x ∈ eval evar_val svar_val phi)).
+      - rewrite [(eval
                     evar_val svar_val
                     (subst_ctx C2 (patt_free_evar x and (phi ---> Bot))))]
                 propagate_context_empty.
         2: { unfold Semantics.Empty. rewrite intersection_empty_r_L. reflexivity. }
-        rewrite pattern_interpretation_and_simpl.
-        rewrite pattern_interpretation_free_evar_simpl.
-        rewrite pattern_interpretation_imp_simpl.
-        rewrite pattern_interpretation_bott_simpl.
+        rewrite eval_and_simpl.
+        rewrite eval_free_evar_simpl.
+        rewrite eval_imp_simpl.
+        rewrite eval_bott_simpl.
         unfold Semantics.Empty.
         rewrite right_id_L.
         clear -H. set_solver.
       - rewrite propagate_context_empty.
         2: { unfold Semantics.Empty. rewrite intersection_empty_l_L. reflexivity. }
-        rewrite pattern_interpretation_and_simpl.
-        rewrite pattern_interpretation_free_evar_simpl.
+        rewrite eval_and_simpl.
+        rewrite eval_free_evar_simpl.
         clear -H. set_solver.
     }
     intros Hv evar_val svar_val.
-    rewrite pattern_interpretation_predicate_not.
+    rewrite eval_predicate_not.
     + rewrite Hemp. clear. apply empty_impl_not_full. reflexivity.
     + unfold M_predicate. right. apply Hemp.
 Qed.

--- a/matching-logic/src/Theories/Definedness_Semantics.v
+++ b/matching-logic/src/Theories/Definedness_Semantics.v
@@ -733,6 +733,155 @@ Section definedness.
 
 End definedness.
 
+From MatchingLogic Require Import StringSignature.
+
+Module equivalence_insufficient.
+
+  Inductive exampleSymbols : Set :=
+  | sym_f.
+
+  Instance exampleSymbols_eqdec : EqDecision exampleSymbols.
+  Proof. unfold EqDecision. intros x y. unfold Decision. decide equality. Defined.
+
+  #[local]
+  Instance mySignature : Signature :=
+  {| variables := StringMLVariables;
+     symbols := exampleSymbols;
+     sym_eqdec := exampleSymbols_eqdec
+  |}.
+
+  Definition examplePattern : Pattern :=
+    ex , (patt_sym sym_f $ patt_free_evar "X"%string <---> b0).
+  Print examplePattern.
+
+  Inductive exampleDomain : Set :=
+  | one | two | f.
+
+  Theorem exampleDomain_Inhabited : Inhabited exampleDomain.
+  Proof. constructor. apply one. Defined.
+
+  Definition example_app_interp (d1 d2 : exampleDomain) : propset exampleDomain :=
+  match d1, d2 with
+  | f, one => ⊤
+  | f, two => ∅
+  | _, _ => ∅
+  end.
+
+  Definition exampleModel : @Model mySignature :=
+  {|
+    Domain := exampleDomain;
+    Domain_inhabited := exampleDomain_Inhabited;
+    sym_interp := fun (x : symbols) =>
+                      {[ f ]};
+    app_interp := example_app_interp;
+  |}.
+
+  Theorem app_ext_singleton : forall x y,
+    app_ext {[x]} {[y]} ≡ @app_interp mySignature exampleModel x y.
+  Proof.
+    intros x y. unfold app_ext. set_solver.
+  Qed.
+
+  Example equiv_not_eq :
+    forall ρₑ ρₛ, @pattern_interpretation _ exampleModel ρₑ ρₛ examplePattern = ⊤.
+  Proof.
+    intros ρₑ ρₛ. unfold_leibniz.
+    rewrite set_equiv_subseteq. split.
+    apply top_subseteq.
+
+    unfold examplePattern.
+    rewrite pattern_interpretation_simpl. simpl.
+    unfold evar_open. simpl.
+    unfold propset_fa_union.
+
+    apply elem_of_subseteq. intros x _.
+    rewrite elem_of_PropSet.
+    destruct (ρₑ "X"%string) eqn:EqX.
+    * destruct x.
+      - exists one.
+        repeat rewrite pattern_interpretation_simpl. simpl.
+        rewrite update_evar_val_same.
+        rewrite app_ext_singleton.
+        rewrite update_evar_val_neq.
+        { set_solver. }
+        simpl. rewrite EqX.
+        set_unfold. intuition.
+      - exists two.
+        repeat rewrite pattern_interpretation_simpl. simpl.
+        rewrite update_evar_val_same.
+        rewrite app_ext_singleton.
+        rewrite update_evar_val_neq.
+        { set_solver. }
+        simpl. rewrite EqX.
+        set_unfold. intuition.
+      - exists f.
+        repeat rewrite pattern_interpretation_simpl. simpl.
+        rewrite update_evar_val_same.
+        rewrite app_ext_singleton.
+        rewrite update_evar_val_neq.
+        { set_solver. }
+        simpl. rewrite EqX.
+        set_unfold. intuition.
+    * destruct x.
+      - exists two.
+        repeat rewrite pattern_interpretation_simpl. simpl.
+        rewrite update_evar_val_same.
+        rewrite app_ext_singleton.
+        rewrite update_evar_val_neq.
+        { set_solver. }
+        simpl. rewrite EqX.
+        set_unfold. intuition.
+        left. intuition. apply H. intro. congruence.
+      - exists one.
+        repeat rewrite pattern_interpretation_simpl. simpl.
+        rewrite update_evar_val_same.
+        rewrite app_ext_singleton.
+        rewrite update_evar_val_neq.
+        { set_solver. }
+        simpl. rewrite EqX.
+        set_unfold. intuition.
+        left. intuition. apply H. intro. congruence.
+      - exists two.
+        repeat rewrite pattern_interpretation_simpl. simpl.
+        rewrite update_evar_val_same.
+        rewrite app_ext_singleton.
+        rewrite update_evar_val_neq.
+        { set_solver. }
+        simpl. rewrite EqX.
+        set_unfold. intuition.
+        left. intuition. apply H. intro. congruence.
+   * destruct x.
+      - exists two.
+        repeat rewrite pattern_interpretation_simpl. simpl.
+        rewrite update_evar_val_same.
+        rewrite app_ext_singleton.
+        rewrite update_evar_val_neq.
+        { set_solver. }
+        simpl. rewrite EqX.
+        set_unfold. intuition.
+        left. intuition. apply H. intro. congruence.
+      - exists one.
+        repeat rewrite pattern_interpretation_simpl. simpl.
+        rewrite update_evar_val_same.
+        rewrite app_ext_singleton.
+        rewrite update_evar_val_neq.
+        { set_solver. }
+        simpl. rewrite EqX.
+        set_unfold. intuition.
+        left. intuition. apply H. intro. congruence.
+      - exists two.
+        repeat rewrite pattern_interpretation_simpl. simpl.
+        rewrite update_evar_val_same.
+        rewrite app_ext_singleton.
+        rewrite update_evar_val_neq.
+        { set_solver. }
+        simpl. rewrite EqX.
+        set_unfold. intuition.
+        left. intuition. apply H. intro. congruence.
+  Qed.
+
+End equivalence_insufficient.
+
 
 #[export]
 Hint Resolve T_predicate_defined : core.

--- a/matching-logic/src/Theories/Definedness_Semantics.v
+++ b/matching-logic/src/Theories/Definedness_Semantics.v
@@ -51,7 +51,7 @@ Section definedness.
     forall (M : @Model Σ) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
       M ⊨ᵀ theory ->
       forall (m: Domain M),
-                 (app_ext (pattern_interpretation ρₑ ρₛ (sym definedness)) {[m]}) = ⊤.
+                 (app_ext (eval ρₑ ρₛ (sym definedness)) {[m]}) = ⊤.
   Proof.
     intros.
     unfold app_ext.
@@ -75,11 +75,11 @@ Section definedness.
     feed specialize H.
     { apply elem_of_top'. }
     unfold patt_defined in H.
-    rewrite -> pattern_interpretation_app_simpl in H.
-    rewrite -> pattern_interpretation_sym_simpl in H.
+    rewrite -> eval_app_simpl in H.
+    rewrite -> eval_sym_simpl in H.
     unfold sym.
     unfold p_x in H.
-    rewrite -> pattern_interpretation_free_evar_simpl in H.
+    rewrite -> eval_free_evar_simpl in H.
     rewrite -> Heqρₑ' in H.
     unfold update_evar_val in H. simpl in H.
     destruct (decide (ev_x = ev_x)).
@@ -89,34 +89,34 @@ Section definedness.
     destruct Hm1m2. destruct H0.
     inversion H0. clear H0. simpl in H2. subst.
     exists m1. exists m2. split. 2: { split. 2: { apply H1. } constructor. }
-    rewrite -> pattern_interpretation_sym_simpl. apply H.
+    rewrite -> eval_sym_simpl. apply H.
   Qed.
 
   Lemma definedness_not_empty_1 : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        (@pattern_interpretation Σ M ρₑ ρₛ ϕ) <> ∅ ->
-        (@pattern_interpretation Σ M ρₑ ρₛ ⌈ ϕ ⌉ ) = ⊤.
+        (@eval Σ M ρₑ ρₛ ϕ) <> ∅ ->
+        (@eval Σ M ρₑ ρₛ ⌈ ϕ ⌉ ) = ⊤.
   Proof.
     intros.
-    pose (H' := stdpp_ext.Not_Empty_Contains_Elements (pattern_interpretation ρₑ ρₛ ϕ) H0).
+    pose (H' := stdpp_ext.Not_Empty_Contains_Elements (eval ρₑ ρₛ ϕ) H0).
     destruct H'.
     unfold patt_defined.
-    rewrite -> pattern_interpretation_app_simpl.
+    rewrite -> eval_app_simpl.
     
     pose proof (H'' := @definedness_model_application M ρₑ ρₛ H x).
     unfold sym in H''.
     rewrite -> set_eq_subseteq in H''.
     destruct H'' as [_ H''].
-    assert (Hincl: {[x]} ⊆ (pattern_interpretation ρₑ ρₛ ϕ) ).
+    assert (Hincl: {[x]} ⊆ (eval ρₑ ρₛ ϕ) ).
     { rewrite -> elem_of_subseteq. intros.  inversion H2. subst. assumption. }
 
     pose proof (Hincl' := @app_ext_monotonic_r
                             Σ
                             M
-                            (pattern_interpretation ρₑ ρₛ (patt_sym (inj definedness)))
+                            (eval ρₑ ρₛ (patt_sym (inj definedness)))
                             {[x]}
-                            (pattern_interpretation ρₑ ρₛ ϕ)
+                            (eval ρₑ ρₛ ϕ)
                             Hincl
                ).
 
@@ -131,11 +131,11 @@ Section definedness.
   Lemma definedness_empty_1 : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-      @pattern_interpretation Σ M ρₑ ρₛ ϕ = ∅ ->
-      @pattern_interpretation Σ M ρₑ ρₛ ⌈ ϕ ⌉ = ∅.
+      @eval Σ M ρₑ ρₛ ϕ = ∅ ->
+      @eval Σ M ρₑ ρₛ ⌈ ϕ ⌉ = ∅.
   Proof.
     intros M H ϕ ρₑ ρₛ H0. unfold patt_defined.
-    rewrite -> pattern_interpretation_app_simpl.
+    rewrite -> eval_app_simpl.
     rewrite -> H0.
     apply app_ext_bot_r.
   Qed.
@@ -146,8 +146,8 @@ Section definedness.
   Lemma definedness_empty_2 : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ ⌈ ϕ ⌉ = ∅ ->
-        @pattern_interpretation Σ M ρₑ ρₛ ϕ = ∅.
+        @eval Σ M ρₑ ρₛ ⌈ ϕ ⌉ = ∅ ->
+        @eval Σ M ρₑ ρₛ ϕ = ∅.
   Proof.
     intros M H ϕ ρₑ ρₛ H0.
     pose proof (H1 := @empty_impl_not_full Σ M _ H0).
@@ -158,8 +158,8 @@ Section definedness.
   Lemma definedness_not_empty_2 : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ ⌈ ϕ ⌉ = ⊤ ->
-        @pattern_interpretation Σ M ρₑ ρₛ ϕ <> ∅.
+        @eval Σ M ρₑ ρₛ ⌈ ϕ ⌉ = ⊤ ->
+        @eval Σ M ρₑ ρₛ ϕ <> ∅.
   Proof.
     intros M H ϕ ρₑ ρₛ H0.
     pose proof (H1 := full_impl_not_empty H0).
@@ -169,8 +169,8 @@ Section definedness.
   Lemma definedness_not_empty_iff : forall (M : @Model Σ),
     M ⊨ᵀ theory ->
     forall (ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-      (@pattern_interpretation Σ M ρₑ ρₛ ϕ) <> ∅ <->
-      (@pattern_interpretation Σ M ρₑ ρₛ ⌈ ϕ ⌉ ) = ⊤.
+      (@eval Σ M ρₑ ρₛ ϕ) <> ∅ <->
+      (@eval Σ M ρₑ ρₛ ⌈ ϕ ⌉ ) = ⊤.
   Proof.
     intros M HM ϕ ρₑ ρₛ.
     split; intros H'.
@@ -185,12 +185,12 @@ Section definedness.
   Lemma totality_not_full : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ ϕ <> ⊤ ->
-        @pattern_interpretation Σ M ρₑ ρₛ ⌊ ϕ ⌋ = ∅.
+        @eval Σ M ρₑ ρₛ ϕ <> ⊤ ->
+        @eval Σ M ρₑ ρₛ ⌊ ϕ ⌋ = ∅.
   Proof.
     intros.
-    assert (Hnonempty : pattern_interpretation ρₑ ρₛ (patt_not ϕ) <> ∅).
-    { unfold not. unfold not in H0. intros. rewrite -> pattern_interpretation_not_simpl in H1.
+    assert (Hnonempty : eval ρₑ ρₛ (patt_not ϕ) <> ∅).
+    { unfold not. unfold not in H0. intros. rewrite -> eval_not_simpl in H1.
       apply H0. clear H0.
       rewrite -> set_eq_subseteq.
       split.
@@ -199,7 +199,7 @@ Section definedness.
       rewrite H1.
       apply top_subseteq.
     }
-    unfold patt_total. rewrite -> pattern_interpretation_not_simpl.
+    unfold patt_total. rewrite -> eval_not_simpl.
     rewrite -> complement_empty_iff_full.
 
     apply definedness_not_empty_1.
@@ -210,14 +210,14 @@ Section definedness.
   Lemma totality_full : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ ϕ = ⊤ ->
-        @pattern_interpretation Σ M ρₑ ρₛ ⌊ ϕ ⌋ = ⊤.
+        @eval Σ M ρₑ ρₛ ϕ = ⊤ ->
+        @eval Σ M ρₑ ρₛ ⌊ ϕ ⌋ = ⊤.
   Proof.
     intros M H ϕ ρₑ ρₛ H0.
     unfold patt_total.
-    rewrite -> pattern_interpretation_not_simpl.
-    assert(H1: pattern_interpretation ρₑ ρₛ (patt_not ϕ) = ∅).
-    { rewrite -> pattern_interpretation_not_simpl.
+    rewrite -> eval_not_simpl.
+    assert(H1: eval ρₑ ρₛ (patt_not ϕ) = ∅).
+    { rewrite -> eval_not_simpl.
       rewrite -> H0.
       clear. set_solver.
     }
@@ -230,8 +230,8 @@ Section definedness.
   Lemma totality_result_empty : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ ⌊ ϕ ⌋ = ∅ ->
-        @pattern_interpretation Σ M ρₑ ρₛ ϕ <> ⊤.
+        @eval Σ M ρₑ ρₛ ⌊ ϕ ⌋ = ∅ ->
+        @eval Σ M ρₑ ρₛ ϕ <> ⊤.
   Proof.
     intros M H ϕ ρₑ ρₛ H0.
     pose proof (H1 := empty_impl_not_full H0).
@@ -242,8 +242,8 @@ Section definedness.
   Lemma totality_not_full_iff : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ ϕ <> ⊤ <->
-        @pattern_interpretation Σ M ρₑ ρₛ ⌊ ϕ ⌋ = ∅.
+        @eval Σ M ρₑ ρₛ ϕ <> ⊤ <->
+        @eval Σ M ρₑ ρₛ ⌊ ϕ ⌋ = ∅.
   Proof.
     intros M HM ϕ ρₑ ρₛ.
     split; intros H'.
@@ -258,8 +258,8 @@ Section definedness.
   Lemma totality_result_nonempty : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ ⌊ ϕ ⌋ <> ∅ ->
-        @pattern_interpretation Σ M ρₑ ρₛ ϕ = ⊤.
+        @eval Σ M ρₑ ρₛ ⌊ ϕ ⌋ <> ∅ ->
+        @eval Σ M ρₑ ρₛ ϕ = ⊤.
   Proof.
     intros M H ϕ ρₑ ρₛ H0.
     pose proof (H2 := @modus_tollens _ _ (@totality_not_full M H ϕ ρₑ ρₛ) H0).
@@ -269,10 +269,10 @@ Section definedness.
   Lemma equal_iff_both_subseteq : forall (M : @Model Σ),        
       M ⊨ᵀ theory ->
       forall (ϕ1 ϕ2 : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ (ϕ1 =ml ϕ2) = ⊤ <->
+        @eval Σ M ρₑ ρₛ (ϕ1 =ml ϕ2) = ⊤ <->
         (
-          @pattern_interpretation Σ M ρₑ ρₛ (ϕ1 ⊆ml ϕ2) = ⊤ /\
-          @pattern_interpretation Σ M ρₑ ρₛ (patt_subseteq ϕ2 ϕ1) = ⊤).
+          @eval Σ M ρₑ ρₛ (ϕ1 ⊆ml ϕ2) = ⊤ /\
+          @eval Σ M ρₑ ρₛ (patt_subseteq ϕ2 ϕ1) = ⊤).
   Proof.
     intros M H ϕ1 ϕ2 ρₑ ρₛ.
     split.
@@ -281,7 +281,7 @@ Section definedness.
       apply full_impl_not_empty in H0.
       apply (@totality_result_nonempty _ H) in H0.
       unfold "<--->" in H0.
-      rewrite -> pattern_interpretation_and_simpl in H0.
+      rewrite -> eval_and_simpl in H0.
       rewrite -> intersection_full_iff_both_full in H0.
       destruct H0 as [H1 H2].
       unfold patt_subseteq.
@@ -297,7 +297,7 @@ Section definedness.
       unfold patt_equal.
       apply (@totality_full _ H).
       unfold "<--->".
-      rewrite -> pattern_interpretation_and_simpl.
+      rewrite -> eval_and_simpl.
       rewrite -> H0.
       rewrite -> H1.
       clear. set_solver.
@@ -306,9 +306,9 @@ Section definedness.
   Lemma subseteq_iff_interpr_subseteq : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ1 ϕ2 : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ (ϕ1 ⊆ml ϕ2) = ⊤ <->
-        (@pattern_interpretation Σ M ρₑ ρₛ ϕ1)
-          ⊆ (@pattern_interpretation Σ M ρₑ ρₛ ϕ2).
+        @eval Σ M ρₑ ρₛ (ϕ1 ⊆ml ϕ2) = ⊤ <->
+        (@eval Σ M ρₑ ρₛ ϕ1)
+          ⊆ (@eval Σ M ρₑ ρₛ ϕ2).
   Proof.
     intros M H ϕ1 ϕ2 ρₑ ρₛ.
     split.
@@ -316,27 +316,27 @@ Section definedness.
       unfold patt_subseteq in H0.
       apply full_impl_not_empty in H0.
       apply (@totality_result_nonempty _ H) in H0.
-      rewrite -> pattern_interpretation_imp_simpl in H0.
+      rewrite -> eval_imp_simpl in H0.
       rewrite -> set_eq_subseteq in H0.
       destruct H0 as [_ H0].
       rewrite -> elem_of_subseteq in H0.
       intros x H1. specialize (H0 x).
       feed specialize H0.
       { apply elem_of_top'. }
-      remember (pattern_interpretation ρₑ ρₛ ϕ1) as Xϕ1.
-      remember (pattern_interpretation ρₑ ρₛ ϕ2) as Xϕ2.
+      remember (eval ρₑ ρₛ ϕ1) as Xϕ1.
+      remember (eval ρₑ ρₛ ϕ2) as Xϕ2.
       clear -H0 H1.
       set_solver.
     - intros H0.
       unfold patt_subseteq.
       apply (@totality_full _ H).
-      rewrite -> pattern_interpretation_imp_simpl.
+      rewrite -> eval_imp_simpl.
       rewrite -> set_eq_subseteq.
       split.
       { apply top_subseteq. }
       rewrite -> elem_of_subseteq.
       intros x _. specialize (H0 x).
-      destruct (classic (x ∈ (pattern_interpretation ρₑ ρₛ ϕ1))).
+      destruct (classic (x ∈ (eval ρₑ ρₛ ϕ1))).
       + right. auto.
       + left. apply elem_of_compl. assumption.
   Qed.
@@ -344,9 +344,9 @@ Section definedness.
   Lemma equal_iff_interpr_same : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ1 ϕ2 : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ (ϕ1 =ml ϕ2) = ⊤ <->
-        @pattern_interpretation Σ M ρₑ ρₛ ϕ1
-        = @pattern_interpretation Σ M ρₑ ρₛ ϕ2.
+        @eval Σ M ρₑ ρₛ (ϕ1 =ml ϕ2) = ⊤ <->
+        @eval Σ M ρₑ ρₛ ϕ1
+        = @eval Σ M ρₑ ρₛ ϕ2.
   Proof.
     intros M H ϕ1 ϕ2 ρₑ ρₛ.
     split.
@@ -368,7 +368,7 @@ Section definedness.
   Lemma equal_refl : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ (patt_equal ϕ ϕ) = ⊤.
+        @eval Σ M ρₑ ρₛ (patt_equal ϕ ϕ) = ⊤.
   Proof.
     intros M H ϕ ρₑ ρₛ.
     apply (@equal_iff_interpr_same _ H).
@@ -378,8 +378,8 @@ Section definedness.
   Lemma equal_sym : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ1 ϕ2 : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ (ϕ1 =ml ϕ2) = ⊤ ->
-        @pattern_interpretation Σ M ρₑ ρₛ (patt_equal ϕ2 ϕ1) = ⊤.
+        @eval Σ M ρₑ ρₛ (ϕ1 =ml ϕ2) = ⊤ ->
+        @eval Σ M ρₑ ρₛ (patt_equal ϕ2 ϕ1) = ⊤.
   Proof.
     intros M H ϕ1 ϕ2 ρₑ ρₛ H0.
     apply (@equal_iff_interpr_same _ H).
@@ -390,9 +390,9 @@ Section definedness.
   Lemma equal_trans : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (ϕ1 ϕ2 ϕ3 : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        @pattern_interpretation Σ M ρₑ ρₛ (ϕ1 =ml ϕ2) = ⊤ ->
-        @pattern_interpretation Σ M ρₑ ρₛ (patt_equal ϕ2 ϕ3) = ⊤ ->
-        @pattern_interpretation Σ M ρₑ ρₛ (patt_equal ϕ1 ϕ3) = ⊤.
+        @eval Σ M ρₑ ρₛ (ϕ1 =ml ϕ2) = ⊤ ->
+        @eval Σ M ρₑ ρₛ (patt_equal ϕ2 ϕ3) = ⊤ ->
+        @eval Σ M ρₑ ρₛ (patt_equal ϕ1 ϕ3) = ⊤.
   Proof.
     intros M H ϕ1 ϕ2 ϕ3 ρₑ ρₛ H0 H1.
     apply (@equal_iff_interpr_same _ H).
@@ -404,8 +404,8 @@ Section definedness.
   Lemma free_evar_in_patt : forall (M : @Model Σ),
       M ⊨ᵀ theory ->
       forall (x : evar)(ϕ : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-        ((ρₑ x) ∈ (@pattern_interpretation Σ M ρₑ ρₛ ϕ)) <->
-        @pattern_interpretation Σ M ρₑ ρₛ (patt_in (patt_free_evar x) ϕ) = ⊤.
+        ((ρₑ x) ∈ (@eval Σ M ρₑ ρₛ ϕ)) <->
+        @eval Σ M ρₑ ρₛ (patt_in (patt_free_evar x) ϕ) = ⊤.
   Proof.
     intros M H x ϕ ρₑ ρₛ.
     split.
@@ -415,28 +415,28 @@ Section definedness.
       intros Contra.
       apply Contains_Elements_Not_Empty in Contra. exact Contra.
       exists (ρₑ x).
-      rewrite -> pattern_interpretation_and_simpl.
+      rewrite -> eval_and_simpl.
       split.
-      + rewrite -> pattern_interpretation_free_evar_simpl. constructor.
+      + rewrite -> eval_free_evar_simpl. constructor.
       + assumption.
     - intros H0.
       unfold patt_in in H0.
       apply (@definedness_not_empty_2 _ H) in H0.
       unfold not in H0.
-      assert (H0': (pattern_interpretation ρₑ ρₛ (patt_free_evar x and ϕ)) = ∅ -> False).
+      assert (H0': (eval ρₑ ρₛ (patt_free_evar x and ϕ)) = ∅ -> False).
       { intros Contra. apply H0. auto. }
       apply Not_Empty_Contains_Elements in H0'.
       destruct H0' as [x0 H0'].
-      rewrite -> pattern_interpretation_and_simpl in H0'.
+      rewrite -> eval_and_simpl in H0'.
       destruct H0'.
-      rewrite -> pattern_interpretation_free_evar_simpl in H1.
+      rewrite -> eval_free_evar_simpl in H1.
       inversion H1. subst. assumption.
   Qed.
   
   Lemma T_predicate_defined : forall ϕ, T_predicate theory ⌈ ϕ ⌉.
   Proof.
     intros ϕ. unfold T_predicate. intros. unfold M_predicate. intros.
-    pose proof (Hlr := classic ( pattern_interpretation ρₑ ρ ϕ = ∅ )).
+    pose proof (Hlr := classic ( eval ρₑ ρ ϕ = ∅ )).
     destruct Hlr.
     + apply definedness_empty_1 in H0. right. apply H0. apply H.
     + apply definedness_not_empty_1 in H0. left. apply H0. apply H.
@@ -520,15 +520,15 @@ Section definedness.
     apply Hm.
   Qed.
 
-  Lemma pattern_interpretation_eq_inversion_of ϕ₁ ϕ₂ M ρₑ ρₛ :
+  Lemma eval_eq_inversion_of ϕ₁ ϕ₂ M ρₑ ρₛ :
     M ⊨ᵀ theory ->
-    @pattern_interpretation Σ M ρₑ ρₛ (patt_eq_inversion_of ϕ₁ ϕ₂) = ⊤
+    @eval Σ M ρₑ ρₛ (patt_eq_inversion_of ϕ₁ ϕ₂) = ⊤
     <-> (forall m₁ m₂,
             m₂ ∈ rel_of ρₑ ρₛ ϕ₁ m₁ <-> m₁ ∈ rel_of ρₑ ρₛ ϕ₂ m₂ (* TODO make rel_of take one more parameter. *)
         ).
   Proof.
     intros Htheory.
-    rewrite pattern_interpretation_forall_predicate.
+    rewrite eval_forall_predicate.
     2: { unfold evar_open. simpl_bevar_subst. apply T_predicate_equals. apply Htheory. }
     apply all_iff_morphism. intros m₁.
     remember ((fresh_evar
@@ -541,12 +541,12 @@ Section definedness.
     rewrite equal_iff_interpr_same.
     2: { apply Htheory. }
 
-    rewrite pattern_interpretation_set_builder.
+    rewrite eval_set_builder.
     { unfold evar_open. simpl_bevar_subst. apply T_predicate_in. apply Htheory. }
 
     assert (Hpi: ∀ M ev sv ϕ rhs,
-               @pattern_interpretation _ M ev sv ϕ = rhs
-               <-> (∀ m, m ∈ @pattern_interpretation _ M ev sv ϕ <-> m ∈ rhs)).
+               @eval _ M ev sv ϕ = rhs
+               <-> (∀ m, m ∈ @eval _ M ev sv ϕ <-> m ∈ rhs)).
     { split; intros H.
       + rewrite H. auto.
       + rewrite -> set_eq_subseteq. repeat rewrite elem_of_subseteq.
@@ -558,7 +558,7 @@ Section definedness.
     }
     rewrite Hpi.
     apply all_iff_morphism. intros m₂.
-    rewrite pattern_interpretation_app_simpl.
+    rewrite eval_app_simpl.
 
     rewrite nest_ex_same.
 (*     {
@@ -585,22 +585,22 @@ Section definedness.
     repeat rewrite elem_of_PropSet.
    (*  rewrite <- free_evar_in_patt.
     2: { apply Htheory. } *)
-    rewrite pattern_interpretation_free_evar_simpl.
+    rewrite eval_free_evar_simpl.
     rewrite update_evar_val_same.
     fold (m₂ ∈ rel_of ρₑ ρₛ ϕ₁ m₁).
 
     (*rewrite simpl_evar_open.*)
     rewrite <- free_evar_in_patt; auto.
-    rewrite pattern_interpretation_app_simpl.
-    repeat rewrite pattern_interpretation_free_evar_simpl.
-    rewrite pattern_interpretation_free_evar_independent.
+    rewrite eval_app_simpl.
+    repeat rewrite eval_free_evar_simpl.
+    rewrite eval_free_evar_independent.
     {
       subst.
       eapply evar_is_fresh_in_richer'.
       2: apply set_evar_fresh_is_fresh'.
       solve_free_evars_inclusion 5.
     }
-    rewrite pattern_interpretation_free_evar_independent.
+    rewrite eval_free_evar_independent.
     {
       subst.
       eapply evar_is_fresh_in_richer'.
@@ -608,7 +608,7 @@ Section definedness.
       rewrite fuse_nest_ex_same. simpl.
       solve_free_evars_inclusion 5.
     }
-    rewrite pattern_interpretation_free_evar_independent.
+    rewrite eval_free_evar_independent.
     {
       subst.
       eapply evar_is_fresh_in_richer'.
@@ -642,8 +642,8 @@ Section definedness.
     unfold sym.
     unfold patt_defined.
     unfold p_x.
-    rewrite -> pattern_interpretation_app_simpl.
-    rewrite -> pattern_interpretation_sym_simpl.
+    rewrite -> eval_app_simpl.
+    rewrite -> eval_sym_simpl.
     rewrite -> set_eq_subseteq.
     split.
     { apply top_subseteq. }
@@ -654,7 +654,7 @@ Section definedness.
     unfold app_ext.
     exists hashdef.
     rewrite Hhashdefsym.
-    rewrite -> pattern_interpretation_free_evar_simpl.
+    rewrite -> eval_free_evar_simpl.
     exists (ρₑ ev_x).
     split.
     { constructor. }
@@ -681,9 +681,9 @@ Section definedness.
     specialize (HM ρₑ).
     specialize (HM (λ (sv : svar), ∅)).
     unfold patt_defined in HM.
-    rewrite pattern_interpretation_app_simpl in HM.
-    rewrite pattern_interpretation_sym_simpl in HM.
-    rewrite pattern_interpretation_free_evar_simpl in HM.
+    rewrite eval_app_simpl in HM.
+    rewrite eval_sym_simpl in HM.
+    rewrite eval_free_evar_simpl in HM.
     unfold app_ext in HM.
     rewrite set_eq_subseteq in HM.
     destruct HM as [_ HM].
@@ -704,9 +704,9 @@ Section definedness.
   Lemma not_equal_iff_not_interpr_same_1 : forall (M : @Model Σ),
     M ⊨ᵀ theory ->
     forall (ϕ1 ϕ2 : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-      @pattern_interpretation Σ M ρₑ ρₛ (ϕ1 =ml ϕ2) = ∅ <->
-      @pattern_interpretation Σ M ρₑ ρₛ ϕ1
-      <> @pattern_interpretation Σ M ρₑ ρₛ ϕ2.
+      @eval Σ M ρₑ ρₛ (ϕ1 =ml ϕ2) = ∅ <->
+      @eval Σ M ρₑ ρₛ ϕ1
+      <> @eval Σ M ρₑ ρₛ ϕ2.
   Proof.
     intros M H ϕ1 ϕ2 ρₑ ρₛ.
     rewrite -predicate_not_full_iff_empty.
@@ -719,9 +719,9 @@ Section definedness.
   Lemma not_subseteq_iff_not_interpr_subseteq_1 : forall (M : @Model Σ),
     M ⊨ᵀ theory ->
     forall (ϕ1 ϕ2 : Pattern) (ρₑ : @EVarVal Σ M) (ρₛ : @SVarVal Σ M),
-      @pattern_interpretation Σ M ρₑ ρₛ (ϕ1 ⊆ml ϕ2) = ∅ <->
-      ~(@pattern_interpretation Σ M ρₑ ρₛ ϕ1)
-        ⊆ (@pattern_interpretation Σ M ρₑ ρₛ ϕ2).
+      @eval Σ M ρₑ ρₛ (ϕ1 ⊆ml ϕ2) = ∅ <->
+      ~(@eval Σ M ρₑ ρₛ ϕ1)
+        ⊆ (@eval Σ M ρₑ ρₛ ϕ2).
   Proof.
     intros M H ϕ1 ϕ2 ρₑ ρₛ.
     rewrite -predicate_not_full_iff_empty.
@@ -749,10 +749,6 @@ Module equivalence_insufficient.
      symbols := exampleSymbols;
      sym_eqdec := exampleSymbols_eqdec
   |}.
-
-  Definition examplePattern : Pattern :=
-    ex , (patt_sym sym_f $ patt_free_evar "X"%string <---> b0).
-  Print examplePattern.
 
   Inductive exampleDomain : Set :=
   | one | two | f.
@@ -783,99 +779,97 @@ Module equivalence_insufficient.
   Qed.
 
   Example equiv_not_eq :
-    forall ρₑ ρₛ, @pattern_interpretation _ exampleModel ρₑ ρₛ examplePattern = ⊤.
+    forall ρₑ ρₛ, @eval _ exampleModel ρₑ ρₛ (ex , (patt_sym sym_f $ patt_free_evar "x"%string <---> b0)) = ⊤.
   Proof.
     intros ρₑ ρₛ. unfold_leibniz.
     rewrite set_equiv_subseteq. split.
     apply top_subseteq.
-
-    unfold examplePattern.
-    rewrite pattern_interpretation_simpl. simpl.
+    rewrite eval_simpl. simpl.
     unfold evar_open. simpl.
     unfold propset_fa_union.
 
     apply elem_of_subseteq. intros x _.
     rewrite elem_of_PropSet.
-    destruct (ρₑ "X"%string) eqn:EqX.
+    destruct (ρₑ "x"%string) eqn:Eqx.
     * destruct x.
       - exists one.
-        repeat rewrite pattern_interpretation_simpl. simpl.
+        repeat rewrite eval_simpl. simpl.
         rewrite update_evar_val_same.
         rewrite app_ext_singleton.
         rewrite update_evar_val_neq.
         { set_solver. }
-        simpl. rewrite EqX.
+        simpl. rewrite Eqx.
         set_unfold. intuition.
       - exists two.
-        repeat rewrite pattern_interpretation_simpl. simpl.
+        repeat rewrite eval_simpl. simpl.
         rewrite update_evar_val_same.
         rewrite app_ext_singleton.
         rewrite update_evar_val_neq.
         { set_solver. }
-        simpl. rewrite EqX.
+        simpl. rewrite Eqx.
         set_unfold. intuition.
       - exists f.
-        repeat rewrite pattern_interpretation_simpl. simpl.
+        repeat rewrite eval_simpl. simpl.
         rewrite update_evar_val_same.
         rewrite app_ext_singleton.
         rewrite update_evar_val_neq.
         { set_solver. }
-        simpl. rewrite EqX.
+        simpl. rewrite Eqx.
         set_unfold. intuition.
     * destruct x.
       - exists two.
-        repeat rewrite pattern_interpretation_simpl. simpl.
+        repeat rewrite eval_simpl. simpl.
         rewrite update_evar_val_same.
         rewrite app_ext_singleton.
         rewrite update_evar_val_neq.
         { set_solver. }
-        simpl. rewrite EqX.
+        simpl. rewrite Eqx.
         set_unfold. intuition.
         left. intuition. apply H. intro. congruence.
       - exists one.
-        repeat rewrite pattern_interpretation_simpl. simpl.
+        repeat rewrite eval_simpl. simpl.
         rewrite update_evar_val_same.
         rewrite app_ext_singleton.
         rewrite update_evar_val_neq.
         { set_solver. }
-        simpl. rewrite EqX.
+        simpl. rewrite Eqx.
         set_unfold. intuition.
         left. intuition. apply H. intro. congruence.
       - exists two.
-        repeat rewrite pattern_interpretation_simpl. simpl.
+        repeat rewrite eval_simpl. simpl.
         rewrite update_evar_val_same.
         rewrite app_ext_singleton.
         rewrite update_evar_val_neq.
         { set_solver. }
-        simpl. rewrite EqX.
+        simpl. rewrite Eqx.
         set_unfold. intuition.
         left. intuition. apply H. intro. congruence.
    * destruct x.
       - exists two.
-        repeat rewrite pattern_interpretation_simpl. simpl.
+        repeat rewrite eval_simpl. simpl.
         rewrite update_evar_val_same.
         rewrite app_ext_singleton.
         rewrite update_evar_val_neq.
         { set_solver. }
-        simpl. rewrite EqX.
+        simpl. rewrite Eqx.
         set_unfold. intuition.
         left. intuition. apply H. intro. congruence.
       - exists one.
-        repeat rewrite pattern_interpretation_simpl. simpl.
+        repeat rewrite eval_simpl. simpl.
         rewrite update_evar_val_same.
         rewrite app_ext_singleton.
         rewrite update_evar_val_neq.
         { set_solver. }
-        simpl. rewrite EqX.
+        simpl. rewrite Eqx.
         set_unfold. intuition.
         left. intuition. apply H. intro. congruence.
       - exists two.
-        repeat rewrite pattern_interpretation_simpl. simpl.
+        repeat rewrite eval_simpl. simpl.
         rewrite update_evar_val_same.
         rewrite app_ext_singleton.
         rewrite update_evar_val_neq.
         { set_solver. }
-        simpl. rewrite EqX.
+        simpl. rewrite Eqx.
         set_unfold. intuition.
         left. intuition. apply H. intro. congruence.
   Qed.

--- a/matching-logic/src/Theories/ModelExtension.v
+++ b/matching-logic/src/Theories/ModelExtension.v
@@ -433,15 +433,15 @@ Section with_syntax.
             Decision (m ∈ @Minterp_inhabitant Σ _ Mext (patt_sym s) (lift_val_e ρₑ) (lift_val_s ρₛ)).
     Proof.
         intros. unfold Minterp_inhabitant.
-        rewrite pattern_interpretation_app_simpl.
+        rewrite eval_app_simpl.
         unfold app_ext,lift_val_e,lift_val_s. simpl.
         destruct m.
         {
             right. intros HContra.
             rewrite elem_of_PropSet in HContra.
             destruct HContra as [le [re [HContra1 [HContra2 HContra3]]]].
-            rewrite pattern_interpretation_sym_simpl in HContra1.
-            rewrite pattern_interpretation_sym_simpl in HContra2.
+            rewrite eval_sym_simpl in HContra1.
+            rewrite eval_sym_simpl in HContra2.
             simpl in HContra1.
             simpl in HContra2.
             unfold new_sym_interp in HContra1, HContra2.
@@ -452,8 +452,8 @@ Section with_syntax.
             right. intros HContra.
             rewrite elem_of_PropSet in HContra.
             destruct HContra as [le [re [HContra1 [HContra2 HContra3]]]].
-            rewrite pattern_interpretation_sym_simpl in HContra1.
-            rewrite pattern_interpretation_sym_simpl in HContra2.
+            rewrite eval_sym_simpl in HContra1.
+            rewrite eval_sym_simpl in HContra2.
             simpl in HContra1.
             simpl in HContra2.
             unfold new_sym_interp in HContra1, HContra2.
@@ -465,8 +465,8 @@ Section with_syntax.
             right. intros HContra.
             rewrite elem_of_PropSet in HContra.
             destruct HContra as [le [re [HContra1 [HContra2 HContra3]]]].
-            rewrite pattern_interpretation_sym_simpl in HContra1.
-            rewrite pattern_interpretation_sym_simpl in HContra2.
+            rewrite eval_sym_simpl in HContra1.
+            rewrite eval_sym_simpl in HContra2.
             simpl in HContra1.
             simpl in HContra2.
             unfold new_sym_interp in HContra1, HContra2.
@@ -477,14 +477,14 @@ Section with_syntax.
         {
             left.
             unfold Minterp_inhabitant in Hin.
-            rewrite pattern_interpretation_app_simpl in Hin.
-            do 2 rewrite pattern_interpretation_sym_simpl in Hin.
+            rewrite eval_app_simpl in Hin.
+            do 2 rewrite eval_sym_simpl in Hin.
             unfold app_ext in Hin.
             rewrite elem_of_PropSet in Hin.
             destruct Hin as [le [re [Hinle [Hinre Hin]]]].
             rewrite elem_of_PropSet.
             
-            do 2 rewrite pattern_interpretation_sym_simpl.
+            do 2 rewrite eval_sym_simpl.
             simpl.
             unfold new_sym_interp.
             repeat case_match; subst; auto; try contradiction; try congruence;
@@ -503,13 +503,13 @@ Section with_syntax.
         {
             right.
             unfold Minterp_inhabitant in Hnotin.
-            rewrite pattern_interpretation_app_simpl in Hnotin.
-            do 2 rewrite pattern_interpretation_sym_simpl in Hnotin.
+            rewrite eval_app_simpl in Hnotin.
+            do 2 rewrite eval_sym_simpl in Hnotin.
             unfold app_ext in Hnotin.
             rewrite elem_of_PropSet in Hnotin.
             rewrite elem_of_PropSet.
             intro HContra. apply Hnotin.
-            do 2 rewrite pattern_interpretation_sym_simpl in HContra.
+            do 2 rewrite eval_sym_simpl in HContra.
             simpl in HContra. unfold new_sym_interp in HContra.
             destruct HContra as [le [re [Hinle [Hinre Hin]]]].
             
@@ -618,11 +618,11 @@ Section with_syntax.
             ρe0 ρs0
             :
             is_not_core_symbol s ->
-            @pattern_interpretation Σ Mext ρe0 ρs0 (patt_sym s) =
-            lift_set (@pattern_interpretation Σ M ρₑ ρₛ (patt_sym s)).
+            @eval Σ Mext ρe0 ρs0 (patt_sym s) =
+            lift_set (@eval Σ M ρₑ ρₛ (patt_sym s)).
         Proof.
             intros H.
-            do 2 rewrite pattern_interpretation_sym_simpl.
+            do 2 rewrite eval_sym_simpl.
             clear -H. unfold_leibniz.
             unfold is_not_core_symbol,is_core_symbol in H.
             unfold sym_interp at 1. simpl. unfold new_sym_interp.
@@ -638,8 +638,8 @@ Section with_syntax.
             ρe0 ρs0
             :
             is_not_core_symbol s ->
-            @pattern_interpretation Σ Mext ρe0 ρs0 (patt_inhabitant_set (patt_sym s))
-            = lift_set (@pattern_interpretation Σ M ρₑ ρₛ (patt_inhabitant_set (patt_sym s))).
+            @eval Σ Mext ρe0 ρs0 (patt_inhabitant_set (patt_sym s))
+            = lift_set (@eval Σ M ρₑ ρₛ (patt_inhabitant_set (patt_sym s))).
         Proof.
             intros H.
             rename H into Hnc.
@@ -647,11 +647,11 @@ Section with_syntax.
                in the proof script does nothing. *)
             unfold_leibniz. 
             unfold patt_inhabitant_set.
-            do 2 rewrite pattern_interpretation_app_simpl.
+            do 2 rewrite eval_app_simpl.
             rewrite (semantics_preservation_sym ρₑ ρₛ);[assumption|].
-            remember (pattern_interpretation ρₑ ρₛ (patt_sym s)) as ps.
+            remember (eval ρₑ ρₛ (patt_sym s)) as ps.
             unfold Sorts_Syntax.sym.
-            do 2 rewrite pattern_interpretation_sym_simpl.
+            do 2 rewrite eval_sym_simpl.
             unfold sym_interp at 1. simpl. unfold new_sym_interp.
             repeat case_match.
             { exfalso. clear -e HDefNeqInh. congruence. }
@@ -770,8 +770,8 @@ Section with_syntax.
                 size' ϕ < sz ->
                 is_SData ϕ ->
                 well_formed ϕ ->
-                @pattern_interpretation Σ Mext (lift_val_e ρₑ) (lift_val_s ρₛ) ϕ
-                = lift_set (@pattern_interpretation Σ M ρₑ ρₛ ϕ)
+                @eval Σ Mext (lift_val_e ρₑ) (lift_val_s ρₛ) ϕ
+                = lift_set (@eval Σ M ρₑ ρₛ ϕ)
             )
             /\
             (
@@ -779,11 +779,11 @@ Section with_syntax.
                 size' ψ < sz ->
                 is_SPredicate ψ ->
                 well_formed ψ ->
-                (@pattern_interpretation Σ Mext (lift_val_e ρₑ) (lift_val_s ρₛ) ψ = ∅
-                <-> @pattern_interpretation Σ M ρₑ ρₛ ψ = ∅)
+                (@eval Σ Mext (lift_val_e ρₑ) (lift_val_s ρₛ) ψ = ∅
+                <-> @eval Σ M ρₑ ρₛ ψ = ∅)
                 /\
-                (@pattern_interpretation Σ Mext (lift_val_e ρₑ) (lift_val_s ρₛ) ψ = ⊤
-                <-> @pattern_interpretation Σ M ρₑ ρₛ ψ = ⊤)
+                (@eval Σ Mext (lift_val_e ρₑ) (lift_val_s ρₛ) ψ = ⊤
+                <-> @eval Σ M ρₑ ρₛ ψ = ⊤)
             ).
         Proof.
             induction sz.
@@ -807,7 +807,7 @@ Section with_syntax.
                     destruct HSData; simpl in Hszϕ.
                     {
                         (* patt_bott *)
-                        do 2 rewrite pattern_interpretation_bott_simpl.
+                        do 2 rewrite eval_bott_simpl.
                         unfold lift_set.
                         unfold fmap.
                         with_strategy transparent [propset_fmap] unfold propset_fmap.
@@ -817,28 +817,28 @@ Section with_syntax.
                     }
                     {
                         (* free_evar x*)
-                        do 2 rewrite pattern_interpretation_free_evar_simpl.
+                        do 2 rewrite eval_free_evar_simpl.
                         unfold lift_set,fmap.
                         with_strategy transparent [propset_fmap] unfold propset_fmap.
                         clear. unfold_leibniz. set_solver.
                     }
                     {
                         (* free_svar X *)
-                        do 2 rewrite pattern_interpretation_free_svar_simpl.
+                        do 2 rewrite eval_free_svar_simpl.
                         unfold lift_set,fmap.
                         with_strategy transparent [propset_fmap] unfold propset_fmap.
                         clear. unfold_leibniz. set_solver.
                     }
                     {
                         (* bound_evar X *)
-                        do 2 rewrite pattern_interpretation_bound_evar_simpl.
+                        do 2 rewrite eval_bound_evar_simpl.
                         unfold lift_set,fmap.
                         with_strategy transparent [propset_fmap] unfold propset_fmap.
                         clear. unfold_leibniz. set_solver.
                     }
                     {
                         (* bound_svar X *)
-                        do 2 rewrite pattern_interpretation_bound_svar_simpl.
+                        do 2 rewrite eval_bound_svar_simpl.
                         unfold lift_set,fmap.
                         with_strategy transparent [propset_fmap] unfold propset_fmap.
                         clear. unfold_leibniz. set_solver.
@@ -856,9 +856,9 @@ Section with_syntax.
                     {
                         (* patt_sorted_neg (patt_sym s) ϕ *)
                         unfold patt_sorted_neg.
-                        do 2 rewrite pattern_interpretation_and_simpl.
+                        do 2 rewrite eval_and_simpl.
                         rewrite (semantics_preservation_inhabitant_set ρₑ ρₛ);[assumption|].
-                        do 2 rewrite pattern_interpretation_not_simpl.
+                        do 2 rewrite eval_not_simpl.
                         rewrite IHszdata.
                         {
                             lia.
@@ -869,15 +869,15 @@ Section with_syntax.
                         {
                             wf_auto2.
                         }
-                        remember (pattern_interpretation ρₑ ρₛ (patt_inhabitant_set (patt_sym s))) as Xinh.
-                        remember (pattern_interpretation ρₑ ρₛ ϕ) as Xϕ.
+                        remember (eval ρₑ ρₛ (patt_inhabitant_set (patt_sym s))) as Xinh.
+                        remember (eval ρₑ ρₛ ϕ) as Xϕ.
                         clear HeqXinh HeqXϕ IHszpred IHszdata.
                         unfold_leibniz.
                         set_solver.
                     }
                     {
                         (* patt_app ϕ₁ ϕ₂ *)
-                        do 2 rewrite pattern_interpretation_app_simpl.
+                        do 2 rewrite eval_app_simpl.
                         rewrite IHszdata.
                         { lia. }
                         { exact HSData1. }
@@ -957,7 +957,7 @@ Section with_syntax.
                     }
                     {
                         (* patt_or ϕ₁ ϕ₂ *)
-                        do 2 rewrite pattern_interpretation_or_simpl.
+                        do 2 rewrite eval_or_simpl.
                         rewrite IHszdata.
                         { lia. }
                         { exact HSData1. }
@@ -974,11 +974,11 @@ Section with_syntax.
                     }
                     {
                         (* patt_and ϕ ψ *)
-                        do 2 rewrite pattern_interpretation_and_simpl.
+                        do 2 rewrite eval_and_simpl.
 
                         rename H into Hspred.
                     
-                        destruct (classic (pattern_interpretation ρₑ ρₛ ψ = ∅)).
+                        destruct (classic (eval ρₑ ρₛ ψ = ∅)).
                         {
                             rewrite IHszdata.
                             { lia. }
@@ -1045,10 +1045,10 @@ Section with_syntax.
                     }
                     {
                         (* patt_exists_of_sort (patt_sym s) ϕ *)
-                        unshelve(erewrite pattern_interpretation_exists_of_sort).
+                        unshelve(erewrite eval_exists_of_sort).
                         3: { rewrite HSortImptDef. apply Mext_satisfies_definedness. }
                         { intros. apply Mext_indec. assumption. }
-                        unshelve(erewrite pattern_interpretation_exists_of_sort).
+                        unshelve(erewrite eval_exists_of_sort).
                         3: { rewrite HSortImptDef. assumption. }
                         { intros. apply indec. assumption. }
                         rewrite lift_set_fa_union.
@@ -1066,8 +1066,8 @@ Section with_syntax.
                                 destruct c.
                                 {
                                     exfalso.
-                                    rewrite pattern_interpretation_app_simpl in Hin.
-                                    do 2 rewrite pattern_interpretation_sym_simpl in Hin.
+                                    rewrite eval_app_simpl in Hin.
+                                    do 2 rewrite eval_sym_simpl in Hin.
                                     unfold app_ext in Hin. simpl in Hin.
                                     unfold new_sym_interp,new_app_interp in Hin.
                                     rewrite elem_of_PropSet in Hin.
@@ -1086,8 +1086,8 @@ Section with_syntax.
                                 }
                                 {
                                     exfalso.
-                                    rewrite pattern_interpretation_app_simpl in Hin.
-                                    do 2 rewrite pattern_interpretation_sym_simpl in Hin.
+                                    rewrite eval_app_simpl in Hin.
+                                    do 2 rewrite eval_sym_simpl in Hin.
                                     unfold app_ext in Hin. simpl in Hin.
                                     unfold new_sym_interp,new_app_interp in Hin.
                                     rewrite elem_of_PropSet in Hin.
@@ -1107,8 +1107,8 @@ Section with_syntax.
                                 destruct el.
                                 2: {
                                     exfalso.
-                                    rewrite pattern_interpretation_app_simpl in Hin.
-                                    do 2 rewrite pattern_interpretation_sym_simpl in Hin.
+                                    rewrite eval_app_simpl in Hin.
+                                    do 2 rewrite eval_sym_simpl in Hin.
                                     unfold app_ext in Hin. simpl in Hin.
                                     unfold new_sym_interp,new_app_interp in Hin.
                                     rewrite elem_of_PropSet in Hin.
@@ -1240,7 +1240,7 @@ Section with_syntax.
                     }
                     {
                         (* patt_mu (patt_sym s) ϕ *)
-                        do 2 rewrite pattern_interpretation_mu_simpl.
+                        do 2 rewrite eval_mu_simpl.
                         cbn zeta.
                         match goal with
                         | [ |- (Lattice.LeastFixpointOf ?fF = lift_set (Lattice.LeastFixpointOf ?fG))] =>
@@ -1303,7 +1303,7 @@ Section with_syntax.
                         }
                         {
                             set (λ (A : propset (Domain Mext)), PropSet (λ (m : Domain M), lift_value m ∈ A)) as strip.
-                            set (λ A, lift_set (pattern_interpretation ρₑ (update_svar_val (fresh_svar ϕ) (strip A) ρₛ) (svar_open 0 (fresh_svar ϕ) ϕ))) as G'.
+                            set (λ A, lift_set (eval ρₑ (update_svar_val (fresh_svar ϕ) (strip A) ρₛ) (svar_open 0 (fresh_svar ϕ) ϕ))) as G'.
 
                             assert (Hstripmono: forall x y, x ⊆ y -> strip x ⊆ strip y).
                             {
@@ -1363,7 +1363,7 @@ Section with_syntax.
                                     apply lift_set_mono.
                                     pose proof (Htmp := Lattice.LeastFixpoint_LesserThanPrefixpoint _ _ L G).
                                     simpl in Htmp. apply Htmp. clear Htmp.
-                                    replace (pattern_interpretation ρₑ (update_svar_val (fresh_svar ϕ) (strip A) ρₛ)
+                                    replace (eval ρₑ (update_svar_val (fresh_svar ϕ) (strip A) ρₛ)
                                     (svar_open 0 (fresh_svar ϕ) ϕ))
                                     with (G (strip A)) by (subst; reflexivity).
                                     apply HmonoG. simpl.
@@ -1390,8 +1390,8 @@ Section with_syntax.
                                 set_solver.
                             }
                             
-                            assert (@pattern_interpretation Σ Mext (lift_val_e ρₑ) (update_svar_val (fresh_svar ϕ) (lift_set (strip A)) (lift_val_s ρₛ)) (svar_open 0 (fresh_svar ϕ) ϕ)
-                            ⊆  @pattern_interpretation Σ Mext (lift_val_e ρₑ) (update_svar_val (fresh_svar ϕ) A (lift_val_s ρₛ)) (svar_open 0 (fresh_svar ϕ) ϕ)).
+                            assert (@eval Σ Mext (lift_val_e ρₑ) (update_svar_val (fresh_svar ϕ) (lift_set (strip A)) (lift_val_s ρₛ)) (svar_open 0 (fresh_svar ϕ) ϕ)
+                            ⊆  @eval Σ Mext (lift_val_e ρₑ) (update_svar_val (fresh_svar ϕ) A (lift_val_s ρₛ)) (svar_open 0 (fresh_svar ϕ) ϕ)).
                             {
                                 apply is_monotonic.
                                 { unfold well_formed in Hwf. destruct_and!. assumption. }
@@ -1414,8 +1414,8 @@ Section with_syntax.
                     destruct HSPred; simpl in Hszϕ.
                     {
                         (* patt_bott *)
-                        rewrite pattern_interpretation_bott_simpl.
-                        rewrite pattern_interpretation_bott_simpl.
+                        rewrite eval_bott_simpl.
+                        rewrite eval_bott_simpl.
                         split.
                         {
                             split; auto.
@@ -1433,8 +1433,8 @@ Section with_syntax.
                     {
                         (* patt_defined ϕ *)
                         unfold patt_defined.
-                        do 2 rewrite pattern_interpretation_app_simpl.
-                        do 2 rewrite pattern_interpretation_sym_simpl.
+                        do 2 rewrite eval_app_simpl.
+                        do 2 rewrite eval_sym_simpl.
                         rewrite IHszdata.
                         { lia. }
                         { assumption. }
@@ -1453,7 +1453,7 @@ Section with_syntax.
                         rewrite Htmp.
                         unfold new_app_interp.
                         unfold_leibniz.
-                        destruct (classic (pattern_interpretation ρₑ ρₛ ϕ = ∅)) as [Hempty|Hnonempty].
+                        destruct (classic (eval ρₑ ρₛ ϕ = ∅)) as [Hempty|Hnonempty].
                         {
                             rewrite Hempty.
                             split.
@@ -1735,7 +1735,7 @@ Section with_syntax.
                                         intros x Hx.
                                         rewrite elem_of_PropSet.
                                         exists cdef.
-                                        assert (Hex : exists el, el ∈ pattern_interpretation ρₑ ρₛ ϕ).
+                                        assert (Hex : exists el, el ∈ eval ρₑ ρₛ ϕ).
                                         {
                                             clear -Hnonempty.
                                             apply NNPP. intros HContra.
@@ -1799,7 +1799,7 @@ Section with_syntax.
                     }
                     {
                         (* patt_impl ψ₁ ψ₂*)
-                        do 2 rewrite pattern_interpretation_imp_simpl.
+                        do 2 rewrite eval_imp_simpl.
                         pose proof (IH1 := IHszpred ϕ₁ ρₑ ρₛ).
                         feed specialize IH1.
                         { lia. }
@@ -1878,7 +1878,7 @@ Section with_syntax.
                                     rewrite H2B.
                                     apply IH21 in H2B.
                                     rewrite H2B in H.
-                                    assert (H': pattern_interpretation (lift_val_e ρₑ) (lift_val_s ρₛ) ϕ₁  = ∅).
+                                    assert (H': eval (lift_val_e ρₑ) (lift_val_s ρₛ) ϕ₁  = ∅).
                                     {
                                         clear -H. set_solver.
                                     }
@@ -1933,11 +1933,11 @@ Section with_syntax.
                         }
                     }
                     {
-                        unshelve (erewrite pattern_interpretation_exists_of_sort).
+                        unshelve (erewrite eval_exists_of_sort).
                         3: { rewrite HSortImptDef. apply Mext_satisfies_definedness. }
                         1: { intros m. apply Mext_indec. assumption. }
 
-                        unshelve (erewrite pattern_interpretation_exists_of_sort).
+                        unshelve (erewrite eval_exists_of_sort).
                         3: { rewrite HSortImptDef. assumption. }
                         1: { intros m. apply indec. assumption. }
 
@@ -1971,10 +1971,10 @@ Section with_syntax.
                                 {
                                     exfalso.
                                     unfold Minterp_inhabitant in Hin,Hnotin'.
-                                    rewrite pattern_interpretation_app_simpl in Hin.
-                                    rewrite pattern_interpretation_app_simpl in Hnotin'.
-                                    do 2 rewrite pattern_interpretation_sym_simpl in Hin.
-                                    do 2 rewrite pattern_interpretation_sym_simpl in Hnotin'.
+                                    rewrite eval_app_simpl in Hin.
+                                    rewrite eval_app_simpl in Hnotin'.
+                                    do 2 rewrite eval_sym_simpl in Hin.
+                                    do 2 rewrite eval_sym_simpl in Hnotin'.
                                     unfold app_ext in Hin,Hnotin'.
                                     unfold lift_value in Hnotin'. simpl in Hnotin'.
                                     unfold new_sym_interp in Hnotin'.
@@ -2020,8 +2020,8 @@ Section with_syntax.
                                 destruct (Mext_indec H c ρₑ ρₛ) as [Hin|Hnotin].
                                 {
                                     unfold Minterp_inhabitant in Hin.
-                                    rewrite pattern_interpretation_app_simpl in Hin.
-                                    do 2 rewrite pattern_interpretation_sym_simpl in Hin.
+                                    rewrite eval_app_simpl in Hin.
+                                    do 2 rewrite eval_sym_simpl in Hin.
                                     unfold app_ext in Hin.
                                     rewrite elem_of_PropSet in Hin.
                                     destruct Hin as [le [re [Hle [Hre Hin]]]].
@@ -2072,8 +2072,8 @@ Section with_syntax.
                                     {
                                         exfalso. apply Hnotin'. clear Hnotin'.
                                         unfold Minterp_inhabitant.
-                                        rewrite pattern_interpretation_app_simpl.
-                                        do 2 rewrite pattern_interpretation_sym_simpl.
+                                        rewrite eval_app_simpl.
+                                        do 2 rewrite eval_sym_simpl.
                                         rewrite elem_of_PropSet in Hin.
                                         destruct Hin as [a [Ha Hin]].
                                         inversion Ha. clear Ha. subst.
@@ -2121,8 +2121,8 @@ Section with_syntax.
                                 destruct (Mext_indec H c ρₑ ρₛ) as [Hin|Hnotin].
                                 {
                                     unfold Minterp_inhabitant in Hin.
-                                    rewrite pattern_interpretation_app_simpl in Hin.
-                                    do 2 rewrite pattern_interpretation_sym_simpl in Hin.
+                                    rewrite eval_app_simpl in Hin.
+                                    do 2 rewrite eval_sym_simpl in Hin.
                                     unfold app_ext in Hin.
                                     rewrite elem_of_PropSet in Hin.
                                     simpl in Hin.
@@ -2156,8 +2156,8 @@ Section with_syntax.
                                     2: {
                                         exfalso. apply Hnotin'.
                                         unfold Minterp_inhabitant.
-                                        rewrite pattern_interpretation_app_simpl.
-                                        do 2 rewrite pattern_interpretation_sym_simpl.
+                                        rewrite eval_app_simpl.
+                                        do 2 rewrite eval_sym_simpl.
                                         unfold app_ext.
                                         rewrite elem_of_PropSet.
                                         exists le'. exists amr'.
@@ -2236,14 +2236,14 @@ Section with_syntax.
                                     {
                                         exfalso. apply Hnotin'. clear Hnotin'.
                                         unfold Minterp_inhabitant.
-                                        rewrite pattern_interpretation_app_simpl.
-                                        do 2 rewrite pattern_interpretation_sym_simpl.
+                                        rewrite eval_app_simpl.
+                                        do 2 rewrite eval_sym_simpl.
                                         simpl.
                                         unfold app_ext.
                                         rewrite elem_of_PropSet.
                                         unfold Minterp_inhabitant in Hin.
-                                        rewrite pattern_interpretation_app_simpl in Hin.
-                                        do 2 rewrite pattern_interpretation_sym_simpl in Hin.
+                                        rewrite eval_app_simpl in Hin.
+                                        do 2 rewrite eval_sym_simpl in Hin.
                                         unfold app_ext in Hin.
                                         rewrite elem_of_PropSet in Hin.
                                         destruct Hin as [le [re [Hle [Hre Hlere]]]].
@@ -2296,11 +2296,11 @@ Section with_syntax.
                         }
                     }
                     {
-                        unshelve (erewrite pattern_interpretation_forall_of_sort).
+                        unshelve (erewrite eval_forall_of_sort).
                         3: { rewrite HSortImptDef. apply Mext_satisfies_definedness. }
                         1: { intros m. apply Mext_indec. assumption. }
 
-                        unshelve (erewrite pattern_interpretation_forall_of_sort).
+                        unshelve (erewrite eval_forall_of_sort).
                         3: { rewrite HSortImptDef. assumption. }
                         1: { intros m. apply indec. assumption. }
 
@@ -2321,8 +2321,8 @@ Section with_syntax.
                                 destruct (Mext_indec H c ρₑ ρₛ) as [Hin|Hnotin].
                                 {
                                     unfold Minterp_inhabitant in Hin.
-                                    rewrite pattern_interpretation_app_simpl in Hin.
-                                    do 2 rewrite pattern_interpretation_sym_simpl in Hin.
+                                    rewrite eval_app_simpl in Hin.
+                                    do 2 rewrite eval_sym_simpl in Hin.
                                     unfold app_ext in Hin.
                                     rewrite elem_of_PropSet in Hin.
                                     simpl in Hin.
@@ -2401,8 +2401,8 @@ Section with_syntax.
                                     {
                                         exfalso. apply Hnotin'.
                                         unfold Minterp_inhabitant.
-                                        rewrite pattern_interpretation_app_simpl.
-                                        do 2 rewrite pattern_interpretation_sym_simpl.
+                                        rewrite eval_app_simpl.
+                                        do 2 rewrite eval_sym_simpl.
                                         unfold app_ext.
                                         rewrite elem_of_PropSet.
                                         exists le. exists a.
@@ -2421,8 +2421,8 @@ Section with_syntax.
                                 destruct (indec H c ρₑ ρₛ) as [Hin|Hnotin].
                                 {
                                     unfold Minterp_inhabitant in Hin.
-                                    rewrite pattern_interpretation_app_simpl in Hin.
-                                    do 2 rewrite pattern_interpretation_sym_simpl in Hin.
+                                    rewrite eval_app_simpl in Hin.
+                                    do 2 rewrite eval_sym_simpl in Hin.
                                     unfold app_ext in Hin.
                                     rewrite elem_of_PropSet in Hin.
                                     destruct Hin as [le [re [Hle [Hre Hin]]]].
@@ -2475,8 +2475,8 @@ Section with_syntax.
                                         exfalso.
                                         apply Hnotin'. clear Hnotin'.
                                         unfold Minterp_inhabitant.
-                                        rewrite pattern_interpretation_app_simpl.
-                                        do 2 rewrite pattern_interpretation_sym_simpl.
+                                        rewrite eval_app_simpl.
+                                        do 2 rewrite eval_sym_simpl.
                                         unfold app_ext.
                                         rewrite elem_of_PropSet.
                                         exists cinh.
@@ -2553,14 +2553,14 @@ Section with_syntax.
                                     {
                                         exfalso. apply Hnotin'. clear Hnotin' H'.
                                         unfold Minterp_inhabitant in Hin.
-                                        rewrite pattern_interpretation_app_simpl in Hin.
-                                        do 2 rewrite pattern_interpretation_sym_simpl in Hin.
+                                        rewrite eval_app_simpl in Hin.
+                                        do 2 rewrite eval_sym_simpl in Hin.
                                         unfold app_ext in Hin.
                                         rewrite elem_of_PropSet in Hin.
                                         destruct Hin as [le [re [Hle [Hre Hin]]]].
                                         unfold Minterp_inhabitant.
-                                        rewrite pattern_interpretation_app_simpl.
-                                        do 2 rewrite pattern_interpretation_sym_simpl.
+                                        rewrite eval_app_simpl.
+                                        do 2 rewrite eval_sym_simpl.
                                         unfold app_ext.
                                         rewrite elem_of_PropSet.
                                         exists cinh.
@@ -2603,8 +2603,8 @@ Section with_syntax.
                                 destruct (Mext_indec H c ρₑ ρₛ) as [Hin|Hnotin].
                                 2: { reflexivity. }
                                 unfold Minterp_inhabitant in Hin.
-                                rewrite pattern_interpretation_app_simpl in Hin.
-                                do 2 rewrite pattern_interpretation_sym_simpl in Hin.
+                                rewrite eval_app_simpl in Hin.
+                                do 2 rewrite eval_sym_simpl in Hin.
                                 unfold app_ext in Hin.
                                 rewrite elem_of_PropSet in Hin.
                                 simpl in Hin.
@@ -2669,8 +2669,8 @@ Section with_syntax.
                                     exfalso.
                                     apply Hnotin'. clear Hnotin'.
                                     unfold Minterp_inhabitant.
-                                    rewrite pattern_interpretation_app_simpl.
-                                    do 2 rewrite pattern_interpretation_sym_simpl.
+                                    rewrite eval_app_simpl.
+                                    do 2 rewrite eval_sym_simpl.
                                     unfold app_ext.
                                     rewrite elem_of_PropSet.
                                     exists le'. exists a.

--- a/matching-logic/src/Theories/Sorts_Semantics.v
+++ b/matching-logic/src/Theories/Sorts_Semantics.v
@@ -40,20 +40,20 @@ Section with_model.
 
     (* ϕ is expected to be a sort pattern *)
     Definition Minterp_inhabitant (ϕ : Pattern) (ρₑ : EVarVal) (ρₛ : SVarVal)
-      := @pattern_interpretation Σ M ρₑ ρₛ (patt_app (sym inhabitant) ϕ).
+      := @eval Σ M ρₑ ρₛ (patt_app (sym inhabitant) ϕ).
     
-    Lemma pattern_interpretation_forall_of_sort_predicate s ϕ ρₑ ρₛ:
+    Lemma eval_forall_of_sort_predicate s ϕ ρₑ ρₛ:
       let x := fresh_evar ϕ in
       M_predicate M (evar_open 0 x ϕ) ->
-      pattern_interpretation ρₑ ρₛ (patt_forall_of_sort s ϕ) = ⊤
+      eval ρₑ ρₛ (patt_forall_of_sort s ϕ) = ⊤
       <-> (∀ m : Domain M, m ∈ Minterp_inhabitant s ρₑ ρₛ ->
-                           pattern_interpretation (update_evar_val x m ρₑ) ρₛ (evar_open 0 x ϕ) = ⊤).
+                           eval (update_evar_val x m ρₑ) ρₛ (evar_open 0 x ϕ) = ⊤).
     Proof.
       intros x Hpred.
       unfold patt_forall_of_sort.
       assert (Hsub: is_subformula_of_ind ϕ (patt_in b0 (patt_inhabitant_set (nest_ex s)) ---> ϕ)).
       { apply sub_imp_r. apply sub_eq. reflexivity.  }
-      rewrite pattern_interpretation_forall_predicate.
+      rewrite eval_forall_predicate.
       2: {
         unfold evar_open. simpl_bevar_subst. simpl.
         apply M_predicate_impl.
@@ -99,14 +99,14 @@ Section with_model.
       split.
       - intros H m H'.
         specialize (H m).
-        (*rewrite -interpretation_fresh_evar_subterm.*)
-        rewrite -(@interpretation_fresh_evar_subterm _ _ _ Bigϕ).
+        (*rewrite -eval_fresh_evar_subterm.*)
+        rewrite -(@eval_fresh_evar_subterm _ _ _ Bigϕ).
         rewrite HeqBigϕ in H.
         rewrite evar_open_imp in H.
         rewrite -HeqBigϕ in H.
         assumption.
         rewrite {3}HeqBigϕ in H.
-        eapply pattern_interpretation_impl_MP.
+        eapply eval_impl_MP.
         apply H.
         simpl. fold evar_open.
   
@@ -117,13 +117,13 @@ Section with_model.
         clear H. unfold sym in H'.
         unfold Ensembles.In.
         
-        rewrite pattern_interpretation_app_simpl.
+        rewrite eval_app_simpl.
         unfold evar_open. rewrite nest_ex_same.
-        rewrite pattern_interpretation_sym_simpl.
+        rewrite eval_sym_simpl.
 
-        rewrite pattern_interpretation_app_simpl in H'.
-        rewrite pattern_interpretation_sym_simpl in H'.
-        rewrite pattern_interpretation_free_evar_independent.
+        rewrite eval_app_simpl in H'.
+        rewrite eval_sym_simpl in H'.
+        rewrite eval_free_evar_independent.
         {
           solve_free_evars_inclusion 5.
         }
@@ -134,44 +134,44 @@ Section with_model.
         destruct Hfeip as [_ Hfeip2].
         rewrite {3}HeqBigϕ.
         unfold evar_open. simpl_bevar_subst. simpl.
-        apply pattern_interpretation_predicate_impl.
+        apply eval_predicate_impl.
         apply T_predicate_in. apply M_satisfies_theory.
         intros H1.
         specialize (Hfeip2 H1). clear H1.
         specialize (H m).
-        rewrite -(@interpretation_fresh_evar_subterm _ _ _ Bigϕ) in H.
+        rewrite -(@eval_fresh_evar_subterm _ _ _ Bigϕ) in H.
         apply Hsub. apply H. clear H.
 
         unfold Minterp_inhabitant.
         unfold Ensembles.In in Hfeip2. unfold sym.
 
 
-        rewrite pattern_interpretation_app_simpl in Hfeip2.
+        rewrite eval_app_simpl in Hfeip2.
         unfold evar_open in Hfeip2. rewrite nest_ex_same in Hfeip2.
-        rewrite pattern_interpretation_sym_simpl in Hfeip2.
+        rewrite eval_sym_simpl in Hfeip2.
 
-        rewrite pattern_interpretation_app_simpl.
-        rewrite pattern_interpretation_sym_simpl.
+        rewrite eval_app_simpl.
+        rewrite eval_sym_simpl.
         rewrite update_evar_val_same in Hfeip2.
-        rewrite pattern_interpretation_free_evar_independent in Hfeip2.
+        rewrite eval_free_evar_independent in Hfeip2.
         {
           solve_free_evars_inclusion 5.
         }
         apply Hfeip2.
     Qed.
 
-    Lemma pattern_interpretation_exists_of_sort_predicate s ϕ ρₑ ρₛ:
+    Lemma eval_exists_of_sort_predicate s ϕ ρₑ ρₛ:
       let x := fresh_evar ϕ in
       M_predicate M (evar_open 0 x ϕ) ->
-      pattern_interpretation ρₑ ρₛ (patt_exists_of_sort s ϕ) = ⊤
+      eval ρₑ ρₛ (patt_exists_of_sort s ϕ) = ⊤
       <-> (∃ m : Domain M, m ∈ Minterp_inhabitant s ρₑ ρₛ /\
-                           pattern_interpretation (update_evar_val x m ρₑ) ρₛ (evar_open 0 x ϕ) = ⊤).
+                           eval (update_evar_val x m ρₑ) ρₛ (evar_open 0 x ϕ) = ⊤).
     Proof.
       intros x Hpred.
       unfold patt_exists_of_sort.
       assert (Hsub: is_subformula_of_ind ϕ (patt_in b0 (patt_inhabitant_set (nest_ex s)) and ϕ)).
       { unfold patt_and. unfold patt_or.  apply sub_imp_l. apply sub_imp_r. apply sub_imp_l. apply sub_eq. reflexivity. }
-      rewrite -> pattern_interpretation_exists_predicate_full.
+      rewrite -> eval_exists_predicate_full.
       2: {
         unfold evar_open. simpl_bevar_subst. simpl.
         apply M_predicate_and.
@@ -219,11 +219,11 @@ Section with_model.
       split.
       - intros [m H].
         exists m.
-        rewrite -(@interpretation_fresh_evar_subterm _ _ _ Bigϕ).
+        rewrite -(@eval_fresh_evar_subterm _ _ _ Bigϕ).
         assumption.
         rewrite {3}HeqBigϕ in H.
 
-        apply pattern_interpretation_and_full in H.
+        apply eval_and_full in H.
         fold evar_open in H.
         destruct H as [H1 H2].
         split. 2: apply H2. clear H2.
@@ -236,14 +236,14 @@ Section with_model.
         unfold sym.
         unfold Ensembles.In in H1.
 
-        rewrite pattern_interpretation_app_simpl in H1.
+        rewrite eval_app_simpl in H1.
         unfold evar_open in H1.
         rewrite nest_ex_same in H1.
-        rewrite pattern_interpretation_sym_simpl in H1.
+        rewrite eval_sym_simpl in H1.
 
-        rewrite pattern_interpretation_app_simpl.
-        rewrite pattern_interpretation_sym_simpl.
-        rewrite pattern_interpretation_free_evar_independent in H1.
+        rewrite eval_app_simpl.
+        rewrite eval_sym_simpl.
+        rewrite eval_free_evar_independent in H1.
         {
           solve_free_evars_inclusion 5.
         }
@@ -253,25 +253,25 @@ Section with_model.
         pose proof (Hfeip := @free_evar_in_patt _ _ M M_satisfies_theory (fresh_evar Bigϕ) (patt_sym (inj inhabitant) $ evar_open 0 (fresh_evar Bigϕ) (nest_ex s)) (update_evar_val (fresh_evar Bigϕ) m ρₑ) ρₛ).
         destruct Hfeip as [Hfeip1 _].
         rewrite {3}HeqBigϕ.
-        apply pattern_interpretation_and_full. fold evar_open.
+        apply eval_and_full. fold evar_open.
         split.
         + apply Hfeip1. clear Hfeip1.
           unfold Ensembles.In.
           rewrite -> update_evar_val_same.
           unfold Minterp_inhabitant in H1. unfold sym in H1.
 
-          rewrite pattern_interpretation_app_simpl in H1.
-          rewrite pattern_interpretation_sym_simpl in H1.
+          rewrite eval_app_simpl in H1.
+          rewrite eval_sym_simpl in H1.
 
-          rewrite pattern_interpretation_app_simpl.
+          rewrite eval_app_simpl.
           unfold evar_open. rewrite nest_ex_same.
-          rewrite pattern_interpretation_sym_simpl.
-          rewrite pattern_interpretation_free_evar_independent.
+          rewrite eval_sym_simpl.
+          rewrite eval_free_evar_independent.
           {
             solve_free_evars_inclusion 5.
           }
           apply H1.
-        + rewrite -(@interpretation_fresh_evar_subterm _ _ _ Bigϕ) in H2.
+        + rewrite -(@eval_fresh_evar_subterm _ _ _ Bigϕ) in H2.
           apply Hsub.
           apply H2.
     Qed.
@@ -322,11 +322,11 @@ Section with_model.
     Hint Resolve M_predicate_forall_of_sort : core.
 
     Lemma interp_total_function f s₁ s₂ ρₑ ρₛ :
-      @pattern_interpretation Σ M ρₑ ρₛ (patt_total_function f s₁ s₂) = ⊤ <->
+      @eval Σ M ρₑ ρₛ (patt_total_function f s₁ s₂) = ⊤ <->
       @is_total_function Σ M f (Minterp_inhabitant s₁ ρₑ ρₛ) (Minterp_inhabitant s₂ ρₑ ρₛ) ρₑ ρₛ.
     Proof.
       unfold is_total_function.
-      rewrite pattern_interpretation_forall_of_sort_predicate.
+      rewrite eval_forall_of_sort_predicate.
       2: { eauto. }
 
       unfold evar_open. simpl_bevar_subst.
@@ -340,7 +340,7 @@ Section with_model.
       unfold pointwise_relation. intros m₁.
       apply all_iff_morphism. unfold pointwise_relation. intros Hinh1.
 
-      rewrite pattern_interpretation_exists_of_sort_predicate.
+      rewrite eval_exists_of_sort_predicate.
       2: {
         unfold evar_open. simpl_bevar_subst.
         apply T_predicate_equals; apply M_satisfies_theory.
@@ -348,9 +348,9 @@ Section with_model.
       apply ex_iff_morphism. unfold pointwise_relation. intros m₂.
 
       unfold Minterp_inhabitant.
-      rewrite 2!pattern_interpretation_app_simpl.
-      rewrite 2!pattern_interpretation_sym_simpl.
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite 2!eval_app_simpl.
+      rewrite 2!eval_sym_simpl.
+      rewrite eval_free_evar_independent.
       (* two subgoals *)
       fold (evar_is_fresh_in x' (nest_ex s₂)).
 
@@ -377,10 +377,10 @@ Section with_model.
       remember (fresh_evar (patt_equal (nest_ex_aux 0 1 f $ patt_free_evar x') b0)) as x''.
 
       rewrite equal_iff_interpr_same. 2: apply M_satisfies_theory.
-      simpl. rewrite pattern_interpretation_free_evar_simpl.
+      simpl. rewrite eval_free_evar_simpl.
       rewrite update_evar_val_same.
-      rewrite pattern_interpretation_app_simpl.
-      rewrite pattern_interpretation_free_evar_simpl.
+      rewrite eval_app_simpl.
+      rewrite eval_free_evar_simpl.
 
       (*  Hx''neqx' : x'' ≠ x'
           Hx''freeinf : x'' ∉ free_evars f
@@ -390,14 +390,14 @@ Section with_model.
         solve_fresh_neq.
       }
       rewrite update_evar_val_same.
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite eval_free_evar_independent.
       {
          rewrite Heqx''. unfold evar_is_fresh_in.
          eapply evar_is_fresh_in_richer'.
          2: apply set_evar_fresh_is_fresh'. cbn.
          solve_free_evars_inclusion 5.
       }
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite eval_free_evar_independent.
       {
          rewrite Heqx'. unfold evar_is_fresh_in.
          eapply evar_is_fresh_in_richer'.
@@ -408,15 +408,15 @@ Section with_model.
     Qed.
 
     Lemma interp_partial_function f s₁ s₂ ρₑ ρₛ :
-      @pattern_interpretation Σ M ρₑ ρₛ (patt_partial_function f s₁ s₂) = ⊤ <->
+      @eval Σ M ρₑ ρₛ (patt_partial_function f s₁ s₂) = ⊤ <->
       ∀ (m₁ : Domain M),
         m₁ ∈ Minterp_inhabitant s₁ ρₑ ρₛ ->
         ∃ (m₂ : Domain M),
           m₂ ∈ Minterp_inhabitant s₂ ρₑ ρₛ /\
-          (app_ext (@pattern_interpretation Σ M ρₑ ρₛ f) {[m₁]})
+          (app_ext (@eval Σ M ρₑ ρₛ f) {[m₁]})
             ⊆ {[m₂]}.
     Proof.
-      rewrite pattern_interpretation_forall_of_sort_predicate.
+      rewrite eval_forall_of_sort_predicate.
       2: { eauto. }
 
       unfold evar_open. simpl_bevar_subst.
@@ -430,7 +430,7 @@ Section with_model.
       unfold pointwise_relation. intros m₁.
       apply all_iff_morphism. unfold pointwise_relation. intros Hinh1.
 
-      rewrite pattern_interpretation_exists_of_sort_predicate.
+      rewrite eval_exists_of_sort_predicate.
       2: {
         unfold evar_open. simpl_bevar_subst.
         apply T_predicate_subseteq; apply M_satisfies_theory.
@@ -439,9 +439,9 @@ Section with_model.
       apply ex_iff_morphism. unfold pointwise_relation. intros m₂.
 
       unfold Minterp_inhabitant.
-      rewrite 2!pattern_interpretation_app_simpl.
-      rewrite 2!pattern_interpretation_sym_simpl.
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite 2!eval_app_simpl.
+      rewrite 2!eval_sym_simpl.
+      rewrite eval_free_evar_independent.
       {
         fold (evar_is_fresh_in x' (nest_ex s₂)).
 
@@ -468,10 +468,10 @@ Section with_model.
       remember (fresh_evar (patt_subseteq (nest_ex_aux 0 1 f $ patt_free_evar x') b0)) as x''.
 
       rewrite subseteq_iff_interpr_subseteq. 2: apply M_satisfies_theory.
-      simpl. rewrite pattern_interpretation_free_evar_simpl.
+      simpl. rewrite eval_free_evar_simpl.
       rewrite update_evar_val_same.
-      rewrite pattern_interpretation_app_simpl.
-      rewrite pattern_interpretation_free_evar_simpl.
+      rewrite eval_app_simpl.
+      rewrite eval_free_evar_simpl.
 
       (*  Hx''neqx' : x'' ≠ x'
           Hx''freeinf : x'' ∉ free_evars f
@@ -484,14 +484,14 @@ Section with_model.
       rewrite update_evar_val_same.
       unfold nest_ex.
 
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite eval_free_evar_independent.
       {
          rewrite Heqx''. unfold evar_is_fresh_in.
          eapply evar_is_fresh_in_richer'.
          2: apply set_evar_fresh_is_fresh'. cbn.
          solve_free_evars_inclusion 5.
       }
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite eval_free_evar_independent.
       {
          rewrite Heqx'. unfold evar_is_fresh_in.
          eapply evar_is_fresh_in_richer'.
@@ -508,14 +508,14 @@ Section with_model.
     Proof.
       intros Hfr.
       unfold Minterp_inhabitant.
-      rewrite 2!pattern_interpretation_app_simpl.
-      rewrite 2!pattern_interpretation_sym_simpl.
+      rewrite 2!eval_app_simpl.
+      rewrite 2!eval_sym_simpl.
       unfold nest_ex, evar_open. rewrite nest_ex_same.
-      rewrite pattern_interpretation_free_evar_independent; auto.
+      rewrite eval_free_evar_independent; auto.
    Qed.
 
     Lemma interp_partial_function_injective f s ρₑ ρₛ :
-      @pattern_interpretation Σ M ρₑ ρₛ (patt_partial_function_injective f s) = ⊤ <->
+      @eval Σ M ρₑ ρₛ (patt_partial_function_injective f s) = ⊤ <->
       ∀ (m₁ : Domain M),
         m₁ ∈ Minterp_inhabitant s ρₑ ρₛ ->
         ∀ (m₂ : Domain M),
@@ -525,7 +525,7 @@ Section with_model.
           m₁ = m₂.
     Proof.
       unfold patt_partial_function_injective.
-      rewrite pattern_interpretation_forall_of_sort_predicate.
+      rewrite eval_forall_of_sort_predicate.
       2: {
         match goal with
         | [ |- M_predicate _ (evar_open _ ?x _) ] => remember x
@@ -549,7 +549,7 @@ Section with_model.
       apply all_iff_morphism. intros Hm₁s.
 
       unfold evar_open. simpl_bevar_subst.
-      rewrite pattern_interpretation_forall_of_sort_predicate. 2: { eauto 8. }
+      rewrite eval_forall_of_sort_predicate. 2: { eauto 8. }
       remember
       (fresh_evar
              (! patt_equal
@@ -579,24 +579,24 @@ Section with_model.
       rewrite nest_ex_same.
       simpl in Heqx₁, Heqx₂.
 
-      rewrite pattern_interpretation_predicate_impl. 2: { eauto. }
+      rewrite eval_predicate_impl. 2: { eauto. }
       simpl.
-      rewrite pattern_interpretation_predicate_not. 2: { eauto. }
+      rewrite eval_predicate_not. 2: { eauto. }
       rewrite equal_iff_interpr_same.
-      rewrite pattern_interpretation_bott_simpl. 2: apply M_satisfies_theory.
-      rewrite pattern_interpretation_app_simpl.
-      rewrite pattern_interpretation_free_evar_simpl.
+      rewrite eval_bott_simpl. 2: apply M_satisfies_theory.
+      rewrite eval_app_simpl.
+      rewrite eval_free_evar_simpl.
       rewrite update_evar_val_neq.
       { solve_fresh_neq. }
       rewrite update_evar_val_same.
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite eval_free_evar_independent.
       {
          rewrite Heqx₂. unfold evar_is_fresh_in.
          eapply evar_is_fresh_in_richer'.
          2: apply set_evar_fresh_is_fresh'. cbn.
          solve_free_evars_inclusion 5.
       }
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite eval_free_evar_independent.
       {
          rewrite Heqx₁. unfold evar_is_fresh_in.
          eapply evar_is_fresh_in_richer'.
@@ -606,25 +606,25 @@ Section with_model.
       fold (rel_of ρₑ ρₛ f m₁).
       apply all_iff_morphism. unfold pointwise_relation. intros Hnonempty.
 
-      rewrite pattern_interpretation_predicate_impl. 2: { eauto. }
+      rewrite eval_predicate_impl. 2: { eauto. }
       (*rewrite simpl_evar_open.*)
       rewrite equal_iff_interpr_same. 2: apply M_satisfies_theory.
-      rewrite 2!pattern_interpretation_app_simpl.
+      rewrite 2!eval_app_simpl.
       rewrite equal_iff_interpr_same. 2: { apply M_satisfies_theory. }
-      rewrite !pattern_interpretation_free_evar_simpl.
+      rewrite !eval_free_evar_simpl.
       rewrite update_evar_val_same.
       rewrite update_evar_val_neq.
       { solve_fresh_neq. }
       rewrite update_evar_val_same.
       unfold rel_of.
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite eval_free_evar_independent.
       {
          rewrite Heqx₂. unfold evar_is_fresh_in.
          eapply evar_is_fresh_in_richer'.
          2: apply set_evar_fresh_is_fresh'. cbn.
          solve_free_evars_inclusion 5.
       }
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite eval_free_evar_independent.
       {
          rewrite Heqx₁. unfold evar_is_fresh_in.
          eapply evar_is_fresh_in_richer'.
@@ -637,12 +637,12 @@ Section with_model.
     Qed.
 
     Lemma interp_total_function_injective f s ρₑ ρₛ :
-      @pattern_interpretation Σ M ρₑ ρₛ (patt_total_function_injective f s) = ⊤ <->
+      @eval Σ M ρₑ ρₛ (patt_total_function_injective f s) = ⊤ <->
       total_function_is_injective f (Minterp_inhabitant s ρₑ ρₛ) ρₑ ρₛ.
     Proof.
       unfold total_function_is_injective.
       unfold patt_partial_function_injective.
-      rewrite pattern_interpretation_forall_of_sort_predicate.
+      rewrite eval_forall_of_sort_predicate.
       2: {
         match goal with
         | [ |- M_predicate _ (evar_open _ ?x _) ] => remember x
@@ -664,7 +664,7 @@ Section with_model.
       apply all_iff_morphism. intros Hm₁s.
 
       unfold evar_open. simpl_bevar_subst.
-      rewrite pattern_interpretation_forall_of_sort_predicate.
+      rewrite eval_forall_of_sort_predicate.
       2: {
                 match goal with
         | [ |- M_predicate _ (evar_open _ ?x _) ] => remember x
@@ -694,28 +694,28 @@ Section with_model.
       rewrite fuse_nest_ex_same. rewrite nest_ex_same_general. 1-2: lia. simpl pred.
       simpl_bevar_subst.
 
-      rewrite pattern_interpretation_predicate_impl. 2: { eauto. }
+      rewrite eval_predicate_impl. 2: { eauto. }
       simpl.
       
       rewrite equal_iff_interpr_same.
       2: { apply M_satisfies_theory. }
-      rewrite 2!pattern_interpretation_app_simpl.
-      rewrite pattern_interpretation_free_evar_simpl.
+      rewrite 2!eval_app_simpl.
+      rewrite eval_free_evar_simpl.
       rewrite update_evar_val_neq.
       { solve_fresh_neq. }
       rewrite update_evar_val_same.
 
-      rewrite pattern_interpretation_free_evar_simpl.
+      rewrite eval_free_evar_simpl.
       rewrite update_evar_val_same.
       rewrite nest_ex_same.
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite eval_free_evar_independent.
       {
          rewrite Heqx₂. unfold evar_is_fresh_in.
          eapply evar_is_fresh_in_richer'.
          2: apply set_evar_fresh_is_fresh'. cbn.
          solve_free_evars_inclusion 5.
       }
-      rewrite pattern_interpretation_free_evar_independent.
+      rewrite eval_free_evar_independent.
       {
          rewrite Heqx₁. unfold evar_is_fresh_in.
          eapply evar_is_fresh_in_richer'.
@@ -727,7 +727,7 @@ Section with_model.
 
 
       rewrite equal_iff_interpr_same. 2: apply M_satisfies_theory.
-      rewrite 2!pattern_interpretation_free_evar_simpl.
+      rewrite 2!eval_free_evar_simpl.
       rewrite update_evar_val_same.
       rewrite update_evar_val_neq.
       { solve_fresh_neq. }
@@ -737,22 +737,22 @@ Section with_model.
 
     
 
-    Lemma pattern_interpretation_exists_of_sort
+    Lemma eval_exists_of_sort
       (s : Pattern)
       (ρₑ : EVarVal)
       (ρₛ : SVarVal)
       (indec : forall (m : Domain M), Decision (m ∈ Minterp_inhabitant s ρₑ ρₛ))
       (ϕ : Pattern):
-    pattern_interpretation ρₑ ρₛ (patt_exists_of_sort s ϕ)
+    eval ρₑ ρₛ (patt_exists_of_sort s ϕ)
     = stdpp_ext.propset_fa_union (λ (m : Domain M),
       match (indec m) with
-      | left _ => pattern_interpretation (update_evar_val (fresh_evar ϕ) m ρₑ) ρₛ (evar_open 0 (fresh_evar ϕ) ϕ)
+      | left _ => eval (update_evar_val (fresh_evar ϕ) m ρₑ) ρₛ (evar_open 0 (fresh_evar ϕ) ϕ)
       | right _ => ∅
       end
     ).
     Proof.
       unfold patt_exists_of_sort.
-      rewrite pattern_interpretation_ex_simpl. simpl.
+      rewrite eval_ex_simpl. simpl.
       f_equal. apply functional_extensionality.
       intros m.
       remember (fresh_evar (patt_in b0 (patt_inhabitant_set (nest_ex s)) and ϕ)) as x.
@@ -762,11 +762,11 @@ Section with_model.
         rename e into Hinh.
         unfold evar_open. simpl_bevar_subst. simpl.
         unfold nest_ex. rewrite nest_ex_same.
-        rewrite pattern_interpretation_and_simpl.
+        rewrite eval_and_simpl.
         unfold Minterp_inhabitant in Hinh.
         replace m with ((update_evar_val x m ρₑ) x) in Hinh.
         2: { apply update_evar_val_same. }
-        rewrite -(@pattern_interpretation_free_evar_independent _ _ ρₑ ρₛ x m) in Hinh.
+        rewrite -(@eval_free_evar_independent _ _ ρₑ ρₛ x m) in Hinh.
         {
           eapply evar_is_fresh_in_richer.
           2: { subst. apply set_evar_fresh_is_fresh. }
@@ -776,12 +776,12 @@ Section with_model.
         2: { apply M_satisfies_theory. }
         rewrite Hinh.
         remember (fresh_evar ϕ) as x'.
-        assert (Htmp: pattern_interpretation (update_evar_val x m ρₑ) ρₛ
+        assert (Htmp: eval (update_evar_val x m ρₑ) ρₛ
           ϕ.[evar:0↦patt_free_evar x] =
-          pattern_interpretation (update_evar_val x' m ρₑ) ρₛ
+          eval (update_evar_val x' m ρₑ) ρₛ
           ϕ.[evar:0↦patt_free_evar x']).
         {
-          apply interpretation_fresh_evar_open.
+          apply eval_fresh_evar_open.
           { subst x.
             eapply evar_is_fresh_in_richer.
             2: { apply set_evar_fresh_is_fresh. }
@@ -797,12 +797,12 @@ Section with_model.
         clear Heqd.
         rename n into Hinh.
         unfold evar_open. simpl_bevar_subst.
-        rewrite pattern_interpretation_and_simpl. simpl.
+        rewrite eval_and_simpl. simpl.
         replace m with ((update_evar_val x m ρₑ) x) in Hinh.
         2: { apply update_evar_val_same. }
         unfold nest_ex. rewrite nest_ex_same.
         unfold Minterp_inhabitant in Hinh.
-        rewrite -(@pattern_interpretation_free_evar_independent _ _ ρₑ ρₛ x m) in Hinh.
+        rewrite -(@eval_free_evar_independent _ _ ρₑ ρₛ x m) in Hinh.
         {
           eapply evar_is_fresh_in_richer.
           2: { subst. apply set_evar_fresh_is_fresh. }
@@ -818,22 +818,22 @@ Section with_model.
 
 
 
-    Lemma pattern_interpretation_forall_of_sort
+    Lemma eval_forall_of_sort
       (s : Pattern)
       (ρₑ : EVarVal)
       (ρₛ : SVarVal)
       (indec : forall (m : Domain M), Decision (m ∈ Minterp_inhabitant s ρₑ ρₛ))
       (ϕ : Pattern):
-    pattern_interpretation ρₑ ρₛ (patt_forall_of_sort s ϕ)
+    eval ρₑ ρₛ (patt_forall_of_sort s ϕ)
     = stdpp_ext.propset_fa_intersection (λ (m : Domain M),
       match (indec m) with
-      | left _ => pattern_interpretation (update_evar_val (fresh_evar ϕ) m ρₑ) ρₛ (evar_open 0 (fresh_evar ϕ) ϕ)
+      | left _ => eval (update_evar_val (fresh_evar ϕ) m ρₑ) ρₛ (evar_open 0 (fresh_evar ϕ) ϕ)
       | right _ => ⊤
       end
     ).
     Proof.
       unfold patt_forall_of_sort.
-      rewrite pattern_interpretation_all_simpl.
+      rewrite eval_all_simpl.
       simpl.
       f_equal. apply functional_extensionality.
       intros m.
@@ -848,7 +848,7 @@ Section with_model.
         unfold Minterp_inhabitant in Hinh.
         replace m with ((update_evar_val x m ρₑ) x) in Hinh.
         2: { apply update_evar_val_same. }
-        rewrite -(@pattern_interpretation_free_evar_independent _ _ ρₑ ρₛ x m) in Hinh.
+        rewrite -(@eval_free_evar_independent _ _ ρₑ ρₛ x m) in Hinh.
         {
           eapply evar_is_fresh_in_richer.
           2: { subst. apply set_evar_fresh_is_fresh. }
@@ -859,15 +859,15 @@ Section with_model.
         unfold patt_inhabitant_set.
         unfold Sorts_Syntax.sym.
         unfold sym in Hinh.
-        rewrite pattern_interpretation_imp_simpl.
+        rewrite eval_imp_simpl.
         rewrite Hinh.
         remember (fresh_evar ϕ) as x'.
-        assert (Htmp: pattern_interpretation (update_evar_val x m ρₑ) ρₛ
+        assert (Htmp: eval (update_evar_val x m ρₑ) ρₛ
           ϕ.[evar:0↦patt_free_evar x] =
-          pattern_interpretation (update_evar_val x' m ρₑ) ρₛ
+          eval (update_evar_val x' m ρₑ) ρₛ
           ϕ.[evar:0↦patt_free_evar x']).
         {
-          apply interpretation_fresh_evar_open.
+          apply eval_fresh_evar_open.
           { subst x.
             eapply evar_is_fresh_in_richer.
             2: { apply set_evar_fresh_is_fresh. }
@@ -883,12 +883,12 @@ Section with_model.
         clear Heqd.
         rename n into Hinh.
         unfold evar_open. simpl_bevar_subst.
-        rewrite pattern_interpretation_imp_simpl. simpl.
+        rewrite eval_imp_simpl. simpl.
         replace m with ((update_evar_val x m ρₑ) x) in Hinh.
         2: { apply update_evar_val_same. }
         unfold nest_ex. rewrite nest_ex_same.
         unfold Minterp_inhabitant in Hinh.
-        rewrite -(@pattern_interpretation_free_evar_independent _ _ ρₑ ρₛ x m) in Hinh.
+        rewrite -(@eval_free_evar_independent _ _ ρₑ ρₛ x m) in Hinh.
         {
           eapply evar_is_fresh_in_richer.
           2: { subst. apply set_evar_fresh_is_fresh. }

--- a/matching-logic/src/monotonic.v
+++ b/matching-logic/src/monotonic.v
@@ -237,12 +237,12 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
                  (X : svar),
             (Bp X ->
              @AntiMonotonicFunction A OS (fun (S : propset (Domain M)) =>
-                                            (@pattern_interpretation Σ M evar_val (update_svar_val X S svar_val) phi)
+                                            (@eval Σ M evar_val (update_svar_val X S svar_val) phi)
                                          )
             ) /\
             (Bn X ->
              @MonotonicFunction A OS (fun S : propset (Domain M) =>
-                                        (@pattern_interpretation Σ M evar_val (update_svar_val X S svar_val) phi))
+                                        (@eval Σ M evar_val (update_svar_val X S svar_val) phi))
             )
     .
     Proof.
@@ -252,11 +252,11 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
         + (* EVar free *)
           unfold MonotonicFunction. unfold AntiMonotonicFunction. unfold leq. simpl.
           setoid_rewrite -> elem_of_subseteq.
-          unfold In. split; intros; rewrite -> pattern_interpretation_free_evar_simpl in *; assumption.
+          unfold In. split; intros; rewrite -> eval_free_evar_simpl in *; assumption.
         + (* SVar free *)
           unfold MonotonicFunction. unfold AntiMonotonicFunction. unfold leq. simpl.
           setoid_rewrite -> elem_of_subseteq.
-          split; intros; rewrite -> pattern_interpretation_free_svar_simpl in *;
+          split; intros; rewrite -> eval_free_svar_simpl in *;
             unfold update_svar_val in *; destruct (decide (X = x)); subst.
           * unfold respects_blacklist in H1.
             specialize (H1 x).
@@ -269,22 +269,22 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
             
         + (* EVar bound *)
           unfold AntiMonotonicFunction. unfold MonotonicFunction. unfold leq. simpl.
-          split; intros; repeat rewrite -> pattern_interpretation_bound_evar_simpl;
+          split; intros; repeat rewrite -> eval_bound_evar_simpl;
             setoid_rewrite -> elem_of_subseteq;
             unfold In; intros; assumption.
         + (* SVar bound *)
           unfold AntiMonotonicFunction. unfold MonotonicFunction. unfold leq. simpl.
-          split; intros; repeat rewrite -> pattern_interpretation_bound_svar_simpl;
+          split; intros; repeat rewrite -> eval_bound_svar_simpl;
             setoid_rewrite -> elem_of_subseteq;
             unfold In; intros; assumption.
         + (* Sym *)
           unfold AntiMonotonicFunction. unfold MonotonicFunction. unfold leq. simpl.
-          split; intros; repeat rewrite -> pattern_interpretation_sym_simpl;
+          split; intros; repeat rewrite -> eval_sym_simpl;
             setoid_rewrite -> elem_of_subseteq;
             unfold In; intros; assumption.
         + (* Bot *)
           unfold AntiMonotonicFunction. unfold MonotonicFunction. unfold leq. simpl.
-          split; intros; rewrite -> pattern_interpretation_bott_simpl;
+          split; intros; rewrite -> eval_bott_simpl;
             setoid_rewrite -> elem_of_subseteq; intros; inversion H4.
       - (* S n *)
         intros phi Hsz Hwfp Bp Bn Hrb evar_val svar_val V.
@@ -312,7 +312,7 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
           {
             intros HBp. unfold AntiMonotonicFunction in *.
             intros.
-            repeat rewrite -> pattern_interpretation_app_simpl.
+            repeat rewrite -> eval_app_simpl.
             unfold app_ext. unfold leq in *. simpl in *.
             setoid_rewrite -> elem_of_subseteq.
             rewrite -> elem_of_subseteq in H.
@@ -333,7 +333,7 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
           {
             intros HBp. unfold MonotonicFunction in *.
             intros.
-            repeat rewrite -> pattern_interpretation_app_simpl.
+            repeat rewrite -> eval_app_simpl.
             unfold app_ext. unfold leq in *. simpl in *.
             setoid_rewrite -> elem_of_subseteq.
             rewrite -> elem_of_subseteq in H.
@@ -381,7 +381,7 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
           {
             intros HBp.
             intros.
-            repeat rewrite -> pattern_interpretation_imp_simpl.
+            repeat rewrite -> eval_imp_simpl.
             unfold leq in *. simpl in *.
             setoid_rewrite -> elem_of_subseteq.
             rewrite -> elem_of_subseteq in H.
@@ -406,7 +406,7 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
           }
           {
             intros HBn.
-            intros. repeat rewrite -> pattern_interpretation_imp_simpl.
+            intros. repeat rewrite -> eval_imp_simpl.
             unfold leq in *. simpl in *.
             rewrite elem_of_subseteq. rewrite -> elem_of_subseteq in H.
             intros.
@@ -442,9 +442,9 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
           unfold leq. simpl.
           setoid_rewrite elem_of_subseteq.
 
-          split; intros HBp S1 S2 Hincl; rewrite -> pattern_interpretation_ex_simpl; simpl;
+          split; intros HBp S1 S2 Hincl; rewrite -> eval_ex_simpl; simpl;
           unfold stdpp_ext.propset_fa_union; intros m; rewrite -> elem_of_PropSet;
-            intros [c Hc]; rewrite -> pattern_interpretation_ex_simpl; simpl;
+            intros [c Hc]; rewrite -> eval_ex_simpl; simpl;
               unfold stdpp_ext.propset_fa_union; rewrite -> elem_of_PropSet; exists c;
               remember (update_evar_val fresh c evar_val) as evar_val';
               specialize (IHn Hrb'' evar_val' svar_val V);
@@ -473,7 +473,7 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
           split.
           {
             unfold AntiMonotonicFunction. intros.
-            repeat rewrite -> pattern_interpretation_mu_simpl.
+            repeat rewrite -> eval_mu_simpl.
             Arguments LeastFixpointOf : simpl never.
             Arguments leq : simpl never.
             simpl.
@@ -546,7 +546,7 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
           (* This is the same as the previous, with minor changes *)
           {
             unfold MonotonicFunction. intros.
-            repeat rewrite -> pattern_interpretation_mu_simpl.
+            repeat rewrite -> eval_mu_simpl.
             Arguments LeastFixpointOf : simpl never.
             Arguments leq : simpl never.
             simpl.
@@ -626,7 +626,7 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
         svar_is_fresh_in X phi ->
         @MonotonicFunction A OS
                            (fun S : propset (Domain M) =>
-                              (@pattern_interpretation Σ M evar_val (update_svar_val X S svar_val)
+                              (@eval Σ M evar_val (update_svar_val X S svar_val)
                                                        (svar_open 0 X phi))).
     Proof.
       simpl. intros phi X evar_val svar_val Hwfp Hfr.


### PR DESCRIPTION
* update README
* rename `pattern_interpretation` into `eval`
* an example why equivalence is not the same as equality