### PR TITLE
Extend `mlRewriteBy` notation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ nra.cache
 
 # Generated documentation
 html/*
+
+# Envrc and Direnv files
+.envrc
+.direnv/*

--- a/matching-logic/src/Theories/Definedness_ProofSystem.v
+++ b/matching-logic/src/Theories/Definedness_ProofSystem.v
@@ -4814,7 +4814,7 @@ Tactic Notation "mlRewriteBy" "<-" constr(name) "at" constr(atn) "in" constr(hyp
   mlRewriteBy name at atn in hypo;
   mlSymmetry in name.
 
-Local Example mlRewriteBy_test {Σ : Signature} {syntax : Syntax} Γ ϕ ψ :
+Local Example mlRewriteBy_test_in_barr {Σ : Signature} {syntax : Syntax} Γ ϕ ψ :
   theory ⊆ Γ -> well_formed ϕ -> well_formed ψ ->
   Γ ⊢i
     ! (ψ ---> ϕ) --->
@@ -4830,6 +4830,39 @@ Proof.
   mlApply "idPh" in "P1".
   mlAssumption.
 Defined.
+
+Local Example mlRewriteBy_test_in {Σ : Signature} {syntax : Syntax} Γ ϕ ψ :
+  theory ⊆ Γ -> well_formed ϕ -> well_formed ψ ->
+  Γ ⊢i
+    ! (ψ ---> ϕ) --->
+    ! (ψ =ml ϕ)
+    using AnyReasoning.
+Proof.
+  intros.
+  toMLGoal;[wf_auto2|].
+  mlIntro "P1"; mlIntro "P2".
+  mlRewriteBy "P2" at 1 in "P1".
+  mlAssert ("idPh" : (ϕ ---> ϕ)); wf_auto2.
+  mlIntro; mlAssumption.
+  mlApply "idPh" in "P1".
+  mlAssumption.
+Defined.
+
+Local Example mlRewriteBy_test_barr {Σ : Signature} {syntax : Syntax} Γ ϕ ψ :
+  theory ⊆ Γ -> well_formed ϕ -> well_formed ψ ->
+  Γ ⊢i
+    (ψ =ml ϕ) --->
+    ! ψ ---> ! ϕ
+    using AnyReasoning.
+Proof.
+  intros.
+  toMLGoal;[wf_auto2|].
+  mlIntro "P1"; mlIntro.
+  mlRewriteBy <- "P1" at 1.
+  mlAssumption.
+Defined.
+
+
 
 (* TODO: eliminate mu_free *)
 Lemma patt_equal_trans {Σ : Signature} {syntax : Syntax} Γ φ1 φ2 φ3:

--- a/matching-logic/src/Theories/Definedness_ProofSystem.v
+++ b/matching-logic/src/Theories/Definedness_ProofSystem.v
@@ -4794,6 +4794,43 @@ Proof.
 Defined.
 
 
+Tactic Notation "mlRewriteBy" "->" constr(name) "at" constr(atn) := mlRewriteBy name at atn.
+
+Tactic Notation "mlRewriteBy" "<-" constr(name) "at" constr(atn) :=
+  mlSymmetry in name;
+  mlRewriteBy name at atn;
+  mlSymmetry in name.
+
+(* TODO: Replace with something safer *)
+Tactic Notation "mlRewriteBy" constr(name) "at" constr(atn) "in" constr(hypo) :=
+  mlRevert hypo;
+  mlRewriteBy name at atn;
+  mlIntro hypo.
+
+Tactic Notation "mlRewriteBy" "->" constr(name) "at" constr(atn) "in" constr(hypo) := mlRewriteBy name at atn in hypo.
+
+Tactic Notation "mlRewriteBy" "<-" constr(name) "at" constr(atn) "in" constr(hypo) :=
+  mlSymmetry in name;
+  mlRewriteBy name at atn in hypo;
+  mlSymmetry in name.
+
+Local Example mlRewriteBy_test {Σ : Signature} {syntax : Syntax} Γ ϕ ψ :
+  theory ⊆ Γ -> well_formed ϕ -> well_formed ψ ->
+  Γ ⊢i
+    ! (ψ ---> ϕ) --->
+    ! (ϕ =ml ψ)
+    using AnyReasoning.
+Proof.
+  intros.
+  toMLGoal;[wf_auto2|].
+  mlIntro "P1"; mlIntro "P2".
+  mlRewriteBy <- "P2" at 1 in "P1".
+  mlAssert ("idPh" : (ϕ ---> ϕ)); wf_auto2.
+  mlIntro; mlAssumption.
+  mlApply "idPh" in "P1".
+  mlAssumption.
+Defined.
+
 (* TODO: eliminate mu_free *)
 Lemma patt_equal_trans {Σ : Signature} {syntax : Syntax} Γ φ1 φ2 φ3:
   theory ⊆ Γ ->


### PR DESCRIPTION
Adds `<-`, `->` and `in` notation support for the mlRewriteBy tactic.

- `mlRewriteBy -> ...` works the same as `mlRewriteBy`, it's just for parity.
- `mlRewriteBy <- ...` applies the proof the other way around
- `mlRewriteBy ... in H` applies the proof on a hypothesis instead of the goal. A `<-` version of this exists as well.

I added a local test to demonstrate the changes.

There is an issue which I'm not sure how to fix: `mlRewriteBy ... in H` applies the proof on the goal if the hypothesis does not have enough occurrences of the LHS of the proof. Me and @Engreyight  tried to experiment with using `mlAssert` to construct a new hypothesis, but we couldn't find a way to compute the type of the new expression. Another potential solution is checking if `H` has enough matching subexpressions and failing if it doesn't, but I'm not sure how to do this either.