### PR TITLE
Generic OPML models

### DIFF
--- a/matching-logic/_CoqProject
+++ b/matching-logic/_CoqProject
@@ -91,4 +91,5 @@ src/OPML/OpmlPattern.v
 src/OPML/OpmlModel.v
 src/OPML/OpmlAmlRelSpec.v
 src/OPML/OpmlExamples.v
+src/OPML/GenericModel.v
 

--- a/matching-logic/src/OPML/GenericModel.v
+++ b/matching-logic/src/OPML/GenericModel.v
@@ -1,0 +1,262 @@
+From Coq Require Import ssreflect ssrfun ssrbool.
+
+From stdpp Require Import base list list_numbers propset.
+(* This is unset by stdpp. We need to set it again.*)
+Set Transparent Obligations.
+
+From Equations Require Import Equations.
+(* Set Equations Transparent. *)
+
+From MatchingLogic.OPML Require Import
+    OpmlSignature
+    OpmlModel
+.
+
+Definition UnifiedCarrierInfo := Type.
+
+Definition UnifiedCarrierFunctor : Type
+    := Type -> UnifiedCarrierInfo
+.
+
+Definition UnifiedCarrierCtorFamily
+    (UCF : UnifiedCarrierFunctor) (A : Type)
+: Type
+    := (nat*(list A))%type -> (* Choose a particuar constructor from the family, and arguments of the constructor from the underlying type *)
+       option (UCF A) (* maybe return something, and maybe not *)
+.
+
+Definition is_monotone (F : UnifiedCarrierFunctor)
+    : Type
+:= forall x, (x -> F x)
+.
+
+Record UnifiedCarrierComponent := {
+    ucc_functor : UnifiedCarrierFunctor ;
+    ucc_functor_monotone : is_monotone ucc_functor ;
+    ucc_ctor_family : forall A, UnifiedCarrierCtorFamily ucc_functor A ;
+}.
+
+(* We can bypass the check because of the `is_monotone` requirement. *)
+#[bypass_check(positivity=yes)]
+Inductive UnifiedCarrier
+    (F: UnifiedCarrierFunctor)
+    (pos : is_monotone F)
+: Type :=
+| c (st : F (UnifiedCarrier F pos))
+.
+
+Definition CompInvertorT
+    (UCC : UnifiedCarrierComponent)
+: Type
+    := forall (A : Type) (x : ucc_functor UCC A),
+        option ({ nla : (nat*(list A))%type | ucc_ctor_family UCC A nla = Some x })
+.
+
+Record Component := {
+    comp_UCC
+        : UnifiedCarrierComponent ;
+
+    comp_invertor
+        : CompInvertorT comp_UCC ;
+
+    comp_invertor_complete
+        : forall
+            (A : Type)
+            (nla : (nat*(list A))%type)
+            (x : ucc_functor comp_UCC A),
+            ucc_ctor_family comp_UCC A nla = Some x ->
+            exists pf,
+                comp_invertor A x = Some (exist _ nla pf)
+        ;
+}.
+
+
+Section constant.
+    Context
+        (UCI : UnifiedCarrierInfo)
+        (inh_UCI : Inhabited UCI)
+    .
+
+    Definition constant_UnifiedCarrierFunctor : UnifiedCarrierFunctor
+        := fun _ => UCI
+    .
+
+    Lemma constant_UnifiedCarrierFunctor_monotone : is_monotone constant_UnifiedCarrierFunctor.
+    Proof.
+        unfold is_monotone,constant_UnifiedCarrierFunctor,UnifiedCarrierInfo in *.
+        intros T x.
+        destruct inh_UCI as [inhabitant].
+        exact inhabitant.
+    Qed.
+
+    (* TODO *)
+    Definition constant_inversion
+        {A : Type}
+        (x : constant_UnifiedCarrierFunctor A)
+    := 0.
+
+
+End constant.
+
+Definition bool_UCC : UnifiedCarrierComponent := {|
+    ucc_functor
+        := constant_UnifiedCarrierFunctor bool ;
+
+    ucc_functor_monotone
+        := constant_UnifiedCarrierFunctor_monotone bool _ ;
+
+    ucc_ctor_family
+        := fun A nla =>
+        match nla with
+        | (0, []) => Some true
+        | (1, []) => Some false
+        | _ => None
+        end
+        ;
+|}.
+
+Program Definition bool_component : Component := {|
+    comp_UCC :=  bool_UCC ;
+    comp_invertor := fun A x =>
+        match x return option ({ nla : (nat*(list A))%type | ucc_ctor_family bool_UCC A nla = Some x }) with 
+        | true => Some (exist (fun y => ucc_ctor_family bool_UCC A y = Some true) (0,([]):(list A)) erefl)
+        | false => Some (exist _ (1,([]):(list A)) erefl)
+        end
+        ;
+|}.
+Next Obligation.
+    destruct n,l.
+    {
+        inversion H; subst; clear H.
+        exists erefl.
+        reflexivity.
+    }
+    { inversion H. }
+    {
+        destruct n; inversion H; subst.
+        {
+            exists erefl.
+            reflexivity.
+        }
+    }
+    {
+        destruct n; inversion H.
+    }
+Qed.
+Fail Next Obligation.
+
+Section paircomb.
+    Context
+        (F1 F2 : UnifiedCarrierFunctor)
+    .
+
+    Definition paircomb_UnifiedCarrierFunctor : UnifiedCarrierFunctor
+    := fun A => ((F1 A)+(F2 A))%type
+    .
+
+    Definition paircomb_type_witness (T : Type) : Type :=
+        (({A : Type | T = F1 A}) + ({A : Type | T = F2 A}))%type
+    .
+
+    Definition paircomb_inversion
+        {A : Type}
+        (x : paircomb_UnifiedCarrierFunctor A)
+        (T : Type)
+        (wit : paircomb_type_witness T)
+    :=
+    match wit with
+    | inl (exist _ A pf) => 0
+    | inr (exist _ A pf) => 0
+    end
+    .
+
+End paircomb.
+
+Section combine_ucf.
+    Context
+        (l : list (UnifiedCarrierFunctor))
+        (pf : forall (F : UnifiedCarrierFunctor), F ∈ l -> is_monotone F)
+    .
+
+    Definition combine_ucf : UnifiedCarrierFunctor
+    := fun A =>
+            let l' := (fun F => F A) <$> l in
+        foldr sum Empty_set l'
+    .
+
+End combine_ucf.
+
+Section combine.
+
+    Context
+        (l : list Component)
+    .
+
+    Definition combine : Component := {|
+        comp_UCC := 
+    |}.
+
+End combine.
+
+
+Section with_signature.
+    Context
+        {Σ : OPMLSignature}
+        (UCI : UnifiedCarrierInfo)
+        (UCF : UnifiedCarrierFunctor)
+        (pos : is_monotone UCF)
+    .
+
+    Definition CarrierFunctor : Type :=
+        forall (s : opml_sort),
+            propset UCI
+    .
+
+    Context
+        (CF : CarrierFunctor)
+        (cfi : CarrierFunctorInvertor)
+    .
+
+    
+    Definition lift_cf : propset (UnifiedCarrier UCF pos)
+    := PropSet (fun (e : UnifiedCarrier UCF pos) =>
+        match e with
+        | c _ _ x =>
+            match (cfi x) with
+            | None => False
+            | Some ((A:Type),(y:A),pf) =>
+                (* Need to know that `x` came from UCF *)
+                True
+            end
+        end
+    ).
+
+End with_signature.
+(*
+(*
+Definition ModelInfo : Type :=
+    ()%type
+.
+*)
+Record ModelInfo := {
+
+}.
+
+Definition ModelFunctor : Type -> Type :=
+    fun (CarrierBase : Type) =>
+    (Type*(ModelInfo))%type
+.
+
+Definition proj_carrier (MF : ModelFunctor) : CarrierFunctor
+:=
+    fun A => (MF A).1
+.
+*)
+Section mybool.
+    Definition F : UnifiedCarrierFunctor := fun _ => bool.
+    Definition interpretation_of_true : bool := true.
+
+
+
+End mybool.
+

