### PR TITLE
Various bugfixes

### DIFF
--- a/matching-logic/src/ProofMode/Basics.v
+++ b/matching-logic/src/ProofMode/Basics.v
@@ -134,6 +134,19 @@ Coercion of_MLGoal {Σ : Signature} (MG : MLGoal) : Type :=
   format "G  'Ⱶ' '//' l -------------------------------------- '//' g '//'",
   only printing).
 
+Ltac2 Type exn ::= [PMTacticFailure(message)].
+
+Ltac2 throw_pm_exn (msg : message) :=
+  Control.zero(PMTacticFailure msg).
+
+Ltac2 goal_to_message () : message :=
+  match! goal with
+  | [ |- ?g] => Message.of_constr g
+  end.
+
+Ltac2 throw_pm_exn_with_goal (msg : string) :=
+  throw_pm_exn (Message.concat (Message.of_string msg) (goal_to_message ())).
+
 Ltac2 _toMLGoal () :=
   unfold derives;
   lazy_match! goal with
@@ -150,7 +163,7 @@ Ltac2 _toMLGoal () :=
          [()|reflexivity]
        )
        |unfold MLGoal_from_goal]
-
+  | [ |- _ ] => throw_pm_exn_with_goal "_toMLGoal: Not a matching logic goal: "
   end.
 
 Ltac2 Notation "toMLGoal" :=
@@ -162,10 +175,13 @@ Tactic Notation "toMLGoal" :=
 .
 
 Ltac2 _fromMLGoal () :=
-  unfold of_MLGoal;
-  simpl;
-  intros _ _
-.
+  match! goal with
+  | [ |- of_MLGoal (mkMLGoal _ _ _ _ _) ] =>
+    unfold of_MLGoal;
+    simpl;
+    intros _ _
+  | [ |- _] => throw_pm_exn_with_goal "_fromMLGoal: Not a matching logic proof mode goal: "
+  end.
 
 Ltac2 Notation "fromMLGoal" :=
   _fromMLGoal ()
@@ -190,9 +206,10 @@ Defined.
 Ltac2 _useBasicReasoning () :=
   Control.enter ( fun () =>
     unfold derives;
-    lazy_match! goal with
+    match! goal with
     | [ |- of_MLGoal (mkMLGoal _ _ _ _ _) ] => apply mlUseBasicReasoning
     | [ |- _ ⊢i _ using _ ] => apply useBasicReasoning
+    | [ |- _] => throw_pm_exn_with_goal "_useBasicReasoning: Not a matching logic goal: "
     end
   )
 .
@@ -223,7 +240,7 @@ Defined.
 (* Extracts well-formedness assumptions about (local) goal and (local) hypotheses. *)
 Ltac2 _mlExtractWF (wfl : ident) (wfg : ident) :=
   Control.enter(fun () =>
-    lazy_match! goal with
+    match! goal with
     | [ |- ?g ] =>
       let wfl' := Fresh.in_goal ident:(wfl') in
       let wfg' := Fresh.in_goal ident:(wfg') in
@@ -234,6 +251,7 @@ Ltac2 _mlExtractWF (wfl : ident) (wfg : ident) :=
       fold $g;
       unfold mlConclusion in $wfg;
       unfold mlHypotheses in $wfl
+    | [ |- _] => throw_pm_exn_with_goal "_mlExtractWF: failed for goal: "
     end
 ).
 
@@ -253,6 +271,9 @@ Proof.
   intros wfp.
   toMLGoal.
   {
+    Fail toMLGoal.
+    Fail mlExtractWF wfl wfg.
+    Fail fromMLGoal.
     wf_auto2.
   }
   (*{ wf_auto2. }*)
@@ -315,7 +336,7 @@ Ltac2 do_mlReshapeHypsByName (name : constr) :=
   | [ |- @of_MLGoal _ (@mkMLGoal _ _ ?l _ _) ] =>
     match! (eval cbv in (index_of $name (names_of $l))) with
     | (Some ?i) => do_mlReshapeHypsByIdx i
-    | None => Message.print (Message.concat (Message.of_string "No such name: ") (Message.of_constr name)); fail
+    | None => throw_pm_exn (Message.concat (Message.of_string "do_mlReshapeHypsByName: No such name: ") (Message.of_constr name))
     end
   end
 .
@@ -366,7 +387,7 @@ Ltac2 do_mlReshapeHypsBy2Idx (i1:constr) (i2:constr) :=
                ltac1:(rewrite -> drop_app_le by (simpl; lia));
                ltac1:(rewrite /firstn); ltac1:(rewrite /skipn); reflexivity)
               |()]
-    | (Eq) => Message.print (Message.of_string "Equal names were used")
+    | (Eq) => throw_pm_exn (Message.of_string "do_mlReshapeHypsBy2Idx: Hypothesis names are equal!")
     end
 .
 
@@ -388,9 +409,9 @@ Ltac2 do_mlReshapeHypsBy2Names (n1 : constr) (n2 : constr) :=
     | (Some ?i1) => 
       match! (eval cbv in (index_of $n2 (names_of $l))) with
       | (Some ?i2) => do_mlReshapeHypsBy2Idx i1 i2
-      | None => Message.print (Message.concat (Message.of_string "No such name: ") (Message.of_constr n2))
+      | None => throw_pm_exn (Message.concat (Message.of_string "do_mlReshapeHypsBy2Names: No such name: ") (Message.of_constr n2))
       end
-    | None => Message.print (Message.concat (Message.of_string "No such name: ") (Message.of_constr n1))
+    | None => throw_pm_exn (Message.concat (Message.of_string "do_mlReshapeHypsBy2Names: No such name: ") (Message.of_constr n1))
     end
   end
 .
@@ -443,10 +464,11 @@ Proof.
 Defined.
 
 Ltac2 _simplLocalContext () :=
-  lazy_match! goal with
+  match! goal with
     | [ |- @of_MLGoal ?sgm (mkMLGoal ?sgm ?ctx ?l ?g ?i) ]
       => let f := ltac1:(l |- rewrite {1}[l]/app) in
          (f (Ltac1.of_constr l))
+    | [ |- _] => throw_pm_exn_with_goal "_simplLocalContext: Not a matching logic proof mode goal: "
   end.
 
 Ltac2 Notation "simplLocalContext" :=
@@ -459,9 +481,10 @@ Tactic Notation "simplLocalContext" :=
 
 
 Ltac2 do_getHypNames () : constr :=
-  lazy_match! goal with
+  match! goal with
   | [ |- of_MLGoal (mkMLGoal _ _ ?l _ _) ]
     => eval lazy in (names_of $l)
+  | [ |- _] => throw_pm_exn_with_goal "do_getHypNames: Not a matching logic proof mode goal: "
   end.
 
 Ltac2 Notation "getHypNames" :=
@@ -484,11 +507,8 @@ Ltac2 do_failIfUsed (name : constr) :=
 lazy_match! goal with
 | [ |- of_MLGoal (mkMLGoal _ _ ?l _ _) ] =>
   lazy_match! (eval cbv in (find (fun x => String.eqb x $name) (names_of $l))) with
-  | Some _ => Message.print (
-    Message.concat
-      (Message.of_string "The name ")
-      (Message.concat (Message.of_constr name) (Message.of_string " is already used")));
-      fail
+  | Some _ =>
+      throw_pm_exn (Message.concat (Message.of_string "do_failIfUsed: Name is already used: ") (Message.of_constr name))
   | _ => () (* should not fail on other values*)
   end
 end.
