### PR TITLE
Evaluation with better examples

### DIFF
--- a/matching-logic/src/Evaluation/Complex.v
+++ b/matching-logic/src/Evaluation/Complex.v
@@ -86,7 +86,28 @@ Section running.
     (***)
     mlDestructAnd "H2" as "H2_1" "H2_2".
     mlExists x. mlApply "H2_1". mlAssumption.
-  Qed.
+  Defined.
+
+  Lemma running_forall_functional_subst (φ φ' : Pattern) :
+    mu_free φ → well_formed φ' → well_formed_closed_ex_aux φ 1 →
+    well_formed_closed_mu_aux φ 0 →
+    Γ ⊢i (all , φ) and (ex , φ' =ml b0) ---> φ^[evar:0↦φ']
+              using AnyReasoning.
+  Proof.
+    intros HMF HWF1 HWF2 HWF3.
+    apply mu_free_wfp in HMF as HMFWF.
+    toMLGoal. wf_auto2.
+    mlIntro "H". mlDestructAnd "H" as "H1" "H2".
+    mlAdd (running_functional_subst (! φ) φ' ltac:(simpl;auto) HWF1 ltac:(wf_auto2) ltac:(wf_auto2)) as "H0".
+    mlSimpl.
+    mlApplyMeta Misc.notnot_taut_1. mlIntro "H3".
+    mlAssert ("H5" : (ex , ! φ)).
+    { wf_auto2. }
+    { mlApply "H0". mlSplitAnd; mlAssumption. }
+    mlDestructEx "H5" as x. mlSimpl.
+    mlApply "H5". mlSpecialize "H1" with x.
+    mlAssumption.
+  Defined.
 
   Local Lemma lhs_from_and_low:
     ∀ (a b c : Pattern) (i : ProofInfo),

--- a/matching-logic/src/Evaluation/Complex.v
+++ b/matching-logic/src/Evaluation/Complex.v
@@ -5,6 +5,7 @@ From MatchingLogic Require Import
     DerivedOperators_Syntax
     ProofSystem
     ProofMode.MLPM
+    FreshnessManager
 .
 
 From MatchingLogic.Theories Require Import Definedness_Syntax
@@ -52,6 +53,31 @@ Section running.
     mlExact "H2". (* .unfold .no-hyps *)
     (* end snippet running *)
   Defined.
+
+  Lemma running_functional_subst (φ φ' : Pattern) :
+    mu_free φ → well_formed φ' → well_formed_closed_ex_aux φ 1 →
+    well_formed_closed_mu_aux φ 0 →
+    Γ ⊢i φ^[evar:0↦φ'] and (ex , φ' =ml b0) ---> (ex , φ)
+              using AnyReasoning.
+  Proof.
+    intros HMF HWF1 HWF2 HWF3.
+    apply mu_free_wfp in HMF as HMFWF.
+    toMLGoal. wf_auto2.
+    mlIntro "H".
+    mlDestructAnd "H" as "H1" "H2".
+    (* TODO: these steps should be automatic with the
+       FreshnessManager *)
+    remember (fresh_evar (φ =ml φ')) as x.
+    _mlDestructExManual "H2" as x. cbn.
+    pose proof (free_evars_bevar_subst φ φ' 0).
+    pose proof (set_evar_fresh_is_fresh (φ =ml φ')). unfold evar_is_fresh_in in H0.
+    simpl in H0. set_solver.
+    (***)
+    mlSimpl. cbn.
+    unfold evar_open. rewrite (bevar_subst_not_occur _ _ φ'). wf_auto2.
+    (* TODO: rewrite with substitutions! *)
+    
+  Qed.
 
   Local Lemma lhs_from_and_low:
     ∀ (a b c : Pattern) (i : ProofInfo),

--- a/matching-logic/src/Evaluation/Firstorder.v
+++ b/matching-logic/src/Evaluation/Firstorder.v
@@ -94,6 +94,16 @@ Proof.
   mlAssumption.
 Defined.
 
+Lemma ex3_coq {T : Type} A B:
+  (exists (x : T), A x /\ B x) -> exists x, A x.
+Proof.
+  intros H.
+  destruct H as [x H].
+  destruct H as [H0 H1].
+  exists x.
+  assumption.
+Qed.
+
 Section compute.
   From MatchingLogic.Theories Require Import Definedness_Syntax
                                              Definedness_Semantics

--- a/matching-logic/src/Evaluation/Propositional.v
+++ b/matching-logic/src/Evaluation/Propositional.v
@@ -79,6 +79,13 @@ Proof.
   mlIntro "H0". mlApply "H0". mlAssumption.
 Defined.
 
+Lemma ex1_coq (A B : Prop) :
+  A -> B -> A /\ B.
+Proof.
+  intros H H0.
+  split; assumption.
+Qed.
+
 Lemma ex1_pm2 : forall {Σ : Signature} (Γ : Theory) (A B : Pattern),
   well_formed A = true ->
   well_formed B = true ->

--- a/matching-logic/src/Evaluation/Rewrite.v
+++ b/matching-logic/src/Evaluation/Rewrite.v
@@ -139,12 +139,14 @@ Proof.
   mlIntro "H1". mlExact "H1".
 Defined.
 
+Import PropExtensionality.
+
 Lemma ex2_coq {T : Type} A (B : T -> Prop) C D:
   B C <-> D ->
   A (B C) -> A D.
 Proof.
   intros H.
-  apply PropExtensionality.propositional_extensionality in H.
+  apply propositional_extensionality in H.
   rewrite H.
   intro H1. exact H1.
 Qed.

--- a/matching-logic/src/Evaluation/Rewrite.v
+++ b/matching-logic/src/Evaluation/Rewrite.v
@@ -139,6 +139,16 @@ Proof.
   mlIntro "H1". mlExact "H1".
 Defined.
 
+Lemma ex2_coq {T : Type} A (B : T -> Prop) C D:
+  B C <-> D ->
+  A (B C) -> A D.
+Proof.
+  intros H.
+  apply PropExtensionality.propositional_extensionality in H.
+  rewrite H.
+  intro H1. exact H1.
+Qed.
+
 Lemma ex2_pm2 {Σ : Signature} (A B C D : Pattern) (Γ : Theory) :
   well_formed (A ---> B ---> C ---> D) = true ->
   Γ ⊢ ((B $ C) <---> D) ->

--- a/matching-logic/src/Freshness.v
+++ b/matching-logic/src/Freshness.v
@@ -352,8 +352,19 @@ Section freshness.
         (@left_id_L SVarSet  ∅ (@union _ _)),
         (@right_id_L SVarSet ∅ (@union _ _))
       ).
-    
 
+    Lemma x_eq_fresh_impl_x_notin_free_evars x ϕ:
+      x = fresh_evar ϕ ->
+      x ∉ free_evars ϕ.
+    Proof.
+      intros H.
+      rewrite H.
+      unfold fresh_evar.
+      apply set_evar_fresh_is_fresh'.
+    Qed.
+    
+    Hint Resolve x_eq_fresh_impl_x_notin_free_evars : core.
+    
 End freshness.
 
 
@@ -493,7 +504,7 @@ Fixpoint svar_fresh_seq {Σ : Signature} (avoid : SVarSet) (n : nat) : list svar
   }
   Qed.
 
-  Lemma svar_fresh_seq_disj {Σ : Signature} S n:
+Lemma svar_fresh_seq_disj {Σ : Signature} S n:
   list_to_set (svar_fresh_seq S n) ## S.
 Proof.
 move: S.
@@ -510,3 +521,11 @@ induction n; intros S; simpl in *; unfold evar_fresh_s in *.
   apply set_svar_fresh_is_fresh'.
 }
 Qed.
+
+Ltac solve_fresh :=
+  (eapply not_elem_of_larger_impl_not_elem_of;
+  [|apply x_eq_fresh_impl_x_notin_free_evars; reflexivity];
+  simpl; clear; set_solver) +
+  by (unfold evar_is_fresh_in;
+  eapply evar_is_fresh_in_richer'; [|apply set_evar_fresh_is_fresh'];
+  clear; set_solver).

--- a/matching-logic/src/ProofMode/Firstorder.v
+++ b/matching-logic/src/ProofMode/Firstorder.v
@@ -896,15 +896,6 @@ End with_signature.
 Open Scope ml_scope.
 Open Scope string_scope.
 
-
-Ltac solve_fresh :=
-  (eapply not_elem_of_larger_impl_not_elem_of;
-  [|apply x_eq_fresh_impl_x_notin_free_evars; reflexivity];
-  simpl; clear; set_solver) +
-  by (unfold evar_is_fresh_in;
-  eapply evar_is_fresh_in_richer'; [|apply set_evar_fresh_is_fresh'];
-  clear; set_solver).
-
 Tactic Notation "mlIntroAll" ident(x) :=
 _ensureProofMode;
 mlFreshEvar as x;

--- a/matching-logic/src/Syntax.v
+++ b/matching-logic/src/Syntax.v
@@ -545,21 +545,6 @@ Section syntax.
     now apply andb_true_iff in H1.
   Qed.
 
-
-
-
-  Lemma x_eq_fresh_impl_x_notin_free_evars x ϕ:
-    x = fresh_evar ϕ ->
-    x ∉ free_evars ϕ.
-  Proof.
-    intros H.
-    rewrite H.
-    unfold fresh_evar.
-    apply set_evar_fresh_is_fresh'.
-  Qed.
-
-  Hint Resolve x_eq_fresh_impl_x_notin_free_evars : core.
-
 End syntax.
 
 Module Notations.

--- a/matching-logic/src/Tests/TEST_ProofMode_relative_completeness.v
+++ b/matching-logic/src/Tests/TEST_ProofMode_relative_completeness.v
@@ -80,7 +80,7 @@ Local Lemma Ex_gen_complete (Γ : Theory) (ϕ₁ ϕ₂ : Pattern) (x : evar) (i 
 Proof.
   unfold exists_quantify. intros.
   mlIntro "H0".
-  _mlDestructExManual "H0" as x.
+  mlDestructEx "H0" as x.
   rewrite evar_open_evar_quantify. wf_auto2.
   mlRevertLast. assumption.
 Qed.


### PR DESCRIPTION
The purpose of this pull request is to extend the evaluation of the proof mode. Two lemmas (universal and existential functional substitutions) were proved mostly with the proof mode, the proof about simpler patterns were also formalized as Coq propositions, and `mlDestructEx` was overloaded (with a slight modification in the `FreshnessManager`).