### PR TITLE
Add `mlTransitivity` and expand `tutorial.v`

### DIFF
--- a/examples/02_proofmode/theories/tutorial.v
+++ b/examples/02_proofmode/theories/tutorial.v
@@ -339,3 +339,27 @@ Proof.
     *)
     mlExact "H2".
 Defined.
+
+(* If you need to compose implications, bijections or equalities, you can use [mlTransitivity]. *)
+Example use_mlTransitivity {Σ : Signature} {syntax : Syntax} Γ a b c :
+  theory ⊆ Γ -> well_formed a -> well_formed b -> well_formed c ->
+  Γ ⊢i
+    (a ---> b) --->
+    (c or b ---> c) --->
+    (a ---> c)
+    using AnyReasoning.
+Proof.
+  intros.
+  toMLGoal;[wf_auto2|].
+  mlIntro "H1"; mlIntro "H2".
+  (* Lets create a hypothesis to convert from b to c or b. *)
+  mlAssert ("T" : (b ---> c or b)); wf_auto2.
+  mlIntro "B".
+  mlRight.
+  mlAssumption.
+  (* Now we can compose H1 and T *)
+  mlTransitivity "H1" -> "T" as "H1T".
+  (* And now H1T and H2 *)
+  mlTransitivity "H1T" -> "H2" as "H1TH2".
+  mlExact "H1TH2".
+Defined.

--- a/examples/02_proofmode/theories/tutorial.v
+++ b/examples/02_proofmode/theories/tutorial.v
@@ -306,6 +306,7 @@ Proof.
   wf_auto2. (* To prove well-formedness *)
   mlIntro "A".
   mlTauto.
+  mlAssumption.
 Defined.
 
 (*

--- a/examples/02_proofmode/theories/tutorial.v
+++ b/examples/02_proofmode/theories/tutorial.v
@@ -303,9 +303,8 @@ Proof.
    *)
   mlAssert ("NewHypo" : (a ---> c)).
   (* This introduces two new goals, one for proving the well-formedness of the new hypothesis and for actually proving it*)
-  wf_auto2. (* To prove well-formedness *)
-  mlIntro "A".
-  mlTauto.
+  { wf_auto2. (* Proving well-formedness *) }
+  { mlIntro "A". mlTauto. (* Proving the introduced assumption *) }
   mlAssumption.
 Defined.
 
@@ -353,10 +352,9 @@ Proof.
   toMLGoal;[wf_auto2|].
   mlIntro "H1"; mlIntro "H2".
   (* Lets create a hypothesis to convert from b to c or b. *)
-  mlAssert ("T" : (b ---> c or b)); wf_auto2.
-  mlIntro "B".
-  mlRight.
-  mlAssumption.
+  mlAssert ("T" : (b ---> c or b)).
+  { wf_auto2. }
+  { mlIntro "B". mlRight. mlAssumption. }
   (* Now we can compose H1 and T *)
   mlTransitivity "H1" -> "T" as "H1T".
   (* And now H1T and H2 *)

--- a/matching-logic/src/Theories/Definedness_ProofSystem.v
+++ b/matching-logic/src/Theories/Definedness_ProofSystem.v
@@ -4882,7 +4882,73 @@ Proof.
   mlAssumption.
 Defined.
 
+Tactic Notation "mlTransitivity" constr(a1) "->" constr(a2) "as" constr(nam) :=
+  _ensureProofMode;
+  match goal with
+    | [ |- context[mkNH _ a1 (@patt_equal _ _ ?a ?b)] ] =>
+        match goal with
+          | [ |- context[mkNH _ a2 (@patt_equal _ _ b ?c)] ] =>
+              mlAssert (nam : (a =ml c)); [wf_auto2 | mlRewriteBy a1 at 1; mlAssumption | ]
+        end
+    | [ |- context[mkNH _ a1 (@patt_imp _ ?a ?b)] ] =>
+        match goal with
+          | [ |- context[mkNH _ a2 (@patt_imp _ b ?c)] ] =>
+              mlAssert (nam : (a ---> c)); [wf_auto2 | mlIntro; mlApply a2; mlApply a1; mlAssumption | ]
+        end
+    | [ |- context[mkNH _ a1 (@patt_iff _ ?a ?b)] ] =>
+        match goal with
+          | [ |- context[mkNH _ a2 (@patt_iff _ b ?c)] ] =>
+              mlAssert (nam : (a <---> c)); [wf_auto2 | mlSplitAnd; mlIntro; mlDestructAnd a1; mlDestructAnd a2; [mlTauto|mlTauto]|]
+        end
+  end.
 
+Local Example mlTransitivity_test_imp {Σ : Signature} {syntax : Syntax} Γ a b c :
+  theory ⊆ Γ -> well_formed a -> well_formed b -> well_formed c ->
+  Γ ⊢i
+    (a ---> b) --->
+    (b ---> c) --->
+    a ---> c
+    using AnyReasoning.
+Proof.
+  intros.
+  toMLGoal;[wf_auto2|].
+  mlIntro "P1"; mlIntro "P2".
+  mlTransitivity "P1" -> "P2" as "PT".
+  mlAssumption.
+Defined.
+
+
+Local Example mlTransitivity_test_mleq {Σ : Signature} {syntax : Syntax} Γ a b c :
+  theory ⊆ Γ -> well_formed a -> well_formed b -> well_formed c ->
+  Γ ⊢i
+    (a =ml b) --->
+    (b =ml c) --->
+    a =ml c
+    using AnyReasoning.
+Proof.
+  intros.
+  toMLGoal;[wf_auto2|].
+  mlIntro "P1"; mlIntro "P2".
+  mlTransitivity "P1" -> "P2" as "PT".
+  mlAssumption.
+Defined.
+
+
+(* TODO: Super slow due to mlTauto *)
+Local Example mlTransitivity_test_iff {Σ : Signature} {syntax : Syntax} Γ a b c :
+  theory ⊆ Γ -> well_formed a -> well_formed b -> well_formed c ->
+  Γ ⊢i
+    (a <---> b) --->
+    (b <---> c) --->
+    a <---> c
+    using AnyReasoning.
+Proof.
+  intros.
+  toMLGoal;[wf_auto2|].
+  mlIntro "P1"; mlIntro "P2".
+  mlTransitivity "P1" -> "P2" as "PT".
+  mlAssumption.
+Defined.
 
 (* TODO: eliminate mu_free *)
 Lemma patt_equal_trans {Σ : Signature} {syntax : Syntax} Γ φ1 φ2 φ3:

--- a/proofmode.md
+++ b/proofmode.md
@@ -29,6 +29,7 @@
 | `mlApply "H" in "H0"`                    | Applies an implication from a local hypothesis `"H"` to another hypothesis `"H0"`. |
 | `mlConj "H1" "H2" as "HC"`               | Makes a conjunction of two hypotheses. |
 | `mlAssert ("H" : phi)`                   | Creates an additional goal about the validity of `phi`, and puts `phi` as a hypothesis in the original proof state. |
+| `mlTransitivity "H1" -> "H2" as "H3"`    | Composes `"H1"` and `"H2"` into a new hypothesis `"H3"`. Works with `=ml`, `--->` and `<--->`.
 
 
 | Meta-level propositional tactics | |


### PR DESCRIPTION
Adds an `mlTransitivity` tactic to compose implication patterns, iff patterns and equality patterns, along with a test for each case. Currently composing iff pattern using this tactic is a bit slow, because I couldn't figure out a better solution for composing iffs without generating fresh names, which I'm not sure how to do robustly.

I also added some extra examples in the proof mode tutorial.