### PR TITLE
Have a separate typeclass for Symbols of signature

### DIFF
--- a/examples/03_FOL/src/LN_FOL.v
+++ b/examples/03_FOL/src/LN_FOL.v
@@ -748,8 +748,10 @@ Section FOL_ML_correspondence.
   Instance sig : Signature := 
   {|
     variables := FOLVars;
-    symbols := Symbols;
-    sym_countable := Symbols_countable;
+    ml_symbols := {|
+      symbols := Symbols;
+      sym_countable := Symbols_countable;
+    |};
   |}.
 
   Instance definedness_syntax : Definedness_Syntax.Syntax :=
@@ -1578,9 +1580,11 @@ Section tests.
   Instance sig2 : Signature := 
   {|
     variables := @FOLVars Σ_vars;
-    symbols := Symbols;
-    sym_eqdec := Symbols_dec;
-    sym_countable := Symbols_countable;
+    ml_symbols := {|
+      symbols := Symbols;
+      sym_eqdec := Symbols_dec;
+      sym_countable := Symbols_countable;
+    |};
   |}.
 
   Instance definedness_syntax2 : Definedness_Syntax.Syntax :=

--- a/matching-logic/src/Pattern.v
+++ b/matching-logic/src/Pattern.v
@@ -38,7 +38,7 @@ Global Instance Pattern_countable {Σ : Signature} (sc : Countable symbols) : Co
 Proof.
   set (enc :=
          fix go p : gen_tree (unit
-                              + ((@symbols Σ)
+                              + ((@symbols (@ml_symbols Σ))
                                  + (((@evar variables) + db_index)
                                     + ((@svar variables) + db_index))))%type :=
            match p with
@@ -57,7 +57,7 @@ Proof.
 
   set (dec :=
          fix go (p : gen_tree (unit
-                              + ((@symbols Σ)
+                              + ((@symbols (@ml_symbols Σ))
                                  + (((@evar variables) + db_index)
                                     + ((@svar variables) + db_index))))%type) : Pattern :=
            match p with

--- a/matching-logic/src/Signature.v
+++ b/matching-logic/src/Signature.v
@@ -14,11 +14,15 @@ Class MLVariables := {
   svar_infinite :> Infinite svar;
 }.
 
-Class Signature := {
-  variables :> MLVariables;
+Class MLSymbols := {
   symbols : Set;
   sym_eqdec :> EqDecision symbols;
   sym_countable :> Countable symbols;
+}.
+
+Class Signature := {
+  variables :> MLVariables;
+  ml_symbols :> MLSymbols;
 }.
 
 (* Later we will define signature morphisms in some file *)

--- a/matching-logic/src/Tests/TEST_LocallyNameless.v
+++ b/matching-logic/src/Tests/TEST_LocallyNameless.v
@@ -45,7 +45,9 @@ Module test_1.
   #[local]
   Instance signature : Signature :=
     {| variables := StringMLVariables ;
-       symbols := Symbols ;
+       ml_symbols := {|
+        symbols := Symbols ;
+       |} ;
     |}.
     
   (* Example patterns *)
@@ -127,7 +129,9 @@ Module test_2.
 
     Instance signature : Signature :=
       {| variables := StringMLVariables ;
-         symbols := Symbols ;
+         ml_symbols := {|
+          symbols := Symbols ;
+         |} ;
       |}.
 
     Instance definedness_syntax : Definedness_Syntax.Syntax :=
@@ -244,7 +248,9 @@ Module test_3.
 
     Instance signature : Signature :=
       {| variables := StringMLVariables ;
-         symbols := Symbols ;
+         ml_symbols := {|
+           symbols := Symbols ;
+         |} ;
       |}.
 
     Instance definedness_syntax : Definedness_Syntax.Syntax :=

--- a/matching-logic/src/Tests/TEST_proofmode_proof_size.v
+++ b/matching-logic/src/Tests/TEST_proofmode_proof_size.v
@@ -145,7 +145,9 @@ Section compute.
 
   Instance signature : Signature :=
     {| variables := StringMLVariables ;
-       symbols := Symbols ;
+       ml_symbols := {|
+         symbols := Symbols ;
+       |} ;
     |}.
 
   Instance definedness_syntax : Definedness_Syntax.Syntax :=

--- a/matching-logic/src/Theories/Definedness_Semantics.v
+++ b/matching-logic/src/Theories/Definedness_Semantics.v
@@ -753,8 +753,10 @@ Module equivalence_insufficient.
   #[local]
   Instance mySignature : Signature :=
   {| variables := StringMLVariables;
-     symbols := exampleSymbols;
-     sym_eqdec := exampleSymbols_eqdec
+     ml_symbols := {|
+      symbols := exampleSymbols;
+      sym_eqdec := exampleSymbols_eqdec;
+     |};
   |}.
 
   Inductive exampleDomain : Set :=

--- a/prover/theories/Named.v
+++ b/prover/theories/Named.v
@@ -39,7 +39,7 @@ Fixpoint nsize' (p : NamedPattern) : nat :=
 Proof.
   set (enc :=
          fix go p : gen_tree (unit
-                              + ((@symbols Σ)
+                              + ((@symbols (@ml_symbols Σ))
                                  + (((@evar variables))
                                     + ((@svar variables)))))%type :=
            match p with
@@ -56,7 +56,7 @@ Proof.
 
   set (dec :=
          fix go (p : gen_tree (unit
-                              + ((@symbols Σ)
+                              + ((@symbols (@ml_symbols Σ))
                                  + (((@evar variables) )
                                     + ((@svar variables)))))%type) : NamedPattern :=
            match p with
@@ -660,8 +660,10 @@ Section named_test.
 
   Definition sig : Signature :=
     {| variables := StringMLVariables;
-       symbols := Symbols;
-       sym_eqdec := Symbols_dec;
+       ml_symbols := {|
+         symbols := Symbols;
+         sym_eqdec := Symbols_dec;
+       |} ;
     |}.
 
   (* Consider the following pattern in locally nameless representation:

--- a/prover/theories/TEST_MMProofExtractor.v
+++ b/prover/theories/TEST_MMProofExtractor.v
@@ -79,7 +79,9 @@ Module MMTest.
   #[local]
   Instance Σ : Signature :=
     {| variables := StringMLVariables ;
-       symbols := Symbol ;
+       ml_symbols := {|
+        symbols := Symbol ;
+       |} ;
     |}.
 
 


### PR DESCRIPTION
I want this in order to have "named" patterns that always work only with strings.