@@ -558,8 +578,12 @@ Ltac2 do_mlIntro (name' : constr) :=
   Control.enter(fun () => 
     do_ensureProofMode ();
     do_failIfUsed name';
-    apply MLGoal_intro with (name := $name');
-    simplLocalContext
+    match! goal with
+    | [ |- of_MLGoal (mkMLGoal _ _ _ (_ ---> _) _)] =>
+      apply MLGoal_intro with (name := $name');
+      simplLocalContext
+    | [ |- _] => throw_pm_exn (Message.of_string "do_mlIntro: goal does not contain more implications!")
+    end
   )
 .
 
@@ -618,6 +642,7 @@ Proof.
   Fail mlIntro "h"%string.
   mlIntro "h'"%string.
   do 2 mlIntro.
+  Fail mlIntro.
 Abort.
 
 Lemma MLGoal_revertLast {Σ : Signature} (Γ : Theory) (l : hypotheses) (x g : Pattern) (n : string) i :
@@ -659,7 +684,9 @@ Defined.
 #[global]
 Ltac2 do_mlRevertLast () :=
   Control.enter(fun () =>
-    lazy_match! goal with
+    match! goal with
+    | [|- @of_MLGoal ?sgm (mkMLGoal ?sgm ?ctx [] ?g ?i)] =>
+      throw_pm_exn (Message.of_string ("do_mlRevertLast: There are no hypotheses to revert!"))
     | [|- @of_MLGoal ?sgm (mkMLGoal ?sgm ?ctx ?l ?g ?i)]
     => eapply cast_proof_ml_hyps>
       [(ltac1:(l |- rewrite -[l](take_drop (length l - 1)); rewrite [take _ _]/=; rewrite [drop _ _]/=) (Ltac1.of_constr l); reflexivity)|()];
@@ -688,6 +715,7 @@ Defined.
 Ltac2 do_mlRename (n1 : constr) (n2 : constr) :=
   Control.enter(fun () =>
     _ensureProofMode;
+    do_failIfUsed n2;
     _mlReshapeHypsByName n1;
     apply MLGoal_rename with (n2 := $n2);
     _mlReshapeHypsBack
@@ -713,6 +741,7 @@ Proof.
   mlRename "0"%string into "H0"%string.
   mlRename "5"%string into "H5"%string.
   Fail mlRename "6"%string into "6"%string.
+  Fail mlRename "4"%string into "1"%string.
 Abort.
 
 Close Scope ml_scope.

--- a/matching-logic/src/ProofMode/Basics.v
+++ b/matching-logic/src/ProofMode/Basics.v
@@ -16,6 +16,7 @@ From MatchingLogic Require Import
   ProofInfo
   wftactics
   Experimental.ProofModePattern
+  Logic
 .
 
 From stdpp Require Import list tactics fin_sets coGset gmap sets.
@@ -23,10 +24,9 @@ From stdpp Require Import list tactics fin_sets coGset gmap sets.
 Import
   MatchingLogic.Utils.stdpp_ext
   MatchingLogic.Utils.extralibrary
-  MatchingLogic.Syntax.Notations
-  MatchingLogic.DerivedOperators_Syntax.Notations
   MatchingLogic.ProofSystem.Notations_private
   MatchingLogic.ProofInfo.Notations
+  MatchingLogic.Logic.Notations
 .
 
 Set Default Proof Mode "Classic".
@@ -151,11 +151,11 @@ Ltac2 _toMLGoal () :=
   unfold derives;
   lazy_match! goal with
   | [ |- ?g ⊢i ?phi using ?pi]
-    => (Std.cut constr:(of_MLGoal (MLGoal_from_goal $g $phi $pi));cbn)>
+    => (Std.cut constr:(of_MLGoal (MLGoal_from_goal $g $phi $pi))(* cbn *))>
        [
        (unfold MLGoal_from_goal;
         unfold of_MLGoal;
-         simpl;
+         (* simpl; *)
          let h := Fresh.in_goal ident:(Halmost) in
          intros $h;
          let h_hyp := Control.hyp h in
@@ -626,9 +626,9 @@ Abort.
 
 Local Example ex_mlIntro {Σ : Signature} Γ a (i : ProofInfo) :
   well_formed a ->
-  Γ ⊢i a ---> a ---> a ---> a ---> a using i.
+  Γ ⊢i a ---> a ---> a ---> (a ---> a)^[evar: 0 ↦ a] using i.
 Proof.
-  intros wfa.
+  intros wfa. toMLGoal. wf_auto2.
   (* This happens automatically *)
   (*
   toMLGoal.

--- a/matching-logic/src/ProofMode/MLPM.v
+++ b/matching-logic/src/ProofMode/MLPM.v
@@ -4,7 +4,8 @@ From stdpp Require Export list fin_sets.
 From MatchingLogic Require Export
   Logic
   ProofInfo
-  BasicProofSystemLemmas.
+  BasicProofSystemLemmas
+  FreshnessManager.
 From MatchingLogic.ProofMode Require Export Basics
                                             Propositional
                                             Firstorder

--- a/matching-logic/src/ProofMode/Misc.v
+++ b/matching-logic/src/ProofMode/Misc.v
@@ -2340,7 +2340,7 @@ Ltac2 mlRewrite (hiff : constr) (atn : int) :=
     lazy_match! goal with
     | [ |- of_MLGoal (@mkMLGoal ?sgm ?g ?l ?p ( ?gpi))]
       =>
-        let hr : HeatResult := heat atn a p in (* TODO: this is slow for bigger patterns *)
+        let hr : HeatResult := heat atn a p in
         if ml_debug_rewrite then
            Message.print (Message.concat (Message.of_string "Heating finished: ") (Message.of_constr (hr.(ctx_pat))))
          else () ;

--- a/matching-logic/src/ProofMode/Misc.v
+++ b/matching-logic/src/ProofMode/Misc.v
@@ -2350,7 +2350,7 @@ Ltac2 mlRewrite (hiff : constr) (atn : int) :=
                                 )
                                 )
          )
-    | [ |- _] => throw_pm_exn_with_goal "mlRewrite: not in proof mode"
+    | [ |- _] => throw_pm_exn_with_goal "mlRewrite: not in proof mode "
     end
   | ?x => throw_pm_exn (Message.concat (Message.of_string "mlRewrite: Given hypothesis is not an equivalence: ") (Message.of_constr x))
   end.

--- a/matching-logic/src/ProofMode/Misc.v
+++ b/matching-logic/src/ProofMode/Misc.v
@@ -2093,59 +2093,7 @@ Defined.
 
 Ltac2 mutable ml_debug_rewrite := false.
 
-(* Calls [cont] for every subpattern [a] of pattern [phi], giving the match context as an argument *)
-Ltac2 for_each_match := fun (a : constr) (phi : constr) (cont : Pattern.context -> unit) =>
-  try (
-      if ml_debug_rewrite then
-           Message.print (
-               Message.concat
-                 (Message.of_string "Trying to match ")
-                 (Message.of_constr a)
-             )
-        else ();
-      match! phi with
-      | context ctx [ ?x ]
-        => if ml_debug_rewrite then
-             Message.print (
-                 Message.concat
-                   (Message.of_string " against ")
-                   (Message.of_constr x)
-               )
-           else ();
-           (* lazy_match! Constr.type x with (* Optimisation, but it does not help much *)
-           | Pattern => *)
-           (if Constr.equal x a then
-              if ml_debug_rewrite then
-                Message.print (Message.of_string "Success.")
-              else () ;
-              cont ctx
-            else ());
-             fail (* backtrack *)
-           (* end *)
-      end
-    ); ().
-
-(* Calls [cont] for [n]th subpatern [a] of pattern [phi]. *)
 Ltac2 for_nth_match :=
-  fun (n : int) (a : constr) (phi : constr) (cont : Pattern.context -> unit) =>
-    if ml_debug_rewrite then
-      Message.print (Message.of_string "for_nth_match")
-    else () ;
-    let curr : int ref := {contents := 0} in
-    let found : bool ref := {contents := false} in
-    for_each_match a phi
-    (fun ctx =>
-      if (found.(contents))
-      then ()
-      else
-        curr.(contents) := Int.add 1 (curr.(contents)) ;
-        if (Int.equal (curr.(contents)) n) then
-          cont ctx
-        else ()
-    )
-.
-
-Ltac2 for_nth_match2 :=
   fun (n : int) (a : constr) (phi : constr) (cont : Pattern.context -> unit) =>
     try (
       if ml_debug_rewrite then
@@ -2283,7 +2231,7 @@ Ltac2 Type HeatResult := {
 Ltac2 heat :=
   fun (n : int) (a : constr) (phi : constr) : HeatResult =>
     let found : (Pattern.context option) ref := { contents := None } in
-     for_nth_match2 n a phi
+     for_nth_match n a phi
      (fun ctx =>
         found.(contents) := Some ctx; ()
      );

--- a/matching-logic/src/ProofMode/Propositional.v
+++ b/matching-logic/src/ProofMode/Propositional.v
@@ -79,7 +79,9 @@ Defined.
 Ltac2 do_mlExactn (n : constr) :=
   do_ensureProofMode ();
   do_mlReshapeHypsByIdx n;
-  apply MLGoal_exactn
+  Control.plus (fun () => apply MLGoal_exactn)
+  (fun _ => _mlReshapeHypsBack;
+            throw_pm_exn_with_goal "do_mlExactn: Hypothesis is not identical to the goal!")
 .
 
 Ltac2 Notation "mlExactn" n(constr) :=
@@ -106,8 +108,11 @@ Defined.
 
 Ltac2 do_mlExact (name' : constr) :=
   do_ensureProofMode ();
-  eapply MLGoal_exact with (name := $name');
-  simpl; apply f_equal; reflexivity
+  Control.plus (fun () =>
+    eapply MLGoal_exact with (name := $name');
+    simpl; apply f_equal; reflexivity)
+    (fun _ => _mlReshapeHypsBack;
+              throw_pm_exn_with_goal ("do_mlExact: Given hypothesis is not identical to the goal, or there is no pattern associated with the given name!"))
 .
 
 Ltac2 Notation "mlExact" name(constr) :=
@@ -132,6 +137,8 @@ Proof.
     { wf_auto2. }
   *)
   mlIntro "H1". mlIntro "H2". mlIntro "H3". (* TODO: mlIntros "H1" "H2" "H3".*)
+  Fail mlExact "H4".
+  Fail mlExact "H1".
   mlExact "H2".
 Defined.
 
@@ -393,7 +400,8 @@ Ltac2 run_in_reshaped_by_idx
 
 Ltac2 do_mlApplyn (n : constr) :=
   run_in_reshaped_by_idx n ( fun () =>
-    apply MLGoal_weakenConclusion
+    Control.plus (fun () => apply MLGoal_weakenConclusion)
+      (fun _ => throw_pm_exn_with_goal "do_mlApplyn: Failed for goal: ")
   )
 .
 
@@ -417,7 +425,8 @@ Ltac2 run_in_reshaped_by_name
 
 Ltac2 do_mlApply (name' : constr) :=
   run_in_reshaped_by_name name' (fun () =>
-    apply MLGoal_weakenConclusion
+    Control.plus (fun () => apply MLGoal_weakenConclusion)
+    (fun _ => throw_pm_exn_with_goal "do_mlApply: Goal does not match the conclusion of the hypothesis")
   )
 .
 
@@ -440,6 +449,8 @@ Proof.
   { wf_auto2. }
   mlIntro "H1".
   mlIntro "H2".
+  Fail mlApply "H1".
+  Fail mlApply "H3".
   mlApply "H2".
   fromMLGoal.
   apply P1; wf_auto2.
@@ -617,7 +628,8 @@ Defined.
 
 Ltac2 do_mlDestructImp (name : constr) :=
   run_in_reshaped_by_name name (fun () =>
-    apply (mlGoal_destructImp _ _ _ $name)
+   Control.plus (fun () => apply (mlGoal_destructImp _ _ _ $name))
+                 (fun _ => throw_pm_exn_with_goal "do_mlDestructImp: The given hypothesis was not an implication pattern: ")
   )
 .
 
@@ -658,7 +670,8 @@ Defined.
 
 Ltac2 do_mlRevert (name : constr) :=
   run_in_reshaped_by_name name (fun () =>
-    apply (MLGoal_revert _ _ _ _ _ $name)
+    Control.plus (fun () => apply (MLGoal_revert _ _ _ _ _ $name))
+      (fun _ => throw_pm_exn_with_goal "do_mlRevert: failed for goal: ")
   )
 .
 
@@ -679,6 +692,7 @@ Proof.
   intros. toMLGoal. wf_auto2.
   mlIntro "H". mlIntro "H0". mlIntro "H1".
   mlRevert "H0". mlRevert "H1".
+  Fail mlRevert "H0".
   mlIntro "H0". mlIntro "H1".
   mlExact "H".
 Defined.
@@ -873,6 +887,7 @@ Proof.
   toMLGoal.
   { wf_auto2. }
   mlIntro "H0". mlIntro "H1".
+  Fail mlAssert ("H0" : a).
   mlAssert ("H2" : a).
   { wf_auto2. }
   { mlExact "H1". }
@@ -1168,7 +1183,10 @@ Ltac2 do_mlAdd_as (n : constr) (name' : constr) :=
   do_failIfUsed name';
   lazy_match! goal with
   | [|- @of_MLGoal ?sgm (@mkMLGoal ?sgm ?ctx ?l ?g ?i)] =>
+  Control.plus(fun () =>
     apply (@MLGoal_add $sgm $ctx $l $name' $g _ $i $n)
+  )
+  (fun _ => throw_pm_exn (Message.concat (Message.of_string "do_mlAdd_as: given Coq hypothesis is not a pattern: ") (Message.of_constr n)))
   end.
 
 Ltac2 Notation "mlAdd" n(constr) "as" name(constr) :=
@@ -1211,6 +1229,8 @@ Proof.
   intros WFl WFg WFh H H0.
   mlAdd H0 as "H0".
   mlAdd H.
+  Fail mlAdd WFl as "0".
+  Fail mlAdd WFl as "1".
   mlApply "0".
   mlExact "H0".
 Defined.
@@ -1252,7 +1272,7 @@ Proof.
   apply H3.
   useBasicReasoning.
   apply prf_clear_hyp; wf_auto2.
-Defined.  
+Defined.
 
 
 
@@ -1300,6 +1320,7 @@ Proof.
   mlIntro "H0". mlIntro "H1". mlIntro "H2".
   mlClear "H2".
   mlClear "H0".
+  Fail mlClear "H0".
   mlExact "H1".
 Defined.
 
@@ -1605,9 +1626,9 @@ Proof.
 Defined.
 
 Lemma MLGoal_disj_elim {Σ : Signature} Γ l₁ l₂ pn p qn q pqn r i:
-  mkMLGoal Σ Γ (l₁ ++ [mkNH _ pn p] ++ l₂) r i ->
-  mkMLGoal Σ Γ (l₁ ++ [mkNH _ qn q] ++ l₂) r i ->
-  mkMLGoal Σ Γ (l₁ ++ [mkNH _ pqn (p or q)] ++ l₂) r i.
+  mkMLGoal Σ Γ (l₁ ++ (mkNH _ pn p) :: l₂) r i ->
+  mkMLGoal Σ Γ (l₁ ++ (mkNH _ qn q) :: l₂) r i ->
+  mkMLGoal Σ Γ (l₁ ++ (mkNH _ pqn (p or q)) :: l₂) r i.
 Proof.
   intros H1 H2.
   unfold of_MLGoal in *. simpl in *.
@@ -1654,9 +1675,12 @@ Ltac2 do_mlDestructOr_as (name : constr) (name1 : constr) (name2 : constr) :=
     eapply cast_proof_ml_hyps;
     f_equal;
     _mlReshapeHypsByName name;
-    apply MLGoal_disj_elim with (pqn := $name) (pn := $name1) (qn := $name2);
-    _mlReshapeHypsBack;
-    simpl
+    Control.plus (fun () =>
+      apply MLGoal_disj_elim with (pqn := $name) (pn := $name1) (qn := $name2);
+      _mlReshapeHypsBack
+    )
+    (fun _ => _mlReshapeHypsBack; 
+      throw_pm_exn_with_goal "do_mlDestructOr_as: failed for goal: ")
   end
 .
 
@@ -1702,6 +1726,8 @@ Proof.
   mlIntro "H0".
   mlIntro "H1".
   mlIntro "H2".
+  Fail mlDestructOr "H3".
+  Fail mlDestructOr "H0".
   mlDestructOr "H1".
   - fromMLGoal. apply H.
   - fromMLGoal. apply H0.
@@ -1995,7 +2021,7 @@ Proof.
   1,2: pose proof (wfrr' := proved_impl_wf _ _ (proj1_sig Himp)); wf_auto2.
 Defined.
 
-
+(* Error message of this one is sufficient *)
 Ltac2 do_mlApplyMetaRaw (t : constr) :=
   eapply (@MLGoal_applyMeta _ _ _ _ _ $t)
 .
@@ -2045,12 +2071,18 @@ Defined.
 
 Ltac2 mlLeft () :=
   _ensureProofMode;
-  apply MLGoal_left
+  Control.plus(fun () =>
+    apply MLGoal_left
+  )
+  (fun _ => throw_pm_exn_with_goal "mlLeft: Current matching logic goal is not a disjunction! ")
 .
 
 Ltac2 mlRight () :=
   _ensureProofMode;
-  apply MLGoal_right
+  Control.plus(fun () =>
+    apply MLGoal_right
+  )
+  (fun _ => throw_pm_exn_with_goal "mlLeft: Current matching logic goal is not a disjunction! ")
 .
 
 Ltac mlLeft := ltac2:(mlLeft ()).
@@ -2065,6 +2097,7 @@ Proof.
   intros wfa.
   toMLGoal.
   { wf_auto2. }
+  Fail mlLeft.
   mlIntro "H0".
   mlLeft.
   mlExact "H0".
@@ -2115,7 +2148,7 @@ Defined.
 Ltac2 do_mlApplyMetaRawIn (t : constr) (name : constr) :=
   eapply cast_proof_ml_hyps;
   f_equal;
-  
+
   run_in_reshaped_by_name name (fun () =>
     eapply (@MLGoal_applyMetaIn _ _ _ _ $name _ _ $t)
   )
@@ -2256,6 +2289,7 @@ Proof.
   apply H.
 Defined.
 
+(* TODO: Create error messages for the following tactics *)
 Ltac2 _callCompletedAndCast (twb : Std.constr_with_bindings) (tac : constr -> unit) :=
   let tac' := (fun (t' : constr) =>
     let tcast := open_constr:(@useGenericReasoning'' _ _ _ _ _ $t') in
@@ -2478,12 +2512,13 @@ Ltac2 mlDestructAnd_as (name : constr) (name1 : constr) (name2 : constr) :=
     _ensureProofMode;
     _failIfUsed $name1;
     _failIfUsed $name2;
-    (*
-    eapply cast_proof_ml_hyps;
-    f_equal;
-    *)
     run_in_reshaped_by_name name (fun () =>
-      apply MLGoal_destructAnd with (nxy := $name) (nx := $name1) (ny := $name2)
+      Control.plus(fun () =>
+        apply MLGoal_destructAnd with (nxy := $name) (nx := $name1) (ny := $name2)
+      )
+      (fun _ => 
+        _mlReshapeHypsBack;
+        throw_pm_exn_with_goal "mlDestructAnd_as: Given matching logic hypothesis is not a conjunction! ")
     )
   )
 .
@@ -2528,6 +2563,10 @@ Proof.
   { wf_auto2. }
   mlIntro "H0". mlIntro "H1". mlIntro "H2".
   mlDestructAnd "H1" as "H3" "H4".
+  Fail mlDestructAnd "H1" as "H3" "H4".
+  Fail mlDestructAnd "H1" as "H3'" "H4".
+  Fail mlDestructAnd "H1" as "H3'" "H4'".
+  Fail mlDestructAnd "H3" as "H3'" "H4'".
   mlDestructAnd "H0".
   mlExact "H3".
 Defined.
@@ -2714,8 +2753,10 @@ Proof.
     + mlRight. mlExact "H5".
   - mlLeft.
     mlIntro "H2".
-    mlExFalso.
+    mlAssert ("0" : ⊥). wf_auto2.
     mlApply "H4". mlExact "H2".
+    Fail mlDestructBot "H1".
+    mlDestructBot "0".
 Defined.
 
 Lemma weird_lemma_meta {Σ : Signature} Γ A B L R i:
@@ -3007,7 +3048,10 @@ Defined.
 Ltac2 do_mlSplitAnd () :=
   Control.enter(fun () =>
     _ensureProofMode;
-    apply MLGoal_splitAnd
+    Control.plus(fun () =>
+      apply MLGoal_splitAnd
+    )
+    (fun _ => throw_pm_exn_with_goal "do_mlSplitAnd: matching logic goal is not a conjunction! ")
   )
 .
 
@@ -3029,7 +3073,9 @@ Proof.
   intros wfa wfb wfc.
   toMLGoal.
   { wf_auto2. }
-  mlIntro "H0". mlIntro "H1". mlIntro "H2".
+  mlIntro "H0". mlIntro "H1".
+  Fail mlSplitAnd.
+  mlIntro "H2".
   mlSplitAnd.
   - mlExact "H0".
   - mlExact "H1".
@@ -3535,8 +3581,8 @@ Defined.
 #[local]
 Ltac2 rec tryExact (l : constr) (idx : constr) :=
   lazy_match! l with
-    | nil => ()
-    | (?a :: ?m) => try (do_mlExactn idx); tryExact m constr:($idx + 1)
+    | nil => throw_pm_exn_with_goal "tryExact: there was no matching logic hypothesis which is exactly matched by the goal: "
+    | (?a :: ?m) => Control.plus (fun () => do_mlExactn idx) (fun exn => tryExact m constr:($idx + 1))
   end.
 
 #[global]
@@ -3575,7 +3621,7 @@ Proof.
     mlApply "H2". mlAssumption.
   - mlApply "H2". mlIntro "H0". mlClear "H2". mlIntro "H1".
     mlDestructOr "H0" as "H2" "H3".
-    + mlExFalso.
+    + mlExFalso. Fail mlAssumption.
       mlApply "H2". mlAssumption.
     + mlAssumption.
 Defined.
@@ -4079,7 +4125,9 @@ Proof.
   _mlReshapeHypsBackTwice.
   _mlReshapeHypsBy2Names "4" "2".
   _mlReshapeHypsBackTwice.
-  _mlReshapeHypsBy2Names "4" "4".
+  Fail mlSwap "3" with "3".
+  Fail mlSwap "5" with "4".
+  Fail mlSwap "1" with "6".
   mlSwap "3" with "4".
   mlApply "3" in "4".
   mlSwap "1" with "3".
@@ -4149,6 +4197,7 @@ Defined.
 Ltac2 do_mlConj (n1 : constr) (n2 : constr) (conj_name' : constr) :=
   Control.enter(fun () => 
     _ensureProofMode;
+    do_failIfUsed conj_name';
     _mlReshapeHypsBy2Names n1 n2;
     apply MLGoal_conjugate_hyps with (conj_name := $conj_name');
     rewrite app_comm_cons;
@@ -4162,11 +4211,11 @@ Ltac2 do_mlConj (n1 : constr) (n2 : constr) (conj_name' : constr) :=
            lazy_match! (eval cbv in (Nat.compare $i1 $i2)) with
            | (Lt) => ()
            | (Gt) => mlApplyMeta patt_and_comm_basic in $conj_name'
-           | (Eq) => Message.print (Message.of_string "Equal names were used"); fail
+           | (Eq) => throw_pm_exn_with_goal "do_mlConj: Equal names were used"
            end
-        | (None) => Message.print (Message.concat (Message.of_string "No such name: ") (Message.of_constr n2)); fail
+        | (None) => throw_pm_exn (Message.concat (Message.of_string "do_mlConj: No such name: ") (Message.of_constr n2))
         end
-      | (None) => Message.print (Message.concat (Message.of_string "No such name: ") (Message.of_constr n2)); fail
+      | (None) => throw_pm_exn (Message.concat (Message.of_string "do_mlConj: No such name: ") (Message.of_constr n1))
       end
     end
   ).
@@ -4180,10 +4229,10 @@ Tactic Notation "mlConj" constr(n1) constr(n2) "as" constr(n3) :=
 
 Ltac2 rec do_mlConj_many l (name : constr) : unit :=
   match l with
-  | [] => Message.print (Message.of_string "empty"); fail
+  | [] => throw_pm_exn (Message.of_string "do_mlConj_many: empty list")
   | a :: t1 => 
     match t1 with
-    | [] => Message.print (Message.of_string "only one"); fail
+    | [] => throw_pm_exn (Message.of_string "do_mlConj_many: singleton list")
     | b :: t2 => 
       match t2 with
       | [] => mlConj $a $b as $name
@@ -4214,6 +4263,10 @@ Example ex_ml_conj_intro {Σ : Signature} Γ a b c d e f i:
 Proof.
   intros wfa wfb wfc wfd wfe wff.
   mlIntro; mlIntro; mlIntro; mlIntro; mlIntro; mlIntro.
+  Fail ltac2:(mlConj "1" as "conj").
+  Fail ltac2:(mlConj "1" as "conj").
+  Fail mlConj "0" "0" as "0".
+  Fail mlConj "0" "0" as "00".
   mlConj "1" "4" as "CN1".
   mlConj "4" "1" as "CN2".
   mlAssumption.
@@ -4370,9 +4423,10 @@ Defined.
         match! goal with (* error handling *)
         | [ |- _] => now (apply MLGoal_reflexivity; eauto)
         | [ |- _] =>
-          Message.print(
-          Message.concat (Message.of_constr op) (Message.of_string " is not reflexive!")
-          ); fail
+          throw_pm_exn
+          (Message.concat (Message.of_string "do_mlReflexivity: ")
+          (Message.concat (Message.of_constr op) (Message.of_string " is not reflexive!"))
+          )
         end
       | [ |- _] => Message.print (Message.of_string "Goal is not shaped as φ = φ!"); fail
       end

--- a/matching-logic/src/ProofMode/Propositional.v
+++ b/matching-logic/src/ProofMode/Propositional.v
@@ -2637,13 +2637,13 @@ Proof with try_wfauto2.
 
   apply conj_intro_meta; auto.
   - toMLGoal.
-    { auto. }
+    { wf_auto2. }
     mlIntro "H0".
     mlDestructOr "H0" as "H1" "H2".
     + mlLeft. fromMLGoal. assumption.
     + mlRight. fromMLGoal. assumption.
   - toMLGoal.
-    { auto. }
+    { wf_auto2. }
     mlIntro "H0".
     mlDestructOr "H0" as "H1" "H2".
     + mlLeft. fromMLGoal. assumption.

--- a/matching-logic/src/SyntacticConstruct.v
+++ b/matching-logic/src/SyntacticConstruct.v
@@ -850,17 +850,17 @@ Ltac simpl_sorted_quantification :=
   | |- context G [?f ?arg _ (?binder _ _)] =>
     match type of binder with
     | Pattern -> Pattern -> Pattern =>
-      tryif
+      (* tryif *)
        unshelve (erewrite (@esorted_binder_morphism _ binder
             _ _ _ (f arg) _ _));
        match goal with
-       | |- SwappableEx _ _ _ => auto
-       | |- PatternMorphism _ => now typeclasses eauto
-       | |- ESortedBinder _ _ => tryif now typeclasses eauto then idtac else fail 3
+       | |- SwappableEx _ _ _ => tryif typeclasses eauto then idtac else eauto
+       | |- PatternMorphism _ => tryif typeclasses eauto then idtac else eauto
+       | |- ESortedBinder _ _ => tryif typeclasses eauto then idtac else eauto
        | _ => idtac
        end
-      then idtac
-      else idtac (* "No sorted simplification instance for " binder *)
+      (* then idtac
+      else idtac (* "No sorted simplification instance for " binder *) *)
     end
   end.
 
@@ -869,33 +869,38 @@ match type of H with
   | context G [?f ?arg _ (?binder _ _)] => 
     match type of binder with
     | Pattern -> Pattern -> Pattern => 
-      tryif
+      (* tryif *)
        (let name := fresh "X" in
+         (* NOTE: erewrite for some reason does not terminate *)
          unshelve (epose proof (name := @esorted_binder_morphism _ binder
             _ _ _ (f arg) _ _)); try (rewrite name in H; clear name);
-            try typeclasses eauto; auto;
+            (* try typeclasses eauto; auto; *)
             match goal with
-             | |- SwappableEx _ _ _ => clear H
-             | |- PatternMorphism _ => clear H; now typeclasses eauto
-             | |- ESortedBinder _ _ => clear H; tryif now typeclasses eauto then idtac else fail 3
+             | |- SwappableEx _ _ _ => clear H; try typeclasses eauto; eauto
+             | |- ESortedBinder _ _ => clear H; try typeclasses eauto; eauto
              | _ => idtac
+            end;
+            match goal with
+            | |- PatternMorphism _ => typeclasses eauto
+            | _ => idtac
             end
               )
-      then idtac
-      else idtac (* "No sorted simplification instance for " binder *)
+      (* then idtac
+      else idtac (* "No sorted simplification instance for " binder *) *)
     end
   end.
 
 
 Section Test.
-Import Substitution.Notations.
-Open Scope ml_scope.
-Context {Σ : Signature}.
-Tactic Notation "mlSimpl" :=
-  repeat (rewrite mlSimpl' + simpl_sorted_quantification); try rewrite [increase_ex _ _]/=; try rewrite [increase_mu]/=.
+  (* NOTE: these tactics are not exported!!!!! *)
+  Import Substitution.Notations.
+  Open Scope ml_scope.
+  Context {Σ : Signature}.
+  Tactic Notation "mlSimpl" :=
+    repeat (rewrite mlSimpl' + simpl_sorted_quantification); repeat rewrite [increase_ex _ _]/=; repeat rewrite [increase_mu]/=.
 
-Tactic Notation "mlSimpl" "in" hyp(H) :=
-  repeat (rewrite mlSimpl' in H + simpl_sorted_quantification_hyp H); try rewrite [increase_ex _ _]/= in H; try rewrite [increase_mu _ _]/= in H.
+  Tactic Notation "mlSimpl" "in" hyp(H) :=
+    repeat (rewrite mlSimpl' in H + simpl_sorted_quantification_hyp H); repeat rewrite [increase_ex _ _]/= in H; repeat rewrite [increase_mu _ _]/= in H.
 
   Local Definition patt_forall_of_sort (sort phi : Pattern) : Pattern :=
     patt_exists (patt_imp (patt_imp (patt_bound_evar 0) (nest_ex sort)) phi).
@@ -903,8 +908,8 @@ Tactic Notation "mlSimpl" "in" hyp(H) :=
   #[local]
   Program Instance sorted_forall_binder : ESortedBinder patt_forall_of_sort nest_ex := {}.
   Next Obligation.
-    intros.
-    repeat rewrite pm_correctness.
+     intros.
+     repeat rewrite pm_correctness.
     cbn.
     rewrite eswap.
     now rewrite pm_ezero_increase.
@@ -924,7 +929,7 @@ Proof.
   2: {
   mlSimpl in H. 2: {
   mlSimpl in H0.
-  mlSimpl in H1. }
+  mlSimpl in H1. cbn. auto. }
 Abort.
 
 Goal forall s ψ x, (* well_formed_closed ψ -> *)

--- a/matching-logic/src/SyntacticConstruct.v
+++ b/matching-logic/src/SyntacticConstruct.v
@@ -903,8 +903,8 @@ Tactic Notation "mlSimpl" "in" hyp(H) :=
   #[local]
   Program Instance sorted_forall_binder : ESortedBinder patt_forall_of_sort nest_ex := {}.
   Next Obligation.
-     intros.
-     repeat rewrite pm_correctness.
+    intros.
+    repeat rewrite pm_correctness.
     cbn.
     rewrite eswap.
     now rewrite pm_ezero_increase.

--- a/matching-logic/src/Tests/TEST_LocallyNameless.v
+++ b/matching-logic/src/Tests/TEST_LocallyNameless.v
@@ -301,13 +301,13 @@ Module test_3.
       { admit. }
       assert (Γₙₐₜ ⊢i ex , (sym_succ $ sym_succ $ sym_succ $ sym_succ $ sym_zero =ml b0) using AnyReasoning) as S4WF.
       { admit. }
-      mgSpecMeta RA1 with (sym_succ $ sym_succ $ sym_zero).
+      mlSpecMeta RA1 with (sym_succ $ sym_succ $ sym_zero).
       mlSimpl in RA1; try_wfauto2. 2: admit. (* apply def_theory. *)
       simpl in RA1.
       apply universal_generalization with (x := "X0") in RA1 as RA2. (* revert Meta *)
       2: apply pile_any. 2: auto.
       mlSimpl in RA2. simpl in RA2.
-      mgSpecMeta RA2 with (sym_succ $ sym_succ $ sym_succ $ sym_succ $ sym_zero).
+      mlSpecMeta RA2 with (sym_succ $ sym_succ $ sym_succ $ sym_succ $ sym_zero).
       mlSimpl in RA2; try_wfauto2. 2: admit. (* apply def_theory. *)
       simpl in RA2.
     Abort.

--- a/matching-logic/src/Theories/DeductionTheorem.v
+++ b/matching-logic/src/Theories/DeductionTheorem.v
@@ -971,8 +971,9 @@ Proof.
       wf_auto2.
     }
     mlIntro "H".
-    mlSplitAnd; fromMLGoal.
+    mlSplitAnd.
     {
+      fromMLGoal.
       apply Knaster_tarski.
       { try_solve_pile. }
       { wf_auto2. }
@@ -988,6 +989,7 @@ Proof.
       { wf_auto2. }
     }
     {
+      fromMLGoal.
       remember (fresh_svar (ψ and ϕ)) as Y.
       rewrite <- svar_quantify_svar_open with (n := 0) (phi := (ψ and ϕ)) (X := Y).
       rewrite <- svar_quantify_svar_open with (n := 0) (phi := ϕ) (X := Y) at 2.
@@ -1082,6 +1084,7 @@ Proof.
       wf_auto2. fold no_negative_occurrence_db_b. apply wfc_impl_no_neg_occ. wf_auto2.
     }
     cbn in Htmp.
+    simpl.
     mlRewrite (useBasicReasoning AnyReasoning (@patt_and_comm Σ Γ _ ψ Htmp wfψ)) at 1.
     
     mlIntro "H".

--- a/matching-logic/src/Theories/Definedness_ProofSystem.v
+++ b/matching-logic/src/Theories/Definedness_ProofSystem.v
@@ -151,7 +151,7 @@ Proof.
   eapply MP.
   exact S1'.
   simpl in S1'. case_match. 2: congruence.
-  toMLGoal. case_match. 2: congruence. wf_auto2.
+  toMLGoal. simpl. case_match. 2: congruence. wf_auto2.
   mlIntro "H".
   mlSpecialize "H" with x.
   mlSimpl. simpl. case_match. 2: congruence.
@@ -1473,7 +1473,7 @@ Defined.
 
     epose proof (Htmp1 := (membership_or_2 _ _ _ _ _ _ HΓ)).
     (* TODO: [change constraint in _] should work even in proof mode! *)
-    change constraint in Htmp1.
+    (* change constraint in Htmp1. *)
     remember_constraint as gpi.
 
     unfold patt_and.
@@ -1510,11 +1510,11 @@ Defined.
     intros wfφ₁ wfφ₂ HΓ.
 
     epose proof (Htmp1 := (membership_or_1 _ _ _ _ _ _ HΓ)).
-    change constraint in Htmp1.
+    (* change constraint in Htmp1. *)
     epose proof (Htmp2 := (membership_not_1 _ _ _ _ HΓ)).
-    change constraint in Htmp2.
+    (* change constraint in Htmp2. *)
     epose proof (Htmp3 := (membership_not_1 _ _ _ _ HΓ)).
-    change constraint in Htmp3.
+    (* change constraint in Htmp3. *)
     toMLGoal.
     { wf_auto2. }
     mlIntro.
@@ -1892,7 +1892,8 @@ Defined.
     assert (well_formed (ex, φ)) as WFEX.
     { wf_auto2. }
     pose proof (EQ := BasicProofSystemLemmas.Ex_quan Γ φ Zvar WFEX).
-    change constraint in EQ.
+    (* change constraint in EQ. *)
+    use AnyReasoning in EQ.
     epose proof (PC := prf_conclusion Γ (patt_equal φ' Z) (instantiate (ex , φ) (patt_free_evar Zvar) ---> ex , φ) AnyReasoning ltac:(apply well_formed_equal;wf_auto2) _ EQ).
 
     assert (Γ ⊢ patt_equal φ' Z ---> (ex , φ) ^ [φ'] ---> ex , φ) as HSUB.
@@ -2133,46 +2134,61 @@ lazy_match! goal with
     eapply (@cast_proof_ml_goal _ $g) >
       [ rewrite $heq; reflexivity | ()];
     Std.clear [hr.(equality)];
-    apply MLGoal_rewriteBy
-    > [ try (match! goal with
-           | [hyp : ?theory ⊆ _ |- _] => unfold theory
-         end); try ltac1:(
-                          (* idtac "Trying set solving"; *)
-                          timeout 5 set_solver)
-      | Control.plus
-          (fun () => ltac1:(now (apply mu_free_in_path; simpl; assumption)))
-          (fun exn => let star := hr.(star_ident) in
-            ltac1:(star |-
-              unfold mu_in_evar_path; simpl; repeat case_match;
-              try reflexivity; try congruence;
-              repeat match goal with
-              | [H : context G [maximal_mu_depth_to _ _ _] |- _ ] =>
-                 (* idtac "rewriting"; *)
-                 rewrite -> maximal_mu_depth_to_0 in H by (try timeout 5 (subst star; try solve_fresh))(* This is potentially non-terminating, hence the timeout *)
-              end;
-              simpl in *; try lia
-          ) (Ltac1.of_ident star))
-      (* TODO: improve these heuristics above *)
-      | lazy_match! goal with
-        | [ |- of_MLGoal (@mkMLGoal ?sgm ?g ?l ?p AnyReasoning)]
-          =>
-            let heq2 := Fresh.in_goal ident:(heq2) in
-            let plugged := Pattern.instantiate (hr.(ctx)) a in
-            assert(heq2: ($p = $plugged))
-            > [
-                abstract (ltac1:(star |- simplify_emplace_2 star) (Ltac1.of_ident (hr.(star_ident)));
-                          reflexivity
-                         )
-              | ()
-              ];
-            let heq2_pf := Control.hyp heq2 in
-            eapply (@cast_proof_ml_goal _ $g)
-              with (goal := $plugged) >
-              [ ltac1:(heq2 |- rewrite [left in _ = left] heq2; reflexivity) (Ltac1.of_ident heq2) | ()];
-            Std.clear [heq2 ; (hr.(star_ident)); (hr.(star_eq))];
-            _mlReshapeHypsBack
-        end
-      ]
+    Control.plus(fun () =>
+      apply MLGoal_rewriteBy
+      > [ try (match! goal with
+             | [hyp : ?theory ⊆ _ |- _] => unfold theory
+           end); try ltac1:(
+                            (* idtac "Trying set solving"; *)
+                            timeout 5 set_solver)
+        | Control.plus
+            (fun () => ltac1:(now (apply mu_free_in_path; simpl; assumption)))
+            (fun exn => let star := hr.(star_ident) in
+              ltac1:(star |-
+                unfold mu_in_evar_path; simpl; repeat case_match;
+                try reflexivity; try congruence;
+                repeat match goal with
+                | [H : context G [maximal_mu_depth_to _ _ _] |- _ ] =>
+                   (* idtac "rewriting"; *)
+                   rewrite -> maximal_mu_depth_to_0 in H by (try timeout 5 (subst star; try solve_fresh))(* This is potentially non-terminating, hence the timeout *)
+                end;
+                simpl in *; try lia
+            ) (Ltac1.of_ident star))
+        (* TODO: improve these heuristics above *)
+        | lazy_match! goal with
+          | [ |- of_MLGoal (@mkMLGoal ?sgm ?g ?l ?p AnyReasoning)]
+            =>
+              let heq2 := Fresh.in_goal ident:(heq2) in
+              let plugged := Pattern.instantiate (hr.(ctx)) a in
+              assert(heq2: ($p = $plugged))
+              > [
+                  abstract (ltac1:(star |- simplify_emplace_2 star) (Ltac1.of_ident (hr.(star_ident)));
+                            reflexivity
+                           )
+                | ()
+                ];
+              let heq2_pf := Control.hyp heq2 in
+              eapply (@cast_proof_ml_goal _ $g)
+                with (goal := $plugged) >
+                [ ltac1:(heq2 |- rewrite [left in _ = left] heq2; reflexivity) (Ltac1.of_ident heq2) | ()];
+              Std.clear [heq2 ; (hr.(star_ident)); (hr.(star_eq))];
+              _mlReshapeHypsBack
+          end
+        ]
+      )
+      (fun _ => throw_pm_exn (Message.concat (Message.of_string "mlRewriteBy: failed when rewriting '")
+                             (Message.concat (Message.of_constr (a))
+                             (Message.concat (Message.of_string "' to/from '")
+                             (Message.concat (Message.of_constr (a'))
+                             (Message.concat (Message.of_string "' in context ")
+                             (Message.of_constr (pc))
+                             )
+                             )
+                             )
+                             )
+                             )
+      )
+| [|- _] => throw_pm_exn_with_goal "mlRewrite: not in proof mode"
 end
 .
 
@@ -2200,6 +2216,7 @@ Proof.
   { wf_auto2. }
   mlIntro "H0". mlIntro "H1".
   mlRewriteBy "H1" at 1.
+  Fail mlRewriteBy "H1" at 1.
   mlExactn 0.
 Defined.
 
@@ -2684,8 +2701,8 @@ Proof.
     mlRewrite (useBasicReasoning (ExGen := ⊤, SVSubst := ∅, KT := false, AKT := false) (patt_and_comm Γ (patt_free_evar x) (ex, φ) ltac:(wf_auto2) ltac:(wf_auto2))) at 1.
     mlRewrite <- (@liftProofInfoLe Σ Γ _ (ExGen := {[fresh_evar (φ and patt_free_evar x)]}, SVSubst := ∅, KT := false, AKT := false) (ExGen := ⊤, SVSubst := ∅, KT := false, AKT := false) ltac:(try_solve_pile) (@prenex_exists_and_iff Σ Γ φ (patt_free_evar x) ltac:(wf_auto2) ltac:(wf_auto2))) at 1.
     remember (evar_fresh (elements ({[x]} ∪ (free_evars φ)))) as y.
-    mlSplitAnd; fromMLGoal.
-    - apply (strip_exists_quantify_l Γ y).
+    mlSplitAnd.
+    - fromMLGoal. apply (strip_exists_quantify_l Γ y).
       { subst y. simpl.
         eapply not_elem_of_larger_impl_not_elem_of.
         2: { apply set_evar_fresh_is_fresh'. }
@@ -2707,7 +2724,7 @@ Proof.
       mlIntro "H0". mlDestructAnd "H0" as "H1" "H2". mlSplitAnd.
       + mlExact "H2".
       + mlExact "H1".
-    - apply (strip_exists_quantify_l Γ y).
+    - fromMLGoal. apply (strip_exists_quantify_l Γ y).
       { subst y. simpl.
         eapply not_elem_of_larger_impl_not_elem_of.
         2: { apply set_evar_fresh_is_fresh'. }
@@ -2834,12 +2851,12 @@ Proof.
   mlSplitAnd; mlIntro "H0".
   - mlApplyMeta (useBasicReasoning (ExGen := ∅, SVSubst := ∅, KT := false, AKT := false) (Prop_disj_right Γ φ₁ φ₂ (patt_sym (Definedness_Syntax.inj definedness)) ltac:(wf_auto2) ltac:(wf_auto2) ltac:(wf_auto2) )).
     mlExact "H0".
-  - mlDestructOr "H0" as "H1" "H2"; fromMLGoal.
-    + unshelve (eapply Framing_right).
+  - mlDestructOr "H0" as "H1" "H2".
+    + fromMLGoal. unshelve (eapply Framing_right).
       * wf_auto2.
       * try_solve_pile.
       * toMLGoal. wf_auto2. mlIntro "H0'". mlLeft. mlExact "H0'".
-    + unshelve (eapply Framing_right).
+    + fromMLGoal. unshelve (eapply Framing_right).
       * wf_auto2.
       * try_solve_pile.
       * toMLGoal. wf_auto2. mlIntro "H0'". mlRight. mlExact "H0'".
@@ -2854,8 +2871,19 @@ Proof.
   mlIntro "H0".
   mlClassic (φ₁) as "H1'" "H1'".
   { assumption. }
-  { mlTauto. }
-  { mlTauto. }
+  {
+    mlIntro. mlSplitAnd. 2: mlAssumption.
+    mlDestructOr "H0".
+    * mlExFalso. mlApply "1". mlAssumption.
+    * mlAssumption.
+  }
+  {
+    mlIntro. mlSplitAnd.
+    * mlDestructOr "H0".
+      - mlExFalso. mlApply "0". mlAssumption.
+      - mlAssumption.
+    * mlExFalso. mlApply "0". mlAssumption.
+  }
 Defined.
 
 Lemma membership_symbol_ceil_aux_0 {Σ : Signature} {syntax : Syntax} Γ x y φ:
@@ -4371,12 +4399,12 @@ Proof.
   intros Γ φ ψ HΓ WF1 WF2 MF P1 P2.
   toMLGoal. wf_auto2.
   mlApplyMeta forall_functional_subst.
-  mlSplitAnd; fromMLGoal; auto.
+  mlSplitAnd. all: try fromMLGoal; auto.
   Unshelve. all: auto. all: wf_auto2.
 Defined.
 
 (* TODO: make sure that the final [assumption] does not solve goals we do not want to solve. *)
-Tactic Notation "mgSpecMeta" ident(hyp) "with" constr(t) := 
+Tactic Notation "mlSpecMeta" ident(hyp) "with" constr(t) := 
   unshelve (eapply (@mlSpecializeMeta _ _ _ _ t) in hyp); try_wfauto2; try assumption.
 
 Local Lemma test_spec {Σ : Signature} {syntax : Syntax}:
@@ -4386,7 +4414,7 @@ Local Lemma test_spec {Σ : Signature} {syntax : Syntax}:
   Γ ⊢i ex , ψ =ml b0 using AnyReasoning ->
   Γ ⊢i φ^[evar: 0 ↦ ψ] using AnyReasoning.
 Proof.
-  intros. mgSpecMeta H3 with ψ.
+  intros. mlSpecMeta H3 with ψ.
 Defined.
 
 Lemma MLGoal_mlSpecialize {Σ : Signature} {syntax : Syntax} Γ l₁ l₂ p t g name:
@@ -4546,22 +4574,27 @@ Defined.
 
 Tactic Notation "mlSymmetry" :=
   _ensureProofMode;
-  apply MLGoal_symmetry; [try assumption; set_solver|].
+  tryif apply MLGoal_symmetry; [try assumption; try timeout 5 set_solver|]
+  then idtac
+  else fail "mlSymmetry: matching logic goal is not an equality".
 
 Tactic Notation "mlSymmetry" "in" constr(name) :=
   _ensureProofMode;
   _mlReshapeHypsByName name;
-  apply (MLGoal_symmetryIn name); [try assumption; set_solver|];
-  _mlReshapeHypsBack.
+  tryif apply (MLGoal_symmetryIn name); [try assumption; try timeout 5 set_solver|];
+  _mlReshapeHypsBack
+  then idtac
+  else fail "mlSymmetry: given local hypothesis is not an equality".
 
 Local Example mlSymmetry_test {Σ : Signature} {syntax : Syntax} Γ ϕ ψ :
   theory ⊆ Γ -> well_formed ϕ -> well_formed ψ ->
-  Γ ⊢i ϕ =ml ψ ---> ϕ =ml ψ using AnyReasoning.
+  Γ ⊢i ψ ---> ϕ =ml ψ ---> ϕ =ml ψ using AnyReasoning.
 Proof.
   intros.
-  mlIntro "H".
+  mlIntro "H0". mlIntro "H".
   mlSymmetry.
   mlSymmetry in "H".
+  Fail mlSymmetry in "H0".
   mlAssumption.
 Defined.
 

--- a/matching-logic/src/Theories/Nat_ProofSystem.v
+++ b/matching-logic/src/Theories/Nat_ProofSystem.v
@@ -132,7 +132,7 @@ Section nat.
     { wf_auto2. }
     { apply pile_any. }
 
-    apply Knaster_tarski.
+    apply FixPoint.Knaster_tarski.
     { apply pile_any. }
     { wf_auto2. }
     unfold instantiate. mlSimpl. simpl.
@@ -223,7 +223,7 @@ Section nat.
         wf_auto2.
       }
 
-      gapply Ex_gen.
+      gapply BasicProofSystemLemmas.Ex_gen.
       { apply pile_any. }
       { apply pile_any. }
       {
@@ -258,7 +258,7 @@ Section nat.
         mlApply "M". mlClear "M".
         mlSplitAnd. mlSplitAnd.
         + mlClear "ys". mlClear "H0".
-          mlApplyMeta Ex_quan.
+          mlApplyMeta BasicProofSystemLemmas.Ex_quan.
           unfold instantiate. mlSimpl. simpl.
           fromMLGoal.
           aapply patt_equal_refl.

--- a/matching-logic/src/Theories/Sorts_ProofSystem.v
+++ b/matching-logic/src/Theories/Sorts_ProofSystem.v
@@ -11,13 +11,13 @@ From Coq.Unicode Require Import Utf8.
 From Coq.micromega Require Import Lia.
 
 From MatchingLogic Require Export Logic ProofMode.MLPM.
-From MatchingLogic.Theories Require Export Definedness_Syntax Definedness_ProofSystem.
+From MatchingLogic.Theories Require Export Definedness_Syntax Definedness_ProofSystem Sorts_Syntax.
 From MatchingLogic.Utils Require Export stdpp_ext.
 
 Require Export MatchingLogic.wftactics.
 
 From stdpp Require Import base fin_sets sets propset proof_irrel option list.
-
+Import FreshnessManager.
 Import extralibrary.
 
 Import MatchingLogic.Logic.Notations.
@@ -35,6 +35,26 @@ Open Scope string_scope.
 Open Scope list_scope.
 
 Set Printing All.
+
+Local Lemma simplTest
+  {Σ : Signature}
+  {syntax : Sorts_Syntax.Syntax}
+  (Γ : Theory)
+  (φ ψ τ: Pattern)
+  (s : symbols) x:
+  well_formed (ex , φ) ->
+  well_formed ψ ->
+  well_formed τ ->
+  Definedness_Syntax.theory ⊆ Γ ->
+  Γ ⊢ ((all ψ , φ) ---> ex ψ ,  φ)^[[evar:x↦τ]].
+Proof.
+  intros. mlSimpl. mlSortedSimpl. mlSortedSimpl. mlSimpl.
+  remember (fresh_evar (ψ $ φ $ τ)) as y.
+  mlIntro.
+  mlSpecialize "0" with x.
+  mlExists x.
+Abort.
+
 Lemma ex_sort_impl_ex
   {Σ : Signature}
   {syntax : Sorts_Syntax.Syntax}
@@ -44,7 +64,7 @@ Lemma ex_sort_impl_ex
   :
   well_formed (ex , ϕ) ->
   Definedness_Syntax.theory ⊆ Γ ->
-  Γ ⊢ ex (patt_sym s) , ϕ ---> (ex , ϕ).
+  Γ ⊢ (ex (patt_sym s) , ϕ) ---> (ex , ϕ).
 Proof.
   intros wfϕ HΓ.
 
@@ -63,7 +83,7 @@ Proof.
     wf_auto2.
   }
 
-  gapply Ex_gen.
+  gapply BasicProofSystemLemmas.Ex_gen.
   { apply pile_any. }
   { apply pile_any. }
   {
@@ -80,7 +100,7 @@ Proof.
   mlDestructAnd "H" as "H0" "H1".
   mlClear "H0".
 
-  mlApplyMeta Ex_quan. simpl.
+  mlApplyMeta BasicProofSystemLemmas.Ex_quan. simpl.
   mlExact "H1".
 Defined.
 

--- a/matching-logic/src/Theories/Sorts_Syntax.v
+++ b/matching-logic/src/Theories/Sorts_Syntax.v
@@ -145,51 +145,6 @@ Section sorts.
             ((nest_ex (nest_ex f) $ b1) =ml (nest_ex (nest_ex f) $ b0))
              ---> (b1 =ml b0))).
 
-(* (* Ltac simpl_sorted_quantification_hyp H :=
-match type of H with
-  | context G [?f ?arg _ (?binder _ _)] => 
-    match type of binder with
-    | Pattern -> Pattern -> Pattern =>
-      (* tryif *)
-       (let name := fresh "X" in
-         unshelve (epose proof (name := @esorted_binder_morphism _ binder
-            _ _ _ (f arg) _ _)); (* try (rewrite name in H; clear name);
-            try typeclasses eauto; auto; *)
-             [ | clear H; typeclasses eauto | clear H; typeclasses eauto | clear H; eauto | rewrite name in H; clear name ] 
-              )
-      (* then idtac "asd" *)
-      (* else idtac "bsd" *) (* "No sorted simplification instance for " binder *)
-    end
-  end. *)
-
-Ltac simpl_sorted_quantification_hyp H :=
-match type of H with
-  | context G [?f ?arg _ (?binder _ _)] => 
-    match type of binder with
-    | Pattern -> Pattern -> Pattern => 
-      (* tryif *)
-       (let name := fresh "X" in
-         (* NOTE: erewrite for some reason does not terminate *)
-         unshelve (epose proof (name := @esorted_binder_morphism _ binder
-            _ _ _ (f arg) _ _)) ; try (erewrite name in H; clear name);
-            match goal with
-             | |- SwappableEx _ _ _ => clear H
-             | |- PatternMorphism _ => clear H; tryif typeclasses eauto then idtac else eauto
-             | |- ESortedBinder _ _ => clear H; tryif typeclasses eauto then idtac else eauto
-             | _ => idtac
-            end
-              )
-      (* then idtac *)
-      (* else idtac *) (* "No sorted simplification instance for " binder *)
-    end
-  end. *)
-
-
-(* Tactic Notation "mlSimpl" "in" hyp(H) :=
-  repeat (rewrite mlSimpl' in H + simpl_sorted_quantification_hyp H); repeat rewrite [increase_ex _ _]/= in H; repeat rewrite [increase_mu _ _]/= in H.
-
- *)
-
 End sorts.
 
 Section sorts.

--- a/matching-logic/src/Theories/Sorts_Syntax.v
+++ b/matching-logic/src/Theories/Sorts_Syntax.v
@@ -145,13 +145,58 @@ Section sorts.
             ((nest_ex (nest_ex f) $ b1) =ml (nest_ex (nest_ex f) $ b0))
              ---> (b1 =ml b0))).
 
+(* (* Ltac simpl_sorted_quantification_hyp H :=
+match type of H with
+  | context G [?f ?arg _ (?binder _ _)] => 
+    match type of binder with
+    | Pattern -> Pattern -> Pattern =>
+      (* tryif *)
+       (let name := fresh "X" in
+         unshelve (epose proof (name := @esorted_binder_morphism _ binder
+            _ _ _ (f arg) _ _)); (* try (rewrite name in H; clear name);
+            try typeclasses eauto; auto; *)
+             [ | clear H; typeclasses eauto | clear H; typeclasses eauto | clear H; eauto | rewrite name in H; clear name ] 
+              )
+      (* then idtac "asd" *)
+      (* else idtac "bsd" *) (* "No sorted simplification instance for " binder *)
+    end
+  end. *)
+
+Ltac simpl_sorted_quantification_hyp H :=
+match type of H with
+  | context G [?f ?arg _ (?binder _ _)] => 
+    match type of binder with
+    | Pattern -> Pattern -> Pattern => 
+      (* tryif *)
+       (let name := fresh "X" in
+         (* NOTE: erewrite for some reason does not terminate *)
+         unshelve (epose proof (name := @esorted_binder_morphism _ binder
+            _ _ _ (f arg) _ _)) ; try (erewrite name in H; clear name);
+            match goal with
+             | |- SwappableEx _ _ _ => clear H
+             | |- PatternMorphism _ => clear H; tryif typeclasses eauto then idtac else eauto
+             | |- ESortedBinder _ _ => clear H; tryif typeclasses eauto then idtac else eauto
+             | _ => idtac
+            end
+              )
+      (* then idtac *)
+      (* else idtac *) (* "No sorted simplification instance for " binder *)
+    end
+  end. *)
+
+
+(* Tactic Notation "mlSimpl" "in" hyp(H) :=
+  repeat (rewrite mlSimpl' in H + simpl_sorted_quantification_hyp H); repeat rewrite [increase_ex _ _]/= in H; repeat rewrite [increase_mu _ _]/= in H.
+
+ *)
+
 End sorts.
 
 Section sorts.
   Context {Σ : Signature}.
   Context {self : Syntax}.
   Open Scope ml_scope.
-  
+
   Definition patt_total_binary_function(phi from1 from2 to : Pattern)
   : Pattern :=
     patt_forall_of_sort from1 (
@@ -166,7 +211,8 @@ End sorts.
 
 Module Notations.
   Notation "〚 phi 〛" := (patt_inhabitant_set phi) (at level 0) : ml_scope.
-  Notation "'all' s ,  phi" := (patt_forall_of_sort s phi) (at level 70) : ml_scope.
-  Notation "'ex' s ,  phi" := (patt_exists_of_sort s phi) (at level 70) : ml_scope.
+  Notation "'all' s ,  phi" := (patt_forall_of_sort s phi) (at level 80) : ml_scope.
+  Notation "'ex' s ,  phi" := (patt_exists_of_sort s phi) (at level 80) : ml_scope.
   Notation "phi :ml s1 × s2 -> s3" :=  (patt_total_binary_function phi s1 s2 s3) (at level 70) : ml_scope.
 End Notations.
+

--- a/proofmode.md
+++ b/proofmode.md
@@ -1,9 +1,12 @@
 # List of proof mode tactics
 
-|    tactic                                | description   |
+|  Entering, exiting the proof mode |  |
 |-----------------------------------------:|------------------------------------|
 | `toMLGoal`                               | enter the proof mode               |
 | `fromMLGoal`                             | leave the proof mode (applies the Inherit proof rule)             |
+
+| Propositional tactics | |
+|-----------------------------------------:|------------------------------------|
 | `mlIntro "H"`                            | move the LHS of an implication into the local context - implication introduction               |
 | `mlRevert "H"`, `mlRevertLast`           | move the local hypothesis `"H"` (or the last one) into the LHS of the goal |
 | `mlClear "H"`                            | removes a local hypothesis `"H"` |
@@ -16,17 +19,27 @@
 | `mlClassic phi as "H1" "H2"`             | destruct on the disjunction `phi or neg phi` and save the result as local hypothesis "H1" or "H2"       |
 | `mlExact "H"`                            | finish a proof by using the local hypothesis `"H"` which is the same as the goal |
 | `mlAssumption`                           | finish a proof by using some local hypothesis which is the same as the goal |
-| `mlExactMeta`                            | finish a proof by using a global hypothesis or a lemma which is the same as the goal |
-| `mlExists x`                             | use `x` to specialize an existential goal - introduction of existential quantifier |
-| `mlDestructEx "H" as x`                  | use the local hypothesis `"H"` to extract a witness `x`, where `x` already is a fresh variable - elimination of existential quantifier |
-| `mlIntroAll x`                           | specialize a universally quantified goal, where `x` already is a fresh variable - introduction of universal quantifier |
-| `mlSpecialize "H" with x`                | specialize a local hypothesis `"H"` using a variable `x` - elimination of universal quantifier |
 | `mlApply "H"`                            | apply an implication from a local hypothesis `"H"` to the goal |
 | `mlApply "H" in "H0"`                    | apply an implication from a local hypothesis `"H"` to another hypothesis "H0" |
-| `mlApplyMeta term`                       | apply an implication (or a chain of implications) from a lemma or a Coq hypothesis to the goal |
-| `mlRewrite term at n`, `mlRewrite <- term at n` | rewrite using a global hypothesis or a lemma that is a matching logic equivalence, where `term` is fully specialized |
 | `mlRewriteBy "H" at n`                   | rewrite using a local hypothesis that is a matching logic equality (when working under the theory of definedness) - elimination of equality |
-| `mlReflexivity`                          | finish proof of a conclusion of the shape `phi =ml phi` - introduction of equality |
+| `mlReflexivity`                          | finish proof of a conclusion of the shape `op phi phi` - for reflexive operators (e.g., `=ml`, `--->`, `<--->`) |
 | `mlSymmetry`, `mlSymmetry in "H"`        | swaps the sides of an equality |
 | `mlSwap "H" with "H0"`                   | swaps the positions of two hypotheses |
 | `mlConj "H1" "H2" as "HC"`               | makes a conjunction of two hypotheses |
+| `mlRename "H1" into "H2"`                | renames a local hypothesis |
+
+
+| Meta-level propositional tactics | |
+|------------------------------------------------:|------------------------------------|
+| `mlExactMeta`                                   | finish a proof by using a global hypothesis or a lemma which is the same as the goal |
+| `mlRewrite term at n`, `mlRewrite <- term at n` | rewrite using a global hypothesis or a lemma that is a matching logic equivalence, where `term` is fully specialized |
+| `mlApplyMeta term`                              | apply an implication (or a chain of implications) from a lemma or a Coq hypothesis to the goal |
+| `mlApplyMeta term in "H"`                       | apply an implication (or a chain of implications) from a lemma or a Coq hypothesis to a local hypothesis |
+
+| First-order tactics | |
+|-----------------------------------------:|------------------------------------|
+| `mlDestructEx "H" as x`                  | use the local hypothesis `"H"` to extract a witness `x`, where `x` already is a fresh variable - elimination of existential quantifier |
+| `mlIntroAll x`                           | specialize a universally quantified goal, where `x` already is a fresh variable - introduction of universal quantifier |
+| `mlSpecialize "H" with x`                | specialize a local hypothesis `"H"` using a variable `x` - elimination of universal quantifier |
+| `mlExists x`                             | use `x` to specialize an existential goal - introduction of existential quantifier |
+| `mlRevertAll x`                          | moves the free variable `x` back into the goal by quantifying over it |

--- a/proofmode.md
+++ b/proofmode.md
@@ -43,3 +43,7 @@
 | `mlSpecialize "H" with x`                | specialize a local hypothesis `"H"` using a variable `x` - elimination of universal quantifier |
 | `mlExists x`                             | use `x` to specialize an existential goal - introduction of existential quantifier |
 | `mlRevertAll x`                          | moves the free variable `x` back into the goal by quantifying over it |
+
+| Other tactics | |
+|-----------------------------------------:|------------------------------------|
+| `mlSimpl` | simplifies substitutions by preserving the structure of derived operators and it can be used otside of the proof mode too. |


### PR DESCRIPTION
Closes #396. This PR fixes the following issues:

- `mlSymmetry` will not fail for non-trivial side conditions anymore
- `for_nth_match` is slightly sped up: when checking a pattern for the nth occurrence of the given subpattern, it will stop when reaching the given occurrence instead of scanning the remaining parts of the pattern (in the previous version, this tactic always scanned the entire pattern).
- removed a number of unnecessary simplifications from proof mode tactics

This PR also extends the description of proof mode tactics, and introduces better error messages for them.