--- a/matching-logic/src/OPML/GenericModel.v
+++ b/matching-logic/src/OPML/GenericModel.v
@@ -27,7 +27,7 @@ Definition UnifiedCarrierCtorFamily
 
 Definition is_monotone (F : UnifiedCarrierFunctor)
     : Type
-:= forall x, (x -> F x)
+:= forall x y, (x -> y) -> (F x -> F x)
 .
 
 Record UnifiedCarrierComponent := {
@@ -74,7 +74,6 @@ Record Component := {
 Section constant.
     Context
         (UCI : UnifiedCarrierInfo)
-        (inh_UCI : Inhabited UCI)
     .
 
     Definition constant_UnifiedCarrierFunctor : UnifiedCarrierFunctor
@@ -84,9 +83,8 @@ Section constant.
     Lemma constant_UnifiedCarrierFunctor_monotone : is_monotone constant_UnifiedCarrierFunctor.
     Proof.
         unfold is_monotone,constant_UnifiedCarrierFunctor,UnifiedCarrierInfo in *.
-        intros T x.
-        destruct inh_UCI as [inhabitant].
-        exact inhabitant.
+        intros T1 T2 f x.
+        exact x.
     Qed.
 
     (* TODO *)
@@ -103,7 +101,7 @@ Definition bool_UCC : UnifiedCarrierComponent := {|
         := constant_UnifiedCarrierFunctor bool ;
 
     ucc_functor_monotone
-        := constant_UnifiedCarrierFunctor_monotone bool _ ;
+        := constant_UnifiedCarrierFunctor_monotone bool ;
 
     ucc_ctor_family
         := fun A nla =>
@@ -160,11 +158,19 @@ Section paircomb_ucf.
         assert (M1 := ucc_functor_monotone F1).
         assert (M2 := ucc_functor_monotone F2).
         unfold is_monotone, paircomb_ucf_UnifiedCarrierFunctor in *.
-        intros T x.
-        specialize (M1 T x).
-        specialize (M2 T x).
-        (* This is highly suspicious. Our definition of monotonicity is probably wrong. *)
-        left. assumption.
+        intros T1 T2 f.
+        specialize (M1 T1 T2 f).
+        specialize (M2 T1 T2 f).
+        intros H.
+        destruct H as [H|H].
+        {
+            specialize (M1 H).
+            left. exact M1.
+        }
+        {
+            specialize (M2 H).
+            right. exact M2.
+        }
     Qed.
 
 End paircomb_ucf.
@@ -184,7 +190,6 @@ Section paircomb.
         |};
 
     |}.
-    Next Obligation. Admitted.
     Next Obligation. Admitted.
     Next Obligation. Admitted.
     Next Obligation. Admitted.

--- a/matching-logic/src/OPML/GenericModel.v
+++ b/matching-logic/src/OPML/GenericModel.v
@@ -145,30 +145,49 @@ Next Obligation.
 Qed.
 Fail Next Obligation.
 
+Section paircomb_ucf.
+    Context
+        (F1 F2 : UnifiedCarrierComponent)
+    .
+
+    Definition paircomb_ucf_UnifiedCarrierFunctor : UnifiedCarrierFunctor
+    :=
+        fun A => ((ucc_functor F1 A)+(ucc_functor F2 A))%type
+    .
+
+    Lemma paircomb_ucf_UnifiedCarrierFunctor_monotone : is_monotone paircomb_ucf_UnifiedCarrierFunctor.
+    Proof.
+        assert (M1 := ucc_functor_monotone F1).
+        assert (M2 := ucc_functor_monotone F2).
+        unfold is_monotone, paircomb_ucf_UnifiedCarrierFunctor in *.
+        intros T x.
+        specialize (M1 T x).
+        specialize (M2 T x).
+        (* This is highly suspicious. Our definition of monotonicity is probably wrong. *)
+        left. assumption.
+    Qed.
+
+End paircomb_ucf.
+
 Section paircomb.
     Context
-        (F1 F2 : UnifiedCarrierFunctor)
+        (C1 C2 : Component)
     .
 
-    Definition paircomb_UnifiedCarrierFunctor : UnifiedCarrierFunctor
-    := fun A => ((F1 A)+(F2 A))%type
-    .
+    Program Definition paircomb : Component := {|
+        comp_UCC := {|
+            ucc_functor :=
+                paircomb_ucf_UnifiedCarrierFunctor
+                    (comp_UCC C1)
+                    (comp_UCC C2)
+                ;
+        |};
 
-    Definition paircomb_type_witness (T : Type) : Type :=
-        (({A : Type | T = F1 A}) + ({A : Type | T = F2 A}))%type
-    .
-
-    Definition paircomb_inversion
-        {A : Type}
-        (x : paircomb_UnifiedCarrierFunctor A)
-        (T : Type)
-        (wit : paircomb_type_witness T)
-    :=
-    match wit with
-    | inl (exist _ A pf) => 0
-    | inr (exist _ A pf) => 0
-    end
-    .
+    |}.
+    Next Obligation. Admitted.
+    Next Obligation. Admitted.
+    Next Obligation. Admitted.
+    Next Obligation. Admitted.
 
 End paircomb.
 
@@ -192,9 +211,11 @@ Section combine.
         (l : list Component)
     .
 
+    (*
     Definition combine : Component := {|
         comp_UCC := 
     |}.
+    *)
 
 End combine.
 
@@ -212,6 +233,7 @@ Section with_signature.
             propset UCI
     .
 
+    (*
     Context
         (CF : CarrierFunctor)
         (cfi : CarrierFunctorInvertor)
@@ -231,6 +253,7 @@ Section with_signature.
         end
     ).
 
+    *)
 End with_signature.
 (*
 (*
@@ -252,11 +275,4 @@ Definition proj_carrier (MF : ModelFunctor) : CarrierFunctor
     fun A => (MF A).1
 .
 *)
-Section mybool.
-    Definition F : UnifiedCarrierFunctor := fun _ => bool.
-    Definition interpretation_of_true : bool := true.
-
-
-
-End mybool.
 


### PR DESCRIPTION
As per the discussion we had this morning and also https://github.com/harp-project/AML-Formalization/issues/383, I created some infrastructure for defining OPML models from components. I am quite satisfied with the `Component` record, which also contains a generic way of constructing and destructing elements that came from the particular component. There is also the example `bool_component`,  There are also some very basic combinators for creating a new component: some for a "constant" component like Bools or Nats, and some for a combination of two components into one. However, here is something suspicious in the proof of the lemma `paircomb_ucf_UnifiedCarrierFunctor_monotone`, where it is enough if one component is monotone in order to prove that the generated component is monotone. Perhaps something is wrong with our definition of monotonicity?