### PR TITLE
mlApplyMetaGeneralized

### DIFF
--- a/matching-logic/src/DerivedOperators_Syntax.v
+++ b/matching-logic/src/DerivedOperators_Syntax.v
@@ -190,6 +190,39 @@ Section with_signature.
   End with_signature.
 
 
+Lemma well_formed_foldr_and {Σ : Signature} (x : Pattern) (xs : list Pattern):
+  well_formed x ->
+  Pattern.wf xs ->
+  well_formed (foldr patt_and x xs).
+Proof.
+  intros wfx wfxs.
+  induction xs; simpl.
+  - assumption.
+  - feed specialize IHxs.
+    { unfold Pattern.wf in wfxs. simpl in wfxs. destruct_and!. assumption. }
+    apply well_formed_and.
+    { unfold Pattern.wf in wfxs. simpl in wfxs. destruct_and!. assumption. }
+    assumption.
+Qed.
+
+Lemma wf_rev {Σ : Signature} l:
+  Pattern.wf l ->
+  Pattern.wf (rev l).
+Proof.
+  intros H. induction l; simpl.
+  { exact H. }
+  {
+    apply wf_app; unfold Pattern.wf in *; simpl in *; destruct_and!.
+    {
+      apply IHl. apply H1.
+    }
+    {
+      split_and;[assumption|reflexivity].
+    }
+  }
+Qed.
+
+
 Module Notations.
   Import Syntax.
 

--- a/matching-logic/src/ProofMode_misc.v
+++ b/matching-logic/src/ProofMode_misc.v
@@ -35,15 +35,15 @@ Open Scope list_scope.
 Ltac2 _callCompletedTransformedAndCast
   (t : constr) (transform : constr) (tac : constr -> unit) :=
   let tac' := (fun (t' : constr) =>
-    Message.print (Message.of_constr t');
+    (*Message.print (Message.of_constr t');*)
     let tac'' := (fun (t'' : constr) =>
-      Message.print (Message.of_constr t'');
+      (*Message.print (Message.of_constr t'');*)
       let tcast := open_constr:(@useGenericReasoning'' _ _ _ _ _ $t'') in
       fillWithUnderscoresAndCall tac tcast []
     ) in
-    fillWithUnderscoresAndCall (fun t''' => Message.print (Message.of_constr t'''); tac'' t''') transform [t']
+    fillWithUnderscoresAndCall (fun t''' => (*Message.print (Message.of_constr t''');*) tac'' t''') transform [t']
   ) in
-  Message.print (Message.of_constr t);
+  (*Message.print (Message.of_constr t);*)
   fillWithUnderscoresAndCall tac' t []
 .
 
@@ -78,7 +78,6 @@ Proof.
   toMLGoal.
   { wf_auto2. }
   mlApplyMetaGeneralized H.
-  
   Set Printing Parentheses.
 Abort.
 

--- a/matching-logic/src/ProofMode_misc.v
+++ b/matching-logic/src/ProofMode_misc.v
@@ -35,15 +35,15 @@ Open Scope list_scope.
 Ltac2 _callCompletedTransformedAndCast
   (t : constr) (transform : constr) (tac : constr -> unit) :=
   let tac' := (fun (t' : constr) =>
-    (*Message.print (Message.of_constr t');*)
+    Message.print (Message.of_constr t');
     let tac'' := (fun (t'' : constr) =>
-      (*Message.print (Message.of_constr t'');*)
+      Message.print (Message.of_constr t'');
       let tcast := open_constr:(@useGenericReasoning'' _ _ _ _ _ $t'') in
       fillWithUnderscoresAndCall tac tcast []
     ) in
-    fillWithUnderscoresAndCall (fun t''' => (*Message.print (Message.of_constr t''');*) tac'' t''') transform [t']
+    fillWithUnderscoresAndCall (fun t''' => Message.print (Message.of_constr t'''); tac'' t''') transform [t']
   ) in
-  (*Message.print (Message.of_constr t);*)
+  Message.print (Message.of_constr t);
   fillWithUnderscoresAndCall tac' t []
 .
 
@@ -78,6 +78,7 @@ Proof.
   toMLGoal.
   { wf_auto2. }
   mlApplyMetaGeneralized H.
+  
   Set Printing Parentheses.
 Abort.
 

--- a/matching-logic/src/ProofMode_misc.v
+++ b/matching-logic/src/ProofMode_misc.v
@@ -35,15 +35,12 @@ Open Scope list_scope.
 Ltac2 _callCompletedTransformedAndCast
   (t : constr) (transform : constr) (tac : constr -> unit) :=
   let tac' := (fun (t' : constr) =>
-    Message.print (Message.of_constr t');
     let tac'' := (fun (t'' : constr) =>
-      Message.print (Message.of_constr t'');
       let tcast := open_constr:(@useGenericReasoning'' _ _ _ _ _ $t'') in
       fillWithUnderscoresAndCall tac tcast []
     ) in
-    fillWithUnderscoresAndCall (fun t''' => Message.print (Message.of_constr t'''); tac'' t''') transform [t']
+    fillWithUnderscoresAndCall (fun t''' => tac'' t''') transform [t']
   ) in
-  Message.print (Message.of_constr t);
   fillWithUnderscoresAndCall tac' t []
 .
 
@@ -56,7 +53,7 @@ Ltac2 mlApplyMetaGeneralized (t : constr) :=
 Ltac _mlApplyMetaGeneralized t :=
   let ff := ltac2:(t' |- mlApplyMetaGeneralized (Option.get (Ltac1.to_constr(t')))) in
   ff t;
-  rewrite [foldr patt_and _ _]/foldr
+  rewrite [foldr patt_and _ _]/=
 .
 
 
@@ -64,6 +61,7 @@ Tactic Notation "mlApplyMetaGeneralized" constr(t) :=
   _mlApplyMetaGeneralized t
 .
 
+#[local]
 Example ex_mlApplyMetaGeneralized  {Σ : Signature} Γ a b c d e f:
   well_formed a ->
   well_formed b ->
@@ -72,17 +70,15 @@ Example ex_mlApplyMetaGeneralized  {Σ : Signature} Γ a b c d e f:
   well_formed e ->
   well_formed f ->
   Γ ⊢ a ---> b ---> c ---> d ---> e ---> f ->
-  Γ ⊢ f.
+  Γ ⊢ (a and b and c and d and e) ---> f.
 Proof.
   intros wfa wfb wfc wfd wfe wff H.
   toMLGoal.
   { wf_auto2. }
+  mlIntro "H1".
   mlApplyMetaGeneralized H.
-  fromMLGoal.
-  eapply MP.
-  2: apply foldr_and_last_rotate_1.
-  Set Printing Parentheses.
-Abort.
+  mlExact "H1".
+Defined.
 
 Section FOL_helpers.
 

--- a/matching-logic/src/ProofMode_misc.v
+++ b/matching-logic/src/ProofMode_misc.v
@@ -35,15 +35,15 @@ Open Scope list_scope.
 Ltac2 _callCompletedTransformedAndCast
   (t : constr) (transform : constr) (tac : constr -> unit) :=
   let tac' := (fun (t' : constr) =>
-    (*Message.print (Message.of_constr t');*)
+    Message.print (Message.of_constr t');
     let tac'' := (fun (t'' : constr) =>
-      (*Message.print (Message.of_constr t'');*)
+      Message.print (Message.of_constr t'');
       let tcast := open_constr:(@useGenericReasoning'' _ _ _ _ _ $t'') in
       fillWithUnderscoresAndCall tac tcast []
     ) in
-    fillWithUnderscoresAndCall (fun t''' => (*Message.print (Message.of_constr t''');*) tac'' t''') transform [t']
+    fillWithUnderscoresAndCall (fun t''' => Message.print (Message.of_constr t'''); tac'' t''') transform [t']
   ) in
-  (*Message.print (Message.of_constr t);*)
+  Message.print (Message.of_constr t);
   fillWithUnderscoresAndCall tac' t []
 .
 
@@ -78,6 +78,9 @@ Proof.
   toMLGoal.
   { wf_auto2. }
   mlApplyMetaGeneralized H.
+  fromMLGoal.
+  eapply MP.
+  2: apply foldr_and_last_rotate_1.
   Set Printing Parentheses.
 Abort.
 

--- a/matching-logic/src/ProofMode_misc.v
+++ b/matching-logic/src/ProofMode_misc.v
@@ -3019,6 +3019,15 @@ Proof.
   mlTauto.
 Defined.
 
+Ltac2 _callCompletedTransformedAndCast
+  (t : constr) (transform : constr) (tac : constr -> unit) :=
+  let tac' := (fun (t' : constr) =>
+    let tcast := open_constr:(@useGenericReasoning'' _ _ _ _ _ $t') in
+    fillWithUnderscoresAndCall tac tcast
+  ) in
+  fillWithUnderscoresAndCall tac' t
+.
+
 
 Close Scope ml_scope.
 Close Scope list_scope.

--- a/matching-logic/src/ProofMode_misc.v
+++ b/matching-logic/src/ProofMode_misc.v
@@ -32,6 +32,55 @@ Open Scope ml_scope.
 Open Scope string_scope.
 Open Scope list_scope.
 
+Ltac2 _callCompletedTransformedAndCast
+  (t : constr) (transform : constr) (tac : constr -> unit) :=
+  let tac' := (fun (t' : constr) =>
+    (*Message.print (Message.of_constr t');*)
+    let tac'' := (fun (t'' : constr) =>
+      (*Message.print (Message.of_constr t'');*)
+      let tcast := open_constr:(@useGenericReasoning'' _ _ _ _ _ $t'') in
+      fillWithUnderscoresAndCall tac tcast []
+    ) in
+    fillWithUnderscoresAndCall (fun t''' => (*Message.print (Message.of_constr t''');*) tac'' t''') transform [t']
+  ) in
+  (*Message.print (Message.of_constr t);*)
+  fillWithUnderscoresAndCall tac' t []
+.
+
+Ltac2 mlApplyMetaGeneralized (t : constr) :=
+  _callCompletedTransformedAndCast t constr:(@reshape_lhs_imp_to_and_forward) _mlApplyMetaRaw ;
+  try_solve_pile_basic ();
+  try_wfa ()
+.
+
+Ltac _mlApplyMetaGeneralized t :=
+  let ff := ltac2:(t' |- mlApplyMetaGeneralized (Option.get (Ltac1.to_constr(t')))) in
+  ff t;
+  rewrite [foldr patt_and _ _]/foldr
+.
+
+
+Tactic Notation "mlApplyMetaGeneralized" constr(t) :=
+  _mlApplyMetaGeneralized t
+.
+
+Example ex_mlApplyMetaGeneralized  {Σ : Signature} Γ a b c d e f:
+  well_formed a ->
+  well_formed b ->
+  well_formed c ->
+  well_formed d ->
+  well_formed e ->
+  well_formed f ->
+  Γ ⊢ a ---> b ---> c ---> d ---> e ---> f ->
+  Γ ⊢ f.
+Proof.
+  intros wfa wfb wfc wfd wfe wff H.
+  toMLGoal.
+  { wf_auto2. }
+  mlApplyMetaGeneralized H.
+  Set Printing Parentheses.
+Abort.
+
 Section FOL_helpers.
 
   Context {Σ : Signature}.
@@ -3019,50 +3068,7 @@ Proof.
   mlTauto.
 Defined.
 
-Ltac2 _callCompletedTransformedAndCast
-  (t : constr) (transform : constr) (tac : constr -> unit) :=
-  let tac' := (fun (t' : constr) =>
-    Message.print (Message.of_constr t');
-    let tac'' := (fun (t'' : constr) =>
-      Message.print (Message.of_constr t'');
-      let tcast := open_constr:(@useGenericReasoning'' _ _ _ _ _ $t'') in
-      fillWithUnderscoresAndCall tac tcast []
-    ) in
-    fillWithUnderscoresAndCall (fun t''' => Message.print (Message.of_constr t'''); tac'' t''') transform [t']
-  ) in
-  Message.print (Message.of_constr t);
-  fillWithUnderscoresAndCall tac' t []
-.
 
-Ltac2 mlApplyMetaGeneralized (t : constr) :=
-  _callCompletedTransformedAndCast t constr:(@reshape_lhs_imp_to_and_forward) _mlApplyMetaRaw ;
-  try_solve_pile_basic ();
-  try_wfa ()
-.
-
-Ltac _mlApplyMetaGeneralized t :=
-  let ff := ltac2:(t' |- mlApplyMetaGeneralized (Option.get (Ltac1.to_constr(t')))) in
-  ff t
-.
-
-
-Tactic Notation "mlApplyMetaGeneralized" constr(t) :=
-  _mlApplyMetaGeneralized t
-.
-
-Example ex_mlApplyMetaGeneralized  {Σ : Signature} Γ a b c d:
-  well_formed a ->
-  well_formed b ->
-  well_formed c ->
-  well_formed d ->
-  Γ ⊢ a ---> b ---> c ---> d ->
-  Γ ⊢ d.
-Proof.
-  intros wfa wfb wfc wfd H.
-  toMLGoal.
-  { wf_auto2. }
-  mlApplyMetaGeneralized H.
-Abort.
 
 Close Scope ml_scope.
 Close Scope list_scope.

--- a/matching-logic/src/ProofMode_propositional.v
+++ b/matching-logic/src/ProofMode_propositional.v
@@ -3947,7 +3947,6 @@ Proof.
   apply foldr_and_weaken_last; assumption.
 Defined.
 
-
 Lemma foldr_and_last_rotate {Σ : Signature} Γ (x1 x2 : Pattern) (xs : list Pattern):
   well_formed x1 ->
   well_formed x2 ->
@@ -3955,8 +3954,7 @@ Lemma foldr_and_last_rotate {Σ : Signature} Γ (x1 x2 : Pattern) (xs : list Pat
   Γ ⊢i ((foldr patt_and x2 (xs ++ [x1])) <---> (x2 and (foldr patt_and x1 xs))) using BasicReasoning.
 Proof.
   intros wfx1 wfx2 wfxs.
-  move: x1 x2 wfx1 wfx2.
-  induction xs; intros x1 x2 wfx1 wfx2; simpl.
+  destruct xs; simpl.
   {
     apply patt_and_comm; assumption.
   }
@@ -3970,6 +3968,8 @@ Proof.
     assert (Hwf1: well_formed (foldr patt_and (x1 and x2) xs)).
     { apply well_formed_foldr_and;[wf_auto2|assumption]. }
     assert (Hwf2: well_formed (foldr patt_and x1 xs)).
+    { apply well_formed_foldr_and; assumption. }
+    assert (Hwf3: well_formed (foldr patt_and x2 xs)).
     { apply well_formed_foldr_and; assumption. }
 
     rewrite foldr_app. simpl. 
@@ -3989,9 +3989,29 @@ Proof.
       }
       { mlExact "Ha". }
       {
-
+        mlApplyMeta foldr_and_weaken_last_meta in "Hf".
+        2: { apply pf_conj_elim_l; wf_auto2. }
+        2: wf_auto2.
+        mlExact "Hf".
       }
-      specialize (IHxs wfxs).
+    }
+    {
+      mlDestructAnd "H" as "H1" "H1'".
+      mlDestructAnd "H1'" as "H2" "H3".
+      mlSplitAnd;[mlExact "H2"|].
+      mlAssert ("Hf": (x2 and foldr patt_and x1 xs)).
+      { wf_auto2. }
+      { mlSplitAnd;[mlExact "H1"|mlExact "H3"]. }
+      mlAdd (foldr_and_weaken_last Γ x1 (x1 and x2) xs ltac:(wf_auto2) ltac:(wf_auto2) ltac:(wf_auto2))as "Hw".
+      mlAssert ("Hw'" : (foldr patt_and x1 xs ---> foldr patt_and (x1 and x2) xs)).
+      { wf_auto2. }
+      {
+        mlApply "Hw".
+        mlIntro "Hx1".
+        mlSplitAnd;[mlExact "Hx1"|mlExact "H1"].
+      }
+      mlApply "Hw'".
+      mlExact "H3".
     }
   }
 Defined.

--- a/matching-logic/src/ProofMode_propositional.v
+++ b/matching-logic/src/ProofMode_propositional.v
@@ -2786,6 +2786,12 @@ Ltac2 rec applyRec (f : constr) (xs : constr list) : constr :=
   | y::ys => (applyRec constr:($f $y) ys)
   end.
 
+Ltac2 Eval (applyRec constr:(S) [constr:("")]).
+
+Ltac2 fitsExactly (f : constr) (xs : constr list) : bool :=
+
+.
+
 (*
   All thic complicated code is here only for one reason:
   I want to be able to first run the tactic with all the parameters

--- a/matching-logic/src/ProofMode_propositional.v
+++ b/matching-logic/src/ProofMode_propositional.v
@@ -3975,10 +3975,6 @@ Proof.
     rewrite foldr_app. simpl. 
     toMLGoal.
     { wf_auto2. }
-    (*
-    mlAdd IHxs as "IH".
-    mlDestructAnd "IH" as "IH1" "IH2".
-    *)
     mlSplitAnd; mlIntro "H".
     {
       mlDestructAnd "H" as "Ha" "Hf".
@@ -4014,6 +4010,44 @@ Proof.
       mlExact "H3".
     }
   }
+Defined.
+
+Lemma foldr_and_last_rotate_1 {Σ : Signature} Γ (x1 x2 : Pattern) (xs : list Pattern):
+  well_formed x1 ->
+  well_formed x2 ->
+  Pattern.wf xs ->
+  Γ ⊢i ((foldr patt_and x2 (xs ++ [x1])) ---> (x2 and (foldr patt_and x1 xs))) using BasicReasoning.
+Proof.
+  intros.
+  assert (well_formed (foldr patt_and (x1 and x2) xs)).
+  { apply well_formed_foldr_and; wf_auto2. }
+  assert (well_formed (foldr patt_and x1 xs)).
+  { apply well_formed_foldr_and; wf_auto2. }
+  eapply pf_iff_proj1.
+  3: { apply foldr_and_last_rotate; assumption. }
+  {
+    rewrite foldr_app. simpl. wf_auto2.
+  }
+  apply well_formed_and; wf_auto2.
+Defined.
+
+Lemma foldr_and_last_rotate_2 {Σ : Signature} Γ (x1 x2 : Pattern) (xs : list Pattern):
+  well_formed x1 ->
+  well_formed x2 ->
+  Pattern.wf xs ->
+  Γ ⊢i ((x2 and (foldr patt_and x1 xs)) ---> ((foldr patt_and x2 (xs ++ [x1])))) using BasicReasoning.
+Proof.
+  intros.
+  assert (well_formed (foldr patt_and (x1 and x2) xs)).
+  { apply well_formed_foldr_and; wf_auto2. }
+  assert (well_formed (foldr patt_and x1 xs)).
+  { apply well_formed_foldr_and; wf_auto2. }
+  eapply pf_iff_proj2.
+  3: { apply foldr_and_last_rotate; assumption. }
+  {
+    rewrite foldr_app. simpl. wf_auto2.
+  }
+  apply well_formed_and; wf_auto2.
 Defined.
 
 #[local]

--- a/matching-logic/src/ProofMode_propositional.v
+++ b/matching-logic/src/ProofMode_propositional.v
@@ -3802,7 +3802,7 @@ Lemma lhs_imp_to_and {Σ : Signature} Γ (g x : Pattern) (xs : list Pattern):
   well_formed g ->
   well_formed x ->
   Pattern.wf xs ->
-  Γ ⊢i (foldr patt_imp g (xs ++ [x])) ---> (foldr patt_and x xs ---> g)
+  Γ ⊢i (foldr patt_imp g (x :: xs)) ---> (foldr patt_and x xs ---> g)
   using BasicReasoning.
 Proof.
   intros wfg wfx wfxs.
@@ -3827,7 +3827,8 @@ Proof.
     mlIntro "H1".
     mlIntro "H2".
     mlDestructAnd "H2" as "H3" "H4".
-    mlAssert ("H5": (foldr patt_imp g (xs ++ [x]))).
+    mlApplyMeta reorder in "H1".
+    mlAssert ("H5": (x ---> foldr patt_imp g xs)).
     { wf_auto2. }
     {
       mlApply "H1".
@@ -3849,7 +3850,7 @@ Lemma lhs_imp_to_and_meta {Σ : Signature} Γ (g x : Pattern) (xs : list Pattern
   well_formed g ->
   well_formed x ->
   Pattern.wf xs ->
-  Γ ⊢i (foldr patt_imp g (xs ++ [x])) using i ->
+  Γ ⊢i (foldr patt_imp g (x :: xs)) using i ->
   Γ ⊢i (foldr patt_and x xs ---> g) using i.
 Proof.
   intros wfg wfx wfxs H.

--- a/matching-logic/src/ProofMode_propositional.v
+++ b/matching-logic/src/ProofMode_propositional.v
@@ -3802,7 +3802,7 @@ Lemma lhs_imp_to_and {Σ : Signature} Γ (g x : Pattern) (xs : list Pattern):
   well_formed g ->
   well_formed x ->
   Pattern.wf xs ->
-  Γ ⊢i (foldr patt_imp g (x :: xs)) ---> (foldr patt_and x xs ---> g)
+  Γ ⊢i (foldr patt_imp g (xs ++ [x])) ---> (foldr patt_and x xs ---> g)
   using BasicReasoning.
 Proof.
   intros wfg wfx wfxs.
@@ -3827,8 +3827,7 @@ Proof.
     mlIntro "H1".
     mlIntro "H2".
     mlDestructAnd "H2" as "H3" "H4".
-    mlApplyMeta reorder in "H1".
-    mlAssert ("H5": (x ---> foldr patt_imp g xs)).
+    mlAssert ("H5": (foldr patt_imp g (xs ++ [x]))).
     { wf_auto2. }
     {
       mlApply "H1".
@@ -3850,7 +3849,7 @@ Lemma lhs_imp_to_and_meta {Σ : Signature} Γ (g x : Pattern) (xs : list Pattern
   well_formed g ->
   well_formed x ->
   Pattern.wf xs ->
-  Γ ⊢i (foldr patt_imp g (x :: xs)) using i ->
+  Γ ⊢i (foldr patt_imp g (xs ++ [x])) using i ->
   Γ ⊢i (foldr patt_and x xs ---> g) using i.
 Proof.
   intros wfg wfx wfxs H.

--- a/matching-logic/src/ProofMode_propositional.v
+++ b/matching-logic/src/ProofMode_propositional.v
@@ -3723,24 +3723,6 @@ Proof.
   mlExact "H2".
 Defined.
 
-
-
-Local Lemma well_formed_foldr_and {Σ : Signature} (x : Pattern) (xs : list Pattern):
-  well_formed x ->
-  Pattern.wf xs ->
-  well_formed (foldr patt_and x xs).
-Proof.
-  intros wfx wfxs.
-  induction xs; simpl.
-  - assumption.
-  - feed specialize IHxs.
-    { unfold Pattern.wf in wfxs. simpl in wfxs. destruct_and!. assumption. }
-    apply well_formed_and.
-    { unfold Pattern.wf in wfxs. simpl in wfxs. destruct_and!. assumption. }
-    assumption.
-Qed.
-
-
 Lemma lhs_and_to_imp {Σ : Signature} Γ (g x : Pattern) (xs : list Pattern):
   well_formed g ->
   well_formed x ->
@@ -4049,7 +4031,7 @@ Proof.
   }
   apply well_formed_and; wf_auto2.
 Defined.
-
+Locate MP.
 #[local]
 Ltac tryExact l idx :=
   match l with

--- a/matching-logic/src/ProofMode_propositional.v
+++ b/matching-logic/src/ProofMode_propositional.v
@@ -3740,24 +3740,6 @@ Proof.
     assumption.
 Qed.
 
-Local Lemma well_formed_foldl_and {Σ : Signature} (x : Pattern) (xs : list Pattern):
-  well_formed x ->
-  Pattern.wf xs ->
-  well_formed (foldl patt_and x xs).
-Proof.
-  intros wfx wfxs.
-  induction xs using rev_ind; simpl.
-  - assumption.
-  - feed specialize IHxs.
-    { apply wfapp_proj_1 in wfxs. exact wfxs. }
-    rewrite foldl_app. simpl.
-    apply well_formed_and.
-    { apply IHxs. }
-    { apply wfapp_proj_2 in wfxs. unfold Pattern.wf in wfxs. simpl in wfxs.
-      rewrite andb_true_r in wfxs.
-      exact wfxs.
-    }
-Qed.
 
 Lemma lhs_and_to_imp {Σ : Signature} Γ (g x : Pattern) (xs : list Pattern):
   well_formed g ->
@@ -3862,47 +3844,6 @@ Proof.
   }
 Defined.
 
-Lemma and_foldl_foldr {Σ : Signature} Γ (x : Pattern) (xs : list Pattern):
-  well_formed x ->
-  Pattern.wf xs ->
-  Γ ⊢i (foldl patt_and x xs <---> (foldr patt_and x xs))
-  using BasicReasoning.
-Proof.
-  intros wfx wfxs.
-  induction xs; simpl.
-  {
-    apply pf_iff_equiv_refl.
-    exact wfx.
-  }
-  {
-    pose proof (wfaxs := wfxs).
-    unfold Pattern.wf in wfxs.
-    simpl in wfxs.
-    apply andb_prop in wfxs as [wfa wfxs].
-    fold (Pattern.wf xs) in wfxs.
-    assert (Hwffaxxs: well_formed (foldr patt_and x xs)).
-    { apply well_formed_foldr_and; assumption. }
-    assert (Hwffa: well_formed (foldl patt_and (x and a) xs)).
-    { apply well_formed_foldl_and; wf_auto2. }
-    specialize (IHxs wfxs).
-    induction xs using rev_ind.
-    toMLGoal.
-    { wf_auto2. }
-    mlSplitAnd; mlIntro "H1"; mlAdd IHxs as "H2"; mlDestructAnd "H2" as "H3" "H4".
-    {
-      mlSplitAnd.
-      {
-        clear. induction xs.
-        {
-          simpl. mlDestructAnd "H1" as "H11" "H12". mlExact "H12".
-        }
-        {
-
-        }
-      }
-    }
-  }
-Defined.
 
 Lemma lhs_imp_to_and_meta {Σ : Signature} Γ (g x : Pattern) (xs : list Pattern) i:
   well_formed g ->

--- a/matching-logic/src/ProofMode_reshaper.v
+++ b/matching-logic/src/ProofMode_reshaper.v
@@ -166,4 +166,127 @@ Section with_signature.
     apply lhs_and_to_imp_r.
   Abort.
 
+
+  Structure AndReshapeS (g : Pattern) (l : list Pattern) :=
+  AndReshape
+    { ars_flattened :> TaggedPattern ;
+      ars_pf : (untagPattern ars_flattened) = foldr patt_and g l ;
+    }.
+
+  Lemma AndReshape_nil_pf0:
+    ∀ (g : Pattern),
+      g = foldr patt_and g [].
+  Proof. intros. reflexivity. Qed.
+
+  Canonical Structure AndReshape_nil (g : Pattern) : AndReshapeS g [] :=
+    AndReshape g [] (reshape_nil g) (AndReshape_nil_pf0 g).
+
+
+  Program Canonical Structure AndReshape_cons
+     (g x : Pattern) (xs : list Pattern) (r : AndReshapeS g xs)
+  : AndReshapeS g (x::xs) :=
+    AndReshape g (x::xs) (reshape_cons (x and untagPattern (reshape_cons r))) _.
+  Next Obligation.
+    intros g x xs r. simpl.
+    rewrite ars_pf.
+    reflexivity.
+  Qed.
+
+
+  Lemma reshape_and (Γ : Theory) (g : Pattern) (xs: list Pattern) (i : ProofInfo) :
+    forall (r : AndReshapeS g xs),
+       Γ ⊢i foldr (patt_and) g xs using i ->
+       Γ ⊢i (untagPattern (ars_flattened _ _ r)) using i.
+  Proof.
+    intros r [pf Hpf].
+    unshelve (eexists).
+    {
+      eapply cast_proof.
+      { rewrite ars_pf; reflexivity. }
+      exact pf.
+    }
+    {
+      simpl.
+      destruct Hpf as [Hpf2 Hpf3 Hpf4].
+      constructor.
+      {
+        rewrite elem_of_subseteq in Hpf2.
+        rewrite elem_of_subseteq.
+        intros x Hx.
+        specialize (Hpf2 x).
+        apply Hpf2. clear Hpf2.
+        rewrite elem_of_gset_to_coGset in Hx.
+        rewrite uses_of_ex_gen_correct in Hx.
+        rewrite elem_of_gset_to_coGset.
+        rewrite uses_of_ex_gen_correct.
+        rewrite indifferent_to_cast_uses_ex_gen in Hx.
+        exact Hx.
+      }
+      {
+        rewrite elem_of_subseteq in Hpf3.
+        rewrite elem_of_subseteq.
+        intros x Hx.
+        specialize (Hpf3 x).
+        apply Hpf3. clear Hpf3.
+        rewrite elem_of_gset_to_coGset in Hx.
+        rewrite uses_of_svar_subst_correct in Hx.
+        rewrite elem_of_gset_to_coGset.
+        rewrite uses_of_svar_subst_correct.
+        rewrite indifferent_to_cast_uses_svar_subst in Hx.
+        exact Hx.
+      }
+      {
+        rewrite indifferent_to_cast_uses_kt.
+        apply Hpf4.
+      }
+      {
+        rewrite framing_patterns_cast_proof.
+        destruct i;assumption.
+      }
+    }
+  Defined.
+
+  Local Example ex_reshape_and Γ a b c d:
+  well_formed a ->
+  well_formed b ->
+  well_formed c ->
+  well_formed d ->
+  Γ ⊢i a and b and c and d using BasicReasoning.
+  Proof.
+    intros wfa wfb wfc wfd.
+    apply reshape_and.
+  (* Now the goal has the right shape *)
+  Abort.
+
+    (*
+      Γ ⊢ φ₁ ---> ... ---> φₖ ---> ψ
+      ------------------------------
+      Γ ⊢ (φ₁ and ... and φₖ) ---> ψ
+    *)
+  Lemma lhs_imp_to_and_r Γ (g x : Pattern) (xs : list Pattern) i :
+    well_formed g ->
+    well_formed x ->
+    Pattern.wf xs ->
+    forall (r : AndReshapeS x xs),
+       Γ ⊢i ((foldr (patt_imp) g (x::xs))) using i ->
+       Γ ⊢i (untagPattern (ars_flattened _ _ r)) ---> g using i .
+  Proof.
+    intros wfg wfx wfxs r H.
+    eapply cast_proof'.
+    { rewrite ars_pf; reflexivity. }
+    clear r.
+    apply lhs_imp_to_and_meta; assumption.
+  Defined.
+
+  Local Example ex_match_and Γ a b c d:
+   well_formed a ->
+   well_formed b ->
+   well_formed c ->
+   well_formed d ->
+   Γ ⊢i (a and b and c) ---> d using BasicReasoning.
+  Proof.
+   intros wfa wfb wfc wfd.
+   apply lhs_imp_to_and_r; simpl.
+  Abort.
+
 End with_signature.

--- a/matching-logic/src/ProofMode_reshaper.v
+++ b/matching-logic/src/ProofMode_reshaper.v
@@ -163,15 +163,14 @@ Section with_signature.
     well_formed g ->
     well_formed x ->
     Pattern.wf xs ->
-    forall (r : ImpReshapeS g (x::xs)),
+    forall (r : ImpReshapeS g (xs++[x])),
        Γ ⊢i untagPattern (irs_flattened _ _ r) using i ->
-       Γ ⊢i ((foldl (patt_and) x xs) ---> g) using i.
+       Γ ⊢i ((foldr (patt_and) x xs) ---> g) using i.
   Proof.
     intros wfg wfx wfxs r H.
     eapply cast_proof' in H.
     2: { rewrite irs_pf; reflexivity. }
     clear r.
-    simpl in H.
     apply lhs_imp_to_and_meta; try assumption.
   Defined.
 

--- a/matching-logic/src/ProofMode_reshaper.v
+++ b/matching-logic/src/ProofMode_reshaper.v
@@ -163,7 +163,7 @@ Section with_signature.
     well_formed g ->
     well_formed x ->
     Pattern.wf xs ->
-    forall (r : ImpReshapeS g (xs++[x])),
+    forall (r : ImpReshapeS g (x::xs)),
        Γ ⊢i untagPattern (irs_flattened _ _ r) using i ->
        Γ ⊢i ((foldr (patt_and) x xs) ---> g) using i.
   Proof.
@@ -171,7 +171,7 @@ Section with_signature.
     eapply cast_proof' in H.
     2: { rewrite irs_pf; reflexivity. }
     clear r.
-    apply lhs_imp_to_and_meta; try assumption.
+    apply lhs_imp_to_and_meta; assumption.
   Defined.
 
   Local Example ex_match_imp Γ a b c d:
@@ -215,9 +215,9 @@ Section with_signature.
   Qed.
 
 
-  Lemma reshape_and (Γ : Theory) (x : Pattern) (xs: list Pattern) (i : ProofInfo) :
-    forall (r : AndReshapeS x xs),
-       Γ ⊢i foldr (patt_and) x xs using i ->
+  Lemma reshape_and (Γ : Theory) (g : Pattern) (xs: list Pattern) (i : ProofInfo) :
+    forall (r : AndReshapeS g xs),
+       Γ ⊢i foldr (patt_and) g xs using i ->
        Γ ⊢i (untagPattern (ars_flattened _ _ r)) using i.
   Proof.
     intros r [pf Hpf].
@@ -234,8 +234,8 @@ Section with_signature.
       {
         rewrite elem_of_subseteq in Hpf2.
         rewrite elem_of_subseteq.
-        intros x' Hx.
-        specialize (Hpf2 x').
+        intros x Hx.
+        specialize (Hpf2 x).
         apply Hpf2. clear Hpf2.
         rewrite elem_of_gset_to_coGset in Hx.
         rewrite uses_of_ex_gen_correct in Hx.
@@ -247,8 +247,8 @@ Section with_signature.
       {
         rewrite elem_of_subseteq in Hpf3.
         rewrite elem_of_subseteq.
-        intros x' Hx.
-        specialize (Hpf3 x').
+        intros x Hx.
+        specialize (Hpf3 x).
         apply Hpf3. clear Hpf3.
         rewrite elem_of_gset_to_coGset in Hx.
         rewrite uses_of_svar_subst_correct in Hx.
@@ -290,14 +290,14 @@ Section with_signature.
     well_formed x ->
     Pattern.wf xs ->
     forall (r : AndReshapeS x xs),
-       Γ ⊢i ((foldr (patt_imp) g (xs ++ [x]))) using i ->
+       Γ ⊢i ((foldr (patt_imp) g (x::xs))) using i ->
        Γ ⊢i (untagPattern (ars_flattened _ _ r)) ---> g using i .
   Proof.
     intros wfg wfx wfxs r H.
     eapply cast_proof'.
     { rewrite ars_pf; reflexivity. }
     clear r.
-    apply lhs_imp_to_and_meta; try assumption.
+    apply lhs_imp_to_and_meta; assumption.
   Defined.
 
   Lemma reshape_lhs_and_to_imp_forward Γ (g x : Pattern) (xs : list Pattern) i :

--- a/matching-logic/src/ProofMode_reshaper.v
+++ b/matching-logic/src/ProofMode_reshaper.v
@@ -163,14 +163,15 @@ Section with_signature.
     well_formed g ->
     well_formed x ->
     Pattern.wf xs ->
-    forall (r : ImpReshapeS g (xs++[x])),
+    forall (r : ImpReshapeS g (x::xs)),
        Γ ⊢i untagPattern (irs_flattened _ _ r) using i ->
-       Γ ⊢i ((foldr (patt_and) x xs) ---> g) using i.
+       Γ ⊢i ((foldl (patt_and) x xs) ---> g) using i.
   Proof.
     intros wfg wfx wfxs r H.
     eapply cast_proof' in H.
     2: { rewrite irs_pf; reflexivity. }
     clear r.
+    simpl in H.
     apply lhs_imp_to_and_meta; try assumption.
   Defined.
 

--- a/matching-logic/src/ProofMode_reshaper.v
+++ b/matching-logic/src/ProofMode_reshaper.v
@@ -163,7 +163,7 @@ Section with_signature.
     well_formed g ->
     well_formed x ->
     Pattern.wf xs ->
-    forall (r : ImpReshapeS g (x::xs)),
+    forall (r : ImpReshapeS g (xs++[x])),
        Γ ⊢i untagPattern (irs_flattened _ _ r) using i ->
        Γ ⊢i ((foldr (patt_and) x xs) ---> g) using i.
   Proof.
@@ -171,7 +171,7 @@ Section with_signature.
     eapply cast_proof' in H.
     2: { rewrite irs_pf; reflexivity. }
     clear r.
-    apply lhs_imp_to_and_meta; assumption.
+    apply lhs_imp_to_and_meta; try assumption.
   Defined.
 
   Local Example ex_match_imp Γ a b c d:
@@ -215,9 +215,9 @@ Section with_signature.
   Qed.
 
 
-  Lemma reshape_and (Γ : Theory) (g : Pattern) (xs: list Pattern) (i : ProofInfo) :
-    forall (r : AndReshapeS g xs),
-       Γ ⊢i foldr (patt_and) g xs using i ->
+  Lemma reshape_and (Γ : Theory) (x : Pattern) (xs: list Pattern) (i : ProofInfo) :
+    forall (r : AndReshapeS x xs),
+       Γ ⊢i foldr (patt_and) x xs using i ->
        Γ ⊢i (untagPattern (ars_flattened _ _ r)) using i.
   Proof.
     intros r [pf Hpf].
@@ -234,8 +234,8 @@ Section with_signature.
       {
         rewrite elem_of_subseteq in Hpf2.
         rewrite elem_of_subseteq.
-        intros x Hx.
-        specialize (Hpf2 x).
+        intros x' Hx.
+        specialize (Hpf2 x').
         apply Hpf2. clear Hpf2.
         rewrite elem_of_gset_to_coGset in Hx.
         rewrite uses_of_ex_gen_correct in Hx.
@@ -247,8 +247,8 @@ Section with_signature.
       {
         rewrite elem_of_subseteq in Hpf3.
         rewrite elem_of_subseteq.
-        intros x Hx.
-        specialize (Hpf3 x).
+        intros x' Hx.
+        specialize (Hpf3 x').
         apply Hpf3. clear Hpf3.
         rewrite elem_of_gset_to_coGset in Hx.
         rewrite uses_of_svar_subst_correct in Hx.
@@ -290,14 +290,14 @@ Section with_signature.
     well_formed x ->
     Pattern.wf xs ->
     forall (r : AndReshapeS x xs),
-       Γ ⊢i ((foldr (patt_imp) g (x::xs))) using i ->
+       Γ ⊢i ((foldr (patt_imp) g (xs ++ [x]))) using i ->
        Γ ⊢i (untagPattern (ars_flattened _ _ r)) ---> g using i .
   Proof.
     intros wfg wfx wfxs r H.
     eapply cast_proof'.
     { rewrite ars_pf; reflexivity. }
     clear r.
-    apply lhs_imp_to_and_meta; assumption.
+    apply lhs_imp_to_and_meta; try assumption.
   Defined.
 
   Lemma reshape_lhs_and_to_imp_forward Γ (g x : Pattern) (xs : list Pattern) i :

--- a/matching-logic/src/ProofMode_reshaper.v
+++ b/matching-logic/src/ProofMode_reshaper.v
@@ -134,6 +134,11 @@ Section with_signature.
   Abort.
 
 
+  (*
+    Γ ⊢ (φ₁ and ... and φₖ) ---> ψ
+    -------------------------------
+    Γ ⊢ φ₁ ---> ... ---> φₖ ---> ψ
+  *)
   Lemma lhs_and_to_imp_r Γ (g x : Pattern) (xs : list Pattern) i :
     well_formed g ->
     well_formed x ->

--- a/matching-logic/src/Semantics.v
+++ b/matching-logic/src/Semantics.v
@@ -166,9 +166,8 @@ Section semantics.
   Lemma update_evar_val_same x m ρ :
     evar_valuation (update_evar_val x m ρ) x = m.
   Proof.
-    unfold update_evar_val. simpl. destruct (decide (x = x)); simpl.
-    + reflexivity.
-    + contradiction.
+    unfold update_evar_val. simpl.
+    rewrite decide_eq_same. reflexivity.
   Qed.
 
   Lemma update_evar_val_neq (ρ : Valuation) x1 e x2 :
@@ -1232,7 +1231,7 @@ Section with_model.
         * repeat rewrite -> eval_bound_evar_simpl; auto.
         * rewrite eval_free_svar_simpl. unfold update_svar_val.
           destruct ρ as [ρₑ ρₛ]. simpl.
-          destruct (decide (X = X)). simpl. auto. contradiction.
+          rewrite decide_eq_same. reflexivity.
         * repeat rewrite -> eval_bound_svar_simpl; auto.
       + (* sym *)
         simpl. repeat rewrite -> eval_sym_simpl; auto.

--- a/matching-logic/src/Syntax.v
+++ b/matching-logic/src/Syntax.v
@@ -1432,6 +1432,9 @@ Section with_signature.
 
 End with_signature.
 
+
+(* TODO remove these hints *)
+
 #[export]
  Hint Resolve well_formed_positive_svar_quantify : core.
 

--- a/matching-logic/src/SyntaxLemmas/PatternCtxApplicationCtx.v
+++ b/matching-logic/src/SyntaxLemmas/PatternCtxApplicationCtx.v
@@ -109,7 +109,7 @@ Lemma count_evar_occurrences_subst_ctx AC x:
 Proof.
   intros H.
   induction AC; simpl.
-  - destruct (decide (x = x)); [reflexivity|contradiction].
+  - rewrite decide_eq_same. reflexivity.
   - simpl in H. apply not_elem_of_union in H.
   rewrite IHAC;[exact (proj1 H)|].
   rewrite count_evar_occurrences_0; [exact (proj2 H)|].
@@ -152,7 +152,7 @@ Proof.
   assert (Hcount0: count_evar_occurrences boxvar p = 0).
   { lia. }
   rewrite Hcount0.
-  destruct (decide (0 = 0)). 2: contradiction. simpl. clear e.
+  rewrite decide_eq_same.
   f_equal.
   2: { apply proof_irrelevance. }
   rewrite IHAC;[assumption|reflexivity].
@@ -174,7 +174,7 @@ Proof.
   { lia. }
 
   rewrite Hcount0.
-  destruct (decide (0 = 0)). 2: contradiction. simpl. clear e.
+  rewrite decide_eq_same.
 
   f_equal.
   2: { apply proof_irrelevance. }
@@ -210,9 +210,7 @@ Proof.
   induction AC.
   - unfold ApplicationContext2PatternCtx,ApplicationContext2PatternCtx'.
     unfold emplace. simpl. unfold free_evar_subst. simpl.
-    destruct (decide (_ = _)); simpl.
-    + reflexivity.
-    + contradiction.
+    rewrite decide_eq_same. reflexivity.
   - simpl.
     rewrite -IHAC.
     unfold ApplicationContext2PatternCtx,ApplicationContext2PatternCtx'.

--- a/matching-logic/src/Theories/Definedness_ProofSystem.v
+++ b/matching-logic/src/Theories/Definedness_ProofSystem.v
@@ -2197,10 +2197,29 @@ Definition dt_exgen_from_fp (ψ : Pattern) (gpi : ProofInfo) : coEVarSet :=
     }
   Qed.
 
+  Lemma evar_quantify_equal_simpl : forall φ1 φ2 x n,
+      evar_quantify x n (φ1 =ml φ2) = (evar_quantify x n φ1) =ml (evar_quantify x n φ2).
+  Proof. auto. Qed.
+
+  Definition is_functional ϕ : Pattern :=
+    (ex, ϕ =ml b0).
+
+  Lemma patt_eq_comm φ φ' Γ:
+    theory ⊆ Γ ->
+    well_formed φ ->
+    well_formed φ' ->
+    Γ ⊢ (φ =ml φ') <---> (φ' =ml φ).
+  Proof.
+    intros HΓ wfφ wfφ'.
+    pose proof (SYM1 := @patt_eq_sym Γ φ' φ HΓ wfφ' wfφ).
+    pose proof (SYM2 := @patt_eq_sym Γ φ φ' HΓ wfφ wfφ').
+    apply pf_iff_split. 3,4: assumption. 1,2: wf_auto2. 
+  Defined.
+
   Lemma exists_functional_subst φ φ' Γ :
     theory ⊆ Γ ->
     mu_free φ -> well_formed φ' -> well_formed_closed_ex_aux φ 1 -> well_formed_closed_mu_aux φ 0 ->
-    Γ ⊢i ((instantiate (patt_exists φ) φ') and (patt_exists (patt_equal φ' (patt_bound_evar 0)))) ---> (patt_exists φ)
+    Γ ⊢i ((instantiate (patt_exists φ) φ') and is_functional φ') ---> (patt_exists φ)
     using AnyReasoning.
   Proof.
     intros HΓ MF WF WFB WFM.
@@ -2208,12 +2227,13 @@ Definition dt_exgen_from_fp (ψ : Pattern) (gpi : ProofInfo) : coEVarSet :=
     remember (patt_free_evar Zvar) as Z.
     assert (well_formed Z) as WFZ.
     { rewrite HeqZ. auto. }
-    assert (Γ ⊢i (patt_equal φ' Z <---> patt_equal Z φ') using AnyReasoning).
+    (*
+    assert (Hcomm: Γ ⊢ (patt_equal φ' Z <---> patt_equal Z φ')).
     {
-      pose proof (SYM1 := patt_eq_sym Γ φ' Z ltac:(auto) ltac:(auto) WFZ).
-      pose proof (SYM2 := patt_eq_sym Γ Z φ' ltac:(assumption) WFZ ltac:(auto)).
-      apply pf_iff_split. 3,4: assumption. 1,2: wf_auto2.  
+      apply patt_eq_comm; assumption.
     }
+    apply pf_iff_iff in Hcomm. destruct Hcomm.     2,3: wf_auto2. *)
+
     assert (well_formed (instantiate (ex , φ) φ')) as WF1. {
       unfold instantiate.
       unfold well_formed, well_formed_closed.
@@ -2232,10 +2252,8 @@ Definition dt_exgen_from_fp (ψ : Pattern) (gpi : ProofInfo) : coEVarSet :=
       now apply mu_free_wfp.
     }
     pose proof (equality_elimination2 Γ φ' Z φ HΓ MF WF WFZ WFB).
-    apply pf_iff_iff in H. destruct H.
     assert (well_formed (ex, φ)) as WFEX.
     { wf_auto. now apply mu_free_wfp. }
-    2,3: wf_auto2.
     pose proof (EQ := Ex_quan Γ φ Zvar WFEX).
     change constraint in EQ.
     epose proof (PC := prf_conclusion Γ (patt_equal φ' Z) (instantiate (ex , φ) (patt_free_evar Zvar) ---> ex , φ) AnyReasoning ltac:(apply well_formed_equal;wf_auto2) _ EQ).
@@ -4268,28 +4286,32 @@ Lemma MLGoal_mlSpecialize {Σ : Signature} {syntax : Syntax} Γ l₁ l₂ p t g 
   mkMLGoal Σ Γ (l₁ ++ (mkNH _ name ((all, p) and (ex , t =ml b0)))::l₂) g AnyReasoning.
 Proof.
   intros HΓ MF WF MG.
-  unfold of_MLGoal in *. simpl in *. wf_auto2.
+  unfold of_MLGoal in *. simpl in *. intros H H0.
   assert (well_formed (ex , p)). {
     unfold patterns_of in H0. rewrite map_app in H0.
     apply wfl₁hl₂_proj_h in H0; simpl in H0.
     apply andb_true_iff in H0 as [H0'' H0'].
     apply andb_true_iff in H0' as [H0_1 H0_2]; simpl in *; repeat rewrite andb_true_r in H0_1, H0_2; repeat rewrite andb_true_iff in H0_1, H0_2; wf_auto2.
   }
-  epose proof (MG H _) as MG'.
+  unshelve (epose proof (MG H _) as MG').
+  {
+    unfold patterns_of in *; rewrite -> map_app in *; simpl in H0; wf_auto2.
+    1: now apply wfl₁hl₂_proj_l₁ in H0.
+    apply wfl₁hl₂_proj_l₂ in H0 as H0'; simpl.
+    apply wfl₁hl₂_proj_h in H0.
+    apply wf_cons; wf_auto2.
+  }
+  clear MG.
   unfold patterns_of in *. rewrite -> map_app in *. simpl.
   eapply prf_strenghten_premise_iter_meta_meta.
-  7: exact MG'. all: auto.
+  7: exact MG'.
+  5: assumption.
   1: now apply wfl₁hl₂_proj_l₁ in H0.
   1: now apply wfl₁hl₂_proj_l₂ in H0.
-  apply wfl₁hl₂_proj_h in H0. wf_auto2.
-  apply wfl₁hl₂_proj_h in H0. wf_auto2.
-  apply forall_functional_subst. 1-3: auto. all: wf_auto2.
-  Unshelve.
-  all: unfold patterns_of in *; rewrite -> map_app in *; simpl in H0; wf_auto2.
-  1: now apply wfl₁hl₂_proj_l₁ in H0.
-  apply wfl₁hl₂_proj_l₂ in H0 as H0'; simpl.
-  apply wfl₁hl₂_proj_h in H0.
-  apply wf_cons; wf_auto2.
+  1,2: wf_auto2.
+  simpl.
+  apply forall_functional_subst. 1-3: assumption.
+  all: wf_auto2.
 Defined.
 
 (**

--- a/matching-logic/src/Theories/Definedness_ProofSystem.v
+++ b/matching-logic/src/Theories/Definedness_ProofSystem.v
@@ -2324,6 +2324,9 @@ Definition dt_exgen_from_fp (ψ : Pattern) (gpi : ProofInfo) : coEVarSet :=
     { wf_auto2. }
     mlIntro "H".
     mlDestructAnd "H" as "H1" "H2".
+
+    mlApplyMeta (reshape_lhs_imp_to_and_forward _ _ _ _ _ _ _ _ _ HSUB).
+    eapply reshape_lhs_imp_to_and_forward in HSUB; try_wfauto2; simpl in HSUB.
     mlApplyMeta HSUB.
     *)
     eapply MP. 2: useBasicReasoning; apply and_impl'; try_wfauto2.

--- a/matching-logic/src/Theories/Definedness_ProofSystem.v
+++ b/matching-logic/src/Theories/Definedness_ProofSystem.v
@@ -2298,22 +2298,18 @@ Definition dt_exgen_from_fp (ψ : Pattern) (gpi : ProofInfo) : coEVarSet :=
     }
     2: { apply pile_any. }
     
-
-    eapply MP. 2: useBasicReasoning; apply and_impl'; try_wfauto2.
-    apply reorder_meta; try_wfauto2.
-    
-
     unfold exists_quantify in HSUB.
     mlSimpl in HSUB.
-    rewrite -> HeqZ, -> HeqZvar in HSUB. simpl evar_quantify in HSUB.
-
+    rewrite -> HeqZ, -> HeqZvar in HSUB.
+    simpl evar_quantify in HSUB.
     rewrite decide_eq_same in HSUB.
 
     rewrite evar_quantify_noop in HSUB.
     {
       apply count_evar_occurrences_0.
       unfold fresh_evar. simpl.
-      epose (NIN := not_elem_of_union (evar_fresh (elements (free_evars φ ∪ free_evars φ'))) (free_evars φ) (free_evars φ')). destruct NIN as [NIN1 NIN2].
+      epose (NIN := not_elem_of_union (evar_fresh (elements (free_evars φ ∪ free_evars φ'))) (free_evars φ) (free_evars φ')).
+      destruct NIN as [NIN1 NIN2].
       epose (NIN3 := NIN1 _). destruct NIN3. auto.
       Unshelve.
       5: { unfold instantiate. simpl.
@@ -2322,6 +2318,10 @@ Definition dt_exgen_from_fp (ψ : Pattern) (gpi : ProofInfo) : coEVarSet :=
 
       1-4: wf_auto2.
     }
+
+
+    eapply MP. 2: useBasicReasoning; apply and_impl'; try_wfauto2.
+    apply reorder_meta; try_wfauto2.
     exact HSUB.
   Qed.
 

--- a/matching-logic/src/Theories/Definedness_ProofSystem.v
+++ b/matching-logic/src/Theories/Definedness_ProofSystem.v
@@ -2319,7 +2319,13 @@ Definition dt_exgen_from_fp (ψ : Pattern) (gpi : ProofInfo) : coEVarSet :=
       1-4: wf_auto2.
     }
 
-
+    (* TODO do something like this, but we need more general mlApplyMeta
+    toMLGoal.
+    { wf_auto2. }
+    mlIntro "H".
+    mlDestructAnd "H" as "H1" "H2".
+    mlApplyMeta HSUB.
+    *)
     eapply MP. 2: useBasicReasoning; apply and_impl'; try_wfauto2.
     apply reorder_meta; try_wfauto2.
     exact HSUB.

--- a/matching-logic/src/Theories/ModelExtension.v
+++ b/matching-logic/src/Theories/ModelExtension.v
@@ -14,6 +14,7 @@ Require Import
 From MatchingLogic
 Require Import
     Utils.extralibrary
+    Utils.stdpp_ext
     Pattern
     Syntax
     Semantics
@@ -656,8 +657,7 @@ Section with_syntax.
             unfold Sorts_Syntax.sym.
             do 2 rewrite eval_sym_simpl.
             unfold sym_interp at 1. simpl. unfold new_sym_interp.
-            destruct (decide (inj inhabitant = inj inhabitant)) as [Heq|Hneq] eqn:Hid;[|contradiction].
-            clear Hid Heq.
+            rewrite decide_eq_same.
             destruct (decide (inj inhabitant = Definedness_Syntax.inj definedness)) as [Heq|Hneq] eqn:Hnid.
             { clear -HDefNeqInh Heq. congruence. }
             {

--- a/matching-logic/src/Theories/Unification.v
+++ b/matching-logic/src/Theories/Unification.v
@@ -99,13 +99,13 @@ Section ProofSystemTheorems.
 
     pose proof (universal_generalization Γ (all , (⌈ b0 and patt_free_evar x ⌉ ---> ⌊ b0 <---> patt_free_evar x ⌋)) x AnyReasoning (pile_any _)) as H1.
     simpl in H1.
-    destruct (decide (x = x)) eqn:Hxx;[|congruence].
+    rewrite decide_eq_same in H1.
     apply H1.
     { wf_auto2. }
     clear H1.
     pose proof (@universal_generalization _ Γ (⌈ (patt_free_evar y) and (patt_free_evar x) ⌉ ---> ⌊ (patt_free_evar y) <---> (patt_free_evar x) ⌋) y AnyReasoning (pile_any _)) as H1.
-    simpl in H1. clear Hxx.
-    destruct (decide (y = y)) eqn:Hyy;[|congruence].
+    simpl in H1.
+    rewrite decide_eq_same in H1.
     destruct (decide (y = x)) eqn:Heqyx;[congruence|].
     apply H1.
     { wf_auto2. }

--- a/matching-logic/src/Theories/Unification.v
+++ b/matching-logic/src/Theories/Unification.v
@@ -488,7 +488,7 @@ Section UnificationProcedure.
         assert (well_formed a) by now apply andb_true_iff in Wf3.
         apply well_formed_and; apply well_formed_imp;
         repeat apply well_formed_and; auto;
-        apply ProofMode_propositional.well_formed_foldr_and; wf_auto2.
+        apply well_formed_foldr_and; wf_auto2.
       }
       mlSplitAnd; mlIntro "H"; mlDestructAnd "H" as "H0" "H1".
       - mlRevertLast. mlRewrite IHxs at 1. mlIntro "H1". mlDestructAnd "H1".

--- a/matching-logic/src/Utils/stdpp_ext.v
+++ b/matching-logic/src/Utils/stdpp_ext.v
@@ -1,7 +1,16 @@
 (* Extensions to the stdpp library *)
 From Coq Require Import ssreflect ssrfun ssrbool.
-From Coq.Logic Require Import Classical_Prop Classical_Pred_Type.
+From Coq.Logic Require Import Classical_Prop Classical_Pred_Type Eqdep_dec.
 From stdpp Require Import pmap gmap mapset fin_sets sets list propset coGset.
+
+Lemma decide_eq_same (A : Type) {dec : forall (t1 t2 : A), Decision (t1 = t2)} t:
+  decide (t = t) = left erefl.
+Proof.
+  destruct (decide (t = t));[|congruence].
+  apply f_equal.
+  apply UIP_dec.
+  apply dec.
+Qed.
 
 Lemma pmap_to_list_lookup {A} (M : Pmap A) (i : positive) (x : A)
   : (i,x) ∈ (map_to_list M) <-> lookup i M = Some x.

--- a/matching-logic/src/monotonic.v
+++ b/matching-logic/src/monotonic.v
@@ -2,7 +2,7 @@ From Coq Require Import ssreflect ssrfun ssrbool.
 
 From Coq Require Import Ensembles.
 From stdpp Require Import base fin_sets sets propset.
-From MatchingLogic.Utils Require Import Lattice.
+From MatchingLogic.Utils Require Import Lattice stdpp_ext.
 From MatchingLogic Require Import Syntax Semantics.
 
 Import MatchingLogic.Syntax.Notations.
@@ -262,7 +262,8 @@ respects_blacklist (evar_open 0 (evar_fresh variables (free_evars phi)) phi) Bp 
             specialize (Hneg H2).
             inversion Hneg. subst. cbn in H5. case_match; congruence.
           * simpl. simpl in H4. destruct (decide (X = x)). contradiction. apply H4.
-          * simpl. simpl in H4. destruct (decide (x = x)). auto. apply H4.
+          * simpl. simpl in H4. rewrite decide_eq_same. rewrite decide_eq_same in H4.
+            auto.
           * simpl. simpl in H4. destruct (decide (X = x)). contradiction. apply H4.
             
         + (* EVar bound *)


### PR DESCRIPTION
* generalized version of `mlApplyMeta`, called `mlApplyMetaGeneralized`, which works with arbitrarily many premises of the applied lemma
* some preparation for FOL proof